### PR TITLE
Use wallet model ID instead of generating new one

### DIFF
--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -30,7 +30,6 @@ module Coinbase
 
       @master = seed.nil? ? MoneyTree::Master.new : MoneyTree::Master.new(seed_hex: seed)
 
-      @wallet_id = SecureRandom.uuid
       # TODO: Make Network an argument to the constructor.
       @network_id = :base_sepolia
       @addresses = []
@@ -178,7 +177,7 @@ module Coinbase
       key = derive_key
 
       address_id = key.address.to_s
-      address_model = @addresses_api.get_address(@wallet_id, address_id)
+      address_model = @addresses_api.get_address(wallet_id, address_id)
 
       cache_address(address_model, key, @client)
     end


### PR DESCRIPTION
### What changed? Why?
Use the wallet model for the wallet ID rather than generating a new one. This was causing a bug in Wallet import / export.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
Fix bug