### PR TITLE
Add configuration initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,13 @@ This instance is rate-limited, but you can also provision your own on the
 [Coinbase Developer Platform](https://portal.cloud.coinbase.com/products/base).
 
 
-You can configure the SDK with your Base Sepolia RPC node by copying your node URL from the CDP portal 
+You can configure the SDK with your Base Sepolia RPC node by copying your node URL from the CDP portal
 and setting the following:
 
 ```ruby
-Coinbase.base_sepolia_rpc_url = 'https://api.developer.coinbase.com/rpc/v1/base/your-node-id'
+Coinbase.configure do |config|
+    config.base_sepolia_rpc_url = 'https://api.developer.coinbase.com/rpc/v1/base/your-node-id'
+end
 ```
 
 ### Wallets and Addresses

--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -14,18 +14,27 @@ require_relative 'coinbase/wallet'
 
 # The Coinbase SDK.
 module Coinbase
-  @base_sepolia_rpc_url = 'https://sepolia.base.org'
-
-  # Returns the Base Sepolia RPC URL.
-  # @return [String] the Base Sepolia RPC URL
-  def self.base_sepolia_rpc_url
-    @base_sepolia_rpc_url
+  def self.configuration
+    @configuration ||= Configuration.new
   end
 
-  # Sets the Base Sepolia RPC URL.
-  # @param value [String] the Base Sepolia RPC URL
-  def self.base_sepolia_rpc_url=(value)
-    @base_sepolia_rpc_url = value
+  def self.configure
+    yield(configuration)
+  end
+
+  # Configuration object for the Coinbase SDK
+  class Configuration
+    attr_reader :base_sepolia_rpc_url, :base_sepolia_client
+
+    def initialize
+      @base_sepolia_rpc_url = 'https://sepolia.base.org'
+      @base_sepolia_client = Jimson::Client.new(@base_sepolia_rpc_url)
+    end
+
+    def base_sepolia_rpc_url=(new_base_sepolia_rpc_url)
+      @base_sepolia_rpc_url = new_base_sepolia_rpc_url
+      @base_sepolia_client = Jimson::Client.new(@base_sepolia_rpc_url)
+    end
   end
 
   # Initializes the Coinbase SDK with the given API key name and private key.

--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -14,88 +14,44 @@ require_relative 'coinbase/wallet'
 
 # The Coinbase SDK.
 module Coinbase
+  class InvalidConfiguration < StandardError; end
+
   def self.configuration
     @configuration ||= Configuration.new
   end
 
   def self.configure
     yield(configuration)
+
+    raise InvalidConfiguration, 'API key private key is not set' unless configuration.api_key_private_key
+    raise InvalidConfiguration, 'API key name is not set' unless configuration.api_key_name
   end
 
   # Configuration object for the Coinbase SDK
   class Configuration
     attr_reader :base_sepolia_rpc_url, :base_sepolia_client
+    attr_accessor :api_url, :api_key_name, :api_key_private_key
 
     def initialize
       @base_sepolia_rpc_url = 'https://sepolia.base.org'
       @base_sepolia_client = Jimson::Client.new(@base_sepolia_rpc_url)
+      @api_url = 'https://api.cdp.coinbase.com'
     end
 
     def base_sepolia_rpc_url=(new_base_sepolia_rpc_url)
       @base_sepolia_rpc_url = new_base_sepolia_rpc_url
       @base_sepolia_client = Jimson::Client.new(@base_sepolia_rpc_url)
     end
-  end
 
-  # Initializes the Coinbase SDK with the given API key name and private key.
-  # @param api_key_name [String] The API key name
-  # @param api_key_private_key [String] The API key's private key
-  # @param api_url [String] The API URL
-  def self.init(api_key_name, api_key_private_key, api_url: 'api.cdp.coinbase.com')
-    @api_key_name = api_key_name
-    @api_key_private_key = api_key_private_key
-    @api_url = api_url
-  end
-
-  # Returns the API key name.
-  # @return [String] the API key name
-  def self.api_key_name
-    raise 'API key name is not set' unless @api_key_name
-
-    @api_key_name
-  end
-
-  # Sets the API key name.
-  # @param value [String] the API key name
-  def self.api_key_name=(value)
-    @api_key_name = value
-  end
-
-  # Returns the API key's private key.
-  # @return [String] the API key's private key
-  def self.api_key_private_key
-    raise 'API key private key is not set' unless @api_key_private_key
-
-    @api_key_private_key
-  end
-
-  # Sets the API key's private key.
-  # @param value [String] the API key's private key
-  def self.api_key_private_key=(value)
-    @api_key_private_key = value
-  end
-
-  # Returns the API URL.
-  # @return [String] the API URL
-  def self.api_url
-    @api_url
-  end
-
-  # Sets the API URL.
-  # @param value [String] the API URL
-  def self.api_url=(value)
-    @api_url = value
+    def api_client
+      @api_client ||= Coinbase::Client::ApiClient.new(Middleware.config)
+    end
   end
 
   # Returns the default user.
   # @return [Coinbase::User] the default user
   def self.default_user
-    @api_client ||= Coinbase::Client::ApiClient.new(Middleware.config)
-    @users_api ||= Coinbase::Client::UsersApi.new(@api_client)
-    @wallets_api ||= Coinbase::Client::WalletsApi.new(@api_client)
-    @addresses_api ||= Coinbase::Client::AddressesApi.new(@api_client)
-    @user_model ||= @users_api.get_current_user
-    @default_user ||= Coinbase::User.new(@user_model, @wallets_api, @addresses_api)
+    @default_user ||= load_default_user
   end
 
   # Converts a string to a symbol, replacing hyphens with underscores.
@@ -122,5 +78,11 @@ module Coinbase
     end
 
     BalanceMap.new(balances)
+  end
+
+  def self.load_default_user
+    users_api = Coinbase::Client::UsersApi.new(configuration.api_client)
+    user_model = users_api.get_current_user
+    Coinbase::User.new(user_model)
   end
 end

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -152,13 +152,13 @@ module Coinbase
         asset_id
       end
     end
-  end
 
-  def addresses_api
-    @addresses_api ||= Coinbase::Client::AddressesApi.new(Coinbase.configuration.api_client)
-  end
+    def addresses_api
+      @addresses_api ||= Coinbase::Client::AddressesApi.new(Coinbase.configuration.api_client)
+    end
 
-  def transfers_api
-    @transfers_api ||= Coinbase::Client::TransfersApi.new(Coinbase.configuration.api_client)
+    def transfers_api
+      @transfers_api ||= Coinbase::Client::TransfersApi.new(Coinbase.configuration.api_client)
+    end
   end
 end

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -16,12 +16,10 @@ module Coinbase
     # @param model [Coinbase::Client::Address] The underlying Address object
     # @param addresses_api [Coinbase::Client::AddressesApi] The Addresses API object
     # @param key [Eth::Key] The key backing the Address
-    # @param client [Jimson::Client] (Optional) The JSON RPC client to use for interacting with the Network
-    def initialize(model, addresses_api, key, client: Jimson::Client.new(Coinbase.base_sepolia_rpc_url))
+    def initialize(model, addresses_api, key)
       @model = model
       @addresses_api = addresses_api
       @key = key
-      @client = client
     end
 
     # Returns the Network ID of the Address.
@@ -101,12 +99,11 @@ module Coinbase
         raise ArgumentError, "Insufficient funds: #{amount} requested, but only #{current_balance} available"
       end
 
-      transfer = Coinbase::Transfer.new(network_id, wallet_id, address_id, amount, asset_id, destination,
-                                        client: @client)
+      transfer = Coinbase::Transfer.new(network_id, wallet_id, address_id, amount, asset_id, destination)
 
       transaction = transfer.transaction
       transaction.sign(@key)
-      @client.eth_sendRawTransaction("0x#{transaction.hex}")
+      client.eth_sendRawTransaction("0x#{transaction.hex}")
 
       transfer
     end
@@ -134,6 +131,10 @@ module Coinbase
       else
         raise ArgumentError, "Unsupported asset: #{asset_id}"
       end
+    end
+
+    def client
+      @client ||= Coinbase.configuration.base_sepolia_client
     end
   end
 end

--- a/lib/coinbase/authenticator.rb
+++ b/lib/coinbase/authenticator.rb
@@ -32,12 +32,12 @@ module Coinbase
     def build_jwt(uri)
       header = {
         typ: 'JWT',
-        kid: Coinbase.api_key_name,
+        kid: Coinbase.configuration.api_key_name,
         nonce: SecureRandom.hex(16)
       }
 
       claims = {
-        sub: Coinbase.api_key_name,
+        sub: Coinbase.configuration.api_key_name,
         iss: 'coinbase-cloud',
         aud: ['cdp_service'],
         nbf: Time.now.to_i,
@@ -45,7 +45,7 @@ module Coinbase
         uris: [uri]
       }
 
-      private_key = OpenSSL::PKey.read(Coinbase.api_key_private_key)
+      private_key = OpenSSL::PKey.read(Coinbase.configuration.api_key_private_key)
       JWT.encode(claims, private_key, 'ES256', header)
     end
   end

--- a/lib/coinbase/middleware.rb
+++ b/lib/coinbase/middleware.rb
@@ -13,7 +13,7 @@ module Coinbase
     def self.config
       Coinbase::Client::Configuration.default.tap do |config|
         config.debugging = true
-        config.host = Coinbase.api_url
+        config.host = Coinbase.configuration.api_url
         config.request(:authenticator)
       end
     end

--- a/lib/coinbase/user.rb
+++ b/lib/coinbase/user.rb
@@ -40,7 +40,7 @@ module Coinbase
     # @return [Coinbase::Wallet] the imported Wallet
     def import_wallet(data)
       model = @wallets_api.get_wallet(data.wallet_id)
-      address_count = @addresses_api.list_addresses(model.id).total_count
+      address_count = addresses_api.list_addresses(model.id).total_count
       Wallet.new(model, seed: data.seed, address_count: address_count)
     end
 

--- a/lib/coinbase/user.rb
+++ b/lib/coinbase/user.rb
@@ -9,12 +9,8 @@ module Coinbase
   class User
     # Returns a new User object. Do not use this method directly. Instead, use Coinbase#default_user.
     # @param model [Coinbase::Client::User] the underlying User object
-    # @param wallets_api [Coinbase::Client::WalletsApi] the Wallets API to use
-    # @param addresses_api [Coinbase::Client::AddressesApi] the Addresses API to use
-    def initialize(model, wallets_api, addresses_api)
+    def initialize(model)
       @model = model
-      @wallets_api = wallets_api
-      @addresses_api = addresses_api
     end
 
     # Returns the User ID.
@@ -34,25 +30,35 @@ module Coinbase
       }
       opts = { create_wallet_request: create_wallet_request }
 
-      model = @wallets_api.create_wallet(opts)
+      model = wallets_api.create_wallet(opts)
 
-      Wallet.new(model, @wallets_api, @addresses_api)
+      Wallet.new(model)
     end
 
     # Imports a Wallet belonging to the User.
     # @param data [Coinbase::Wallet::Data] the Wallet data to import
     # @return [Coinbase::Wallet] the imported Wallet
     def import_wallet(data)
-      model = @wallets_api.get_wallet(data.wallet_id)
-      address_count = @addresses_api.list_addresses(model.id).total_count
-      Wallet.new(model, @wallets_api, @addresses_api, seed: data.seed, address_count: address_count)
+      model = wallets_api.get_wallet(data.wallet_id)
+      address_count = addresses_api.list_addresses(model.id).total_count
+      Wallet.new(model, seed: data.seed, address_count: address_count)
     end
 
     # Lists the IDs of the Wallets belonging to the User.
     # @return [Array<String>] the IDs of the Wallets belonging to the User
     def list_wallet_ids
-      wallets = @wallets_api.list_wallets
+      wallets = wallets_api.list_wallets
       wallets.data.map(&:id)
+    end
+
+    private
+
+    def addresses_api
+      @addresses_api ||= Coinbase::Client::AddressesApi.new(Coinbase.configuration.api_client)
+    end
+
+    def wallets_api
+      @wallets_api ||= Coinbase::Client::WalletsApi.new(Coinbase.configuration.api_client)
     end
   end
 end

--- a/spec/coinbase/address_spec.rb
+++ b/spec/coinbase/address_spec.rb
@@ -16,8 +16,14 @@ describe Coinbase::Address do
   let(:addresses_api) { double('Coinbase::Client::AddressesApi') }
   let(:client) { double('Jimson::Client') }
 
+  before(:each) do
+    configuration = double(Coinbase::Configuration)
+    allow(Coinbase).to receive(:configuration).and_return(configuration)
+    allow(configuration).to receive(:base_sepolia_client).and_return(client)
+  end
+
   subject(:address) do
-    described_class.new(model, addresses_api, key, client: client)
+    described_class.new(model, addresses_api, key)
   end
 
   describe '#initialize' do
@@ -160,7 +166,8 @@ describe Coinbase::Address do
     # TODO: Add test case for when the destination is a Wallet.
 
     context 'when the destination is a valid Address' do
-      let(:destination) { described_class.new(model, addresses_api, to_key, client: client) }
+      let(:destination) { described_class.new(model, addresses_api, to_key) }
+
       it 'creates a Transfer' do
         expect(addresses_api)
           .to receive(:get_address_balance)
@@ -202,7 +209,7 @@ describe Coinbase::Address do
 
       it 'raises an ArgumentError' do
         expect do
-          address.transfer(amount, asset_id, Coinbase::Address.new(new_model, addresses_api, to_key, client: client))
+          address.transfer(amount, asset_id, Coinbase::Address.new(new_model, addresses_api, to_key))
         end.to raise_error(ArgumentError, 'Transfer must be on the same Network')
       end
     end

--- a/spec/coinbase/address_spec.rb
+++ b/spec/coinbase/address_spec.rb
@@ -18,13 +18,13 @@ describe Coinbase::Address do
   let(:client) { double('Jimson::Client') }
 
   before(:each) do
-    configuration = double(Coinbase::Configuration)
-    allow(Coinbase).to receive(:configuration).and_return(configuration)
-    allow(configuration).to receive(:base_sepolia_client).and_return(client)
+    allow(Coinbase.configuration).to receive(:base_sepolia_client).and_return(client)
+    allow(Coinbase::Client::AddressesApi).to receive(:new).and_return(addresses_api)
+    allow(Coinbase::Client::TransfersApi).to receive(:new).and_return(transfers_api)
   end
 
   subject(:address) do
-    described_class.new(model, addresses_api, key)
+    described_class.new(model, key)
   end
 
   describe '#initialize' do
@@ -167,7 +167,7 @@ describe Coinbase::Address do
     context 'when the destination is a valid Address' do
       let(:asset_id) { :wei }
       let(:amount) { 500_000_000_000_000_000 }
-      let(:destination) { described_class.new(model, addresses_api, to_key) }
+      let(:destination) { described_class.new(model, to_key) }
       let(:create_transfer_request) do
         { amount: amount.to_s, network_id: network_id, asset_id: 'eth', destination: destination.address_id }
       end
@@ -246,7 +246,7 @@ describe Coinbase::Address do
 
       it 'raises an ArgumentError' do
         expect do
-          address.transfer(amount, asset_id, Coinbase::Address.new(new_model, addresses_api, to_key))
+          address.transfer(amount, asset_id, Coinbase::Address.new(new_model, to_key))
         end.to raise_error(ArgumentError, 'Transfer must be on the same Network')
       end
     end

--- a/spec/coinbase/authenticator_spec.rb
+++ b/spec/coinbase/authenticator_spec.rb
@@ -4,13 +4,12 @@ describe Coinbase::Authenticator do
   let(:app) { double('Faraday::Connection') }
   let(:authenticator) { described_class.new(app) }
   let(:data) { JSON.parse(File.read('spec/fixtures/cdp_api_key.json')) }
-  before do
-    Coinbase.init(data['name'], data['privateKey'])
-  end
+  let(:api_key_name) { data['name'] }
+  let(:api_key_private_key) { data['privateKey'] }
 
-  after(:each) do
-    Coinbase.api_key_name = nil
-    Coinbase.api_key_private_key = nil
+  before do
+    allow(Coinbase.configuration).to receive(:api_key_name).and_return(api_key_name)
+    allow(Coinbase.configuration).to receive(:api_key_private_key).and_return(api_key_private_key)
   end
 
   describe '#call' do
@@ -35,18 +34,6 @@ describe Coinbase::Authenticator do
       jwt = authenticator.build_jwt(uri)
 
       expect(jwt).to be_a(String)
-    end
-
-    it 'raises an error if the API key name is not set' do
-      Coinbase.api_key_name = nil
-
-      expect { authenticator.build_jwt(uri) }.to raise_error('API key name is not set')
-    end
-
-    it 'raises an error if the API key private key is not set' do
-      Coinbase.api_key_private_key = nil
-
-      expect { authenticator.build_jwt(uri) }.to raise_error('API key private key is not set')
     end
   end
 end

--- a/spec/coinbase/transfer_spec.rb
+++ b/spec/coinbase/transfer_spec.rb
@@ -10,8 +10,14 @@ describe Coinbase::Transfer do
   let(:to_address_id) { to_key.address.to_s }
   let(:client) { double('Jimson::Client') }
 
+  before(:each) do
+    configuration = double(Coinbase::Configuration)
+    allow(Coinbase).to receive(:configuration).and_return(configuration)
+    allow(configuration).to receive(:base_sepolia_client).and_return(client)
+  end
+
   subject(:transfer) do
-    described_class.new(network_id, wallet_id, from_address_id, amount, :eth, to_address_id, client: client)
+    described_class.new(network_id, wallet_id, from_address_id, amount, :eth, to_address_id)
   end
 
   describe '#initialize' do
@@ -21,7 +27,7 @@ describe Coinbase::Transfer do
 
     it 'does not initialize a new transfer for an invalid asset' do
       expect do
-        Coinbase::Transfer.new(network_id, wallet_id, from_address_id, amount, :uni, to_address_id, client: client)
+        Coinbase::Transfer.new(network_id, wallet_id, from_address_id, amount, :uni, to_address_id)
       end.to raise_error(ArgumentError, 'Unsupported asset: uni')
     end
   end
@@ -52,7 +58,7 @@ describe Coinbase::Transfer do
     context 'when the amount is a Float' do
       let(:float_amount) { 0.5 }
       let(:float_transfer) do
-        described_class.new(network_id, wallet_id, from_address_id, float_amount, :eth, to_address_id, client: client)
+        described_class.new(network_id, wallet_id, from_address_id, float_amount, :eth, to_address_id)
       end
 
       it 'normalizes the amount' do
@@ -63,7 +69,7 @@ describe Coinbase::Transfer do
     context 'when the amount is an Integer' do
       let(:integer_amount) { 5 }
       let(:integer_transfer) do
-        described_class.new(network_id, wallet_id, from_address_id, integer_amount, :eth, to_address_id, client: client)
+        described_class.new(network_id, wallet_id, from_address_id, integer_amount, :eth, to_address_id)
       end
 
       it 'normalizes the amount' do
@@ -74,8 +80,7 @@ describe Coinbase::Transfer do
     context 'when the amount is a BigDecimal' do
       let(:big_decimal_amount) { BigDecimal('0.5') }
       let(:big_decimal_transfer) do
-        described_class.new(network_id, wallet_id, from_address_id, big_decimal_amount, :eth, to_address_id,
-                            client: client)
+        described_class.new(network_id, wallet_id, from_address_id, big_decimal_amount, :eth, to_address_id)
       end
 
       it 'normalizes the amount' do

--- a/spec/coinbase/user_spec.rb
+++ b/spec/coinbase/user_spec.rb
@@ -5,7 +5,7 @@ describe Coinbase::User do
   let(:model) { Coinbase::Client::User.new({ 'id': user_id }) }
   let(:wallets_api) { instance_double(Coinbase::Client::WalletsApi) }
   let(:addresses_api) { instance_double(Coinbase::Client::AddressesApi) }
-  let(:user) { described_class.new(model, wallets_api, addresses_api) }
+  let(:user) { described_class.new(model) }
 
   describe '#user_id' do
     it 'returns the user ID' do
@@ -35,6 +35,8 @@ describe Coinbase::User do
     end
 
     before do
+      allow(Coinbase::Client::AddressesApi).to receive(:new).and_return(addresses_api)
+      allow(Coinbase::Client::WalletsApi).to receive(:new).and_return(wallets_api)
       expect(wallets_api).to receive(:create_wallet).with(opts).and_return(wallet_model)
       expect(addresses_api)
         .to receive(:create_address)
@@ -85,6 +87,8 @@ describe Coinbase::User do
     end
 
     before do
+      allow(Coinbase::Client::AddressesApi).to receive(:new).and_return(addresses_api)
+      allow(Coinbase::Client::WalletsApi).to receive(:new).and_return(wallets_api)
       expect(wallets_api).to receive(:create_wallet).with(opts).and_return(wallet_model)
       expect(addresses_api)
         .to receive(:create_address)
@@ -116,6 +120,7 @@ describe Coinbase::User do
     end
     let(:wallet_list) { Coinbase::Client::WalletList.new({ 'data' => data }) }
     it 'lists the wallet IDs' do
+      allow(Coinbase::Client::WalletsApi).to receive(:new).and_return(wallets_api)
       expect(wallets_api).to receive(:list_wallets).and_return(wallet_list)
       expect(user.list_wallet_ids).to eq(wallet_ids)
     end

--- a/spec/coinbase/wallet_spec.rb
+++ b/spec/coinbase/wallet_spec.rb
@@ -25,10 +25,12 @@ describe Coinbase::Wallet do
   let(:addresses_api) { double('Coinbase::Client::AddressesApi') }
 
   before do
+    allow(Coinbase::Client::AddressesApi).to receive(:new).and_return(addresses_api)
+    allow(Coinbase::Client::WalletsApi).to receive(:new).and_return(wallets_api)
     allow(addresses_api).to receive(:create_address).and_return(address_model)
     allow(addresses_api).to receive(:get_address).and_return(address_model)
     allow(wallets_api).to receive(:get_wallet).with(wallet_id).and_return(model_with_default_address)
-    @wallet = described_class.new(model, wallets_api, addresses_api)
+    @wallet = described_class.new(model)
   end
 
   describe '#initialize' do
@@ -41,14 +43,14 @@ describe Coinbase::Wallet do
             attestation_present = opts[:create_address_request][:attestation].is_a?(String)
             public_key_present && attestation_present
           end)
-        @wallet = described_class.new(model, wallets_api, addresses_api)
+        @wallet = described_class.new(model)
         expect(@wallet).to be_a(Coinbase::Wallet)
       end
     end
 
     context 'when a seed is provided' do
       let(:seed) { '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' }
-      let(:seed_wallet) { described_class.new(model, wallets_api, addresses_api, seed: seed) }
+      let(:seed_wallet) { described_class.new(model, seed: seed) }
 
       it 'initializes a new Wallet with the provided seed' do
         expect(addresses_api)
@@ -64,7 +66,7 @@ describe Coinbase::Wallet do
 
       it 'raises an error for an invalid seed' do
         expect do
-          described_class.new(model, wallets_api, addresses_api, seed: 'invalid')
+          described_class.new(model, seed: 'invalid')
         end.to raise_error(ArgumentError, 'Seed must be 32 bytes')
       end
     end
@@ -72,7 +74,7 @@ describe Coinbase::Wallet do
     context 'when the address count is provided' do
       let(:address_count) { 5 }
       let(:address_wallet) do
-        described_class.new(model, wallets_api, addresses_api, address_count: address_count)
+        described_class.new(model, address_count: address_count)
       end
 
       it 'initializes a new Wallet with the provided address count' do
@@ -208,7 +210,7 @@ describe Coinbase::Wallet do
     let(:asset_id) { :eth }
 
     context 'when the destination is a Wallet' do
-      let(:destination) { described_class.new(model, wallets_api, addresses_api) }
+      let(:destination) { described_class.new(model) }
       let(:to_address_id) { destination.default_address.address_id }
 
       before do
@@ -250,7 +252,7 @@ describe Coinbase::Wallet do
     let(:seed) { '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' }
     let(:address_count) { 5 }
     let(:seed_wallet) do
-      described_class.new(model, wallets_api, addresses_api, seed: seed, address_count: address_count)
+      described_class.new(model, seed: seed, address_count: address_count)
     end
 
     it 'exports the Wallet data' do
@@ -262,8 +264,7 @@ describe Coinbase::Wallet do
 
     it 'allows for re-creation of a Wallet' do
       wallet_data = seed_wallet.export
-      new_wallet = described_class.new(model, wallets_api, addresses_api, seed: wallet_data.seed,
-                                                                          address_count: address_count)
+      new_wallet = described_class.new(model, seed: wallet_data.seed, address_count: address_count)
       expect(new_wallet.list_addresses.length).to eq(address_count)
       new_wallet.list_addresses.each_with_index do |address, i|
         expect(address.address_id).to eq(seed_wallet.list_addresses[i].address_id)

--- a/spec/coinbase/wallet_spec.rb
+++ b/spec/coinbase/wallet_spec.rb
@@ -41,7 +41,7 @@ describe Coinbase::Wallet do
             attestation_present = opts[:create_address_request][:attestation].is_a?(String)
             public_key_present && attestation_present
           end)
-        @wallet = described_class.new(model, wallets_api, addresses_api, client: client)
+        @wallet = described_class.new(model, wallets_api, addresses_api)
         expect(@wallet).to be_a(Coinbase::Wallet)
       end
     end
@@ -262,7 +262,8 @@ describe Coinbase::Wallet do
 
     it 'allows for re-creation of a Wallet' do
       wallet_data = seed_wallet.export
-      new_wallet = described_class.new(model, wallets_api, addresses_api, seed: wallet_data.seed, address_count: address_count)
+      new_wallet = described_class.new(model, wallets_api, addresses_api, seed: wallet_data.seed,
+                                                                          address_count: address_count)
       expect(new_wallet.list_addresses.length).to eq(address_count)
       new_wallet.list_addresses.each_with_index do |address, i|
         expect(address.address_id).to eq(seed_wallet.list_addresses[i].address_id)

--- a/spec/coinbase/wallet_spec.rb
+++ b/spec/coinbase/wallet_spec.rb
@@ -28,7 +28,7 @@ describe Coinbase::Wallet do
     allow(addresses_api).to receive(:create_address).and_return(address_model)
     allow(addresses_api).to receive(:get_address).and_return(address_model)
     allow(wallets_api).to receive(:get_wallet).with(wallet_id).and_return(model_with_default_address)
-    @wallet = described_class.new(model, wallets_api, addresses_api, client: client)
+    @wallet = described_class.new(model, wallets_api, addresses_api)
   end
 
   describe '#initialize' do
@@ -48,7 +48,7 @@ describe Coinbase::Wallet do
 
     context 'when a seed is provided' do
       let(:seed) { '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' }
-      let(:seed_wallet) { described_class.new(model, wallets_api, addresses_api, seed: seed, client: client) }
+      let(:seed_wallet) { described_class.new(model, wallets_api, addresses_api, seed: seed) }
 
       it 'initializes a new Wallet with the provided seed' do
         expect(addresses_api)
@@ -64,7 +64,7 @@ describe Coinbase::Wallet do
 
       it 'raises an error for an invalid seed' do
         expect do
-          described_class.new(model, wallets_api, addresses_api, seed: 'invalid', client: client)
+          described_class.new(model, wallets_api, addresses_api, seed: 'invalid')
         end.to raise_error(ArgumentError, 'Seed must be 32 bytes')
       end
     end
@@ -72,7 +72,7 @@ describe Coinbase::Wallet do
     context 'when the address count is provided' do
       let(:address_count) { 5 }
       let(:address_wallet) do
-        described_class.new(model, wallets_api, addresses_api, address_count: address_count, client: client)
+        described_class.new(model, wallets_api, addresses_api, address_count: address_count)
       end
 
       it 'initializes a new Wallet with the provided address count' do
@@ -208,7 +208,7 @@ describe Coinbase::Wallet do
     let(:asset_id) { :eth }
 
     context 'when the destination is a Wallet' do
-      let(:destination) { described_class.new(model, wallets_api, addresses_api, client: client) }
+      let(:destination) { described_class.new(model, wallets_api, addresses_api) }
       let(:to_address_id) { destination.default_address.address_id }
 
       before do
@@ -250,7 +250,7 @@ describe Coinbase::Wallet do
     let(:seed) { '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' }
     let(:address_count) { 5 }
     let(:seed_wallet) do
-      described_class.new(model, wallets_api, addresses_api, seed: seed, address_count: address_count, client: client)
+      described_class.new(model, wallets_api, addresses_api, seed: seed, address_count: address_count)
     end
 
     it 'exports the Wallet data' do
@@ -262,8 +262,7 @@ describe Coinbase::Wallet do
 
     it 'allows for re-creation of a Wallet' do
       wallet_data = seed_wallet.export
-      new_wallet = described_class.new(model, wallets_api, addresses_api, seed: wallet_data.seed,
-                                                                          address_count: address_count, client: client)
+      new_wallet = described_class.new(model, wallets_api, addresses_api, seed: wallet_data.seed, address_count: address_count)
       expect(new_wallet.list_addresses.length).to eq(address_count)
       new_wallet.list_addresses.each_with_index do |address, i|
         expect(address.address_id).to eq(seed_wallet.list_addresses[i].address_id)

--- a/spec/coinbase_spec.rb
+++ b/spec/coinbase_spec.rb
@@ -9,14 +9,14 @@ describe Coinbase do
 
   describe '#base_sepolia_rpc_url' do
     it 'returns the Base Sepolia RPC URL' do
-      expect(Coinbase.base_sepolia_rpc_url).to eq('https://sepolia.base.org')
+      expect(Coinbase.configuration.base_sepolia_rpc_url).to eq('https://sepolia.base.org')
     end
   end
 
   describe '#base_sepolia_rpc_url=' do
     it 'sets the Base Sepolia RPC URL' do
-      Coinbase.base_sepolia_rpc_url = 'https://not-sepolia.base.org'
-      expect(Coinbase.base_sepolia_rpc_url).to eq('https://not-sepolia.base.org')
+      Coinbase.configuration.base_sepolia_rpc_url = 'https://not-sepolia.base.org'
+      expect(Coinbase.configuration.base_sepolia_rpc_url).to eq('https://not-sepolia.base.org')
     end
   end
 

--- a/spec/coinbase_spec.rb
+++ b/spec/coinbase_spec.rb
@@ -1,55 +1,69 @@
 # frozen_string_literal: true
 
 describe Coinbase do
-  after(:each) do
-    Coinbase.api_key_name = nil
-    Coinbase.api_key_private_key = nil
-    Coinbase.api_url = 'api.cdp.coinbase.com'
-  end
+  describe '#configure' do
+    let(:api_key_private_key) { 'some-key' }
+    let(:api_key_name) { 'some-key-name' }
 
-  describe '#base_sepolia_rpc_url' do
-    it 'returns the Base Sepolia RPC URL' do
-      expect(Coinbase.configuration.base_sepolia_rpc_url).to eq('https://sepolia.base.org')
+    subject do
+      Coinbase.configure do |config|
+        config.api_key_private_key = api_key_private_key
+        config.api_key_name = api_key_name
+      end
+    end
+
+    context 'when api_key_private_key is nil' do
+      let(:api_key_private_key) { nil }
+      it 'raises an exception' do
+        expect { subject }.to raise_error(Coinbase::InvalidConfiguration, /API key private key/)
+      end
+    end
+
+    context 'when api_key_name is nil' do
+      let(:api_key_name) { nil }
+      it 'raises an exception' do
+        expect { subject }.to raise_error(Coinbase::InvalidConfiguration, /API key name/)
+      end
     end
   end
 
-  describe '#base_sepolia_rpc_url=' do
-    it 'sets the Base Sepolia RPC URL' do
-      Coinbase.configuration.base_sepolia_rpc_url = 'https://not-sepolia.base.org'
-      expect(Coinbase.configuration.base_sepolia_rpc_url).to eq('https://not-sepolia.base.org')
+  describe '#default_user' do
+    let(:users_api) { double Coinbase::Client::UsersApi }
+    let(:user_model) { double 'User Model' }
+
+    before(:each) do
+      allow(Coinbase::Client::UsersApi).to receive(:new).and_return(users_api)
+      allow(users_api).to receive(:get_current_user).and_return(user_model)
+      allow(Coinbase::User).to receive(:new)
+    end
+
+    it 'creates a new users api client' do
+      Coinbase.default_user
+      expect(Coinbase::Client::UsersApi).to have_received(:new).with(Coinbase.configuration.api_client)
+    end
+
+    it 'gets the current user from the api' do
+      Coinbase.default_user
+      expect(users_api).to have_received(:get_current_user)
+    end
+
+    it 'creates a new user object from the response' do
+      Coinbase.default_user
+      expect(Coinbase::User).to have_received(:new).with(user_model)
     end
   end
 
-  describe '#init' do
-    it 'initializes the Coinbase SDK with the given API key name and private key' do
-      Coinbase.init('api_key_name', 'api_key_private_key')
-      expect(Coinbase.api_key_name).to eq('api_key_name')
-      expect(Coinbase.api_key_private_key).to eq('api_key_private_key')
+  describe Coinbase::Configuration do
+    describe '#api_url' do
+      it 'returns the default api url' do
+        expect(Coinbase.configuration.api_url).to eq 'https://api.cdp.coinbase.com'
+      end
     end
-  end
 
-  describe '#api_key_name' do
-    it 'raises an error if the API key name is not set' do
-      expect { Coinbase.api_key_name }.to raise_error('API key name is not set')
-    end
-  end
-
-  describe '#api_key_private_key' do
-    it 'raises an error if the API key private key is not set' do
-      expect { Coinbase.api_key_private_key }.to raise_error('API key private key is not set')
-    end
-  end
-
-  describe '#api_url' do
-    it 'returns the API URL' do
-      expect(Coinbase.api_url).to eq('api.cdp.coinbase.com')
-    end
-  end
-
-  describe '#api_url=' do
-    it 'sets the API URL' do
-      Coinbase.api_url = 'api.cdp.not-coinbase.com'
-      expect(Coinbase.api_url).to eq('api.cdp.not-coinbase.com')
+    describe '#base_sepolia_rpc_url' do
+      it 'returns the default base sepolia rpc url' do
+        expect(Coinbase.configuration.base_sepolia_rpc_url).to eq 'https://sepolia.base.org'
+      end
     end
   end
 end


### PR DESCRIPTION
### What changed? Why?
This adds the configuration initializer pattern to help simplify initialization in things like rails applications.

#### Qualified Impact
This changes how the gem is initialized:

```ruby
#old
Coinbase.parameter = 'x'

#new
Coinbase.configure do |config|
  config.parameter = 'x'
end
``` 
This allows us to build validation logic, as well as automation built into initialization of the gem.