### PR TITLE
[PSDK-11] Create Transfer Server Side

### DIFF
--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -85,8 +85,9 @@ module Coinbase
     @users_api ||= Coinbase::Client::UsersApi.new(@api_client)
     @wallets_api ||= Coinbase::Client::WalletsApi.new(@api_client)
     @addresses_api ||= Coinbase::Client::AddressesApi.new(@api_client)
+    @transfers_api ||= Coinbase::Client::TransfersApi.new(@api_client)
     @user_model ||= @users_api.get_current_user
-    @default_user ||= Coinbase::User.new(@user_model, @wallets_api, @addresses_api)
+    @default_user ||= Coinbase::User.new(@user_model, @wallets_api, @addresses_api, @transfers_api)
   end
 
   # Converts a string to a symbol, replacing hyphens with underscores.

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -15,11 +15,13 @@ module Coinbase
     # Returns a new Address object. Do not use this method directly. Instead, use Wallet#create_address.
     # @param model [Coinbase::Client::Address] The underlying Address object
     # @param addresses_api [Coinbase::Client::AddressesApi] The Addresses API object
+    # @param transfers_api [Coinbase::Client::TransfersApi] The Transfers API object
     # @param key [Eth::Key] The key backing the Address
     # @param client [Jimson::Client] (Optional) The JSON RPC client to use for interacting with the Network
-    def initialize(model, addresses_api, key, client: Jimson::Client.new(Coinbase.base_sepolia_rpc_url))
+    def initialize(model, addresses_api, transfers_api, key, client: Jimson::Client.new(Coinbase.base_sepolia_rpc_url))
       @model = model
       @addresses_api = addresses_api
+      @transfers_api = transfers_api
       @key = key
       @client = client
     end
@@ -54,11 +56,7 @@ module Coinbase
     # @param asset_id [Symbol] The Asset to retrieve the balance for
     # @return [BigDecimal] The balance of the Asset
     def get_balance(asset_id)
-      normalized_asset_id = if %i[wei gwei].include?(asset_id)
-                              :eth
-                            else
-                              asset_id
-                            end
+      normalized_asset_id = normalize_asset_id(asset_id)
 
       response = @addresses_api.get_address_balance(wallet_id, address_id, normalized_asset_id.to_s)
 
@@ -101,8 +99,20 @@ module Coinbase
         raise ArgumentError, "Insufficient funds: #{amount} requested, but only #{current_balance} available"
       end
 
-      transfer = Coinbase::Transfer.new(network_id, wallet_id, address_id, amount, asset_id, destination,
-                                        client: @client)
+      normalized_amount = normalize_eth_amount(amount, asset_id)
+
+      normalized_asset_id = normalize_asset_id(asset_id)
+
+      create_transfer_request = {
+        amount: normalized_amount.to_i.to_s,
+        network_id: network_id,
+        asset_id: normalized_asset_id.to_s,
+        destination: destination
+      }
+
+      transfer_model = @transfers_api.create_transfer(wallet_id, address_id, create_transfer_request)
+
+      transfer = Coinbase::Transfer.new(transfer_model, @transfers_api, client: @client)
 
       transaction = transfer.transaction
       transaction.sign(@key)
@@ -122,17 +132,30 @@ module Coinbase
     # Normalizes the amount of ETH to send based on the asset ID.
     # @param amount [Integer, Float, BigDecimal] The amount to normalize
     # @param asset_id [Symbol] The ID of the Asset being transferred
-    # @return [BigDecimal] The normalized amount in units of ETH
+    # @return [BigDecimal] The normalized amount in units of Wei
     def normalize_eth_amount(amount, asset_id)
+      big_amount = BigDecimal(amount.to_s)
+
       case asset_id
       when :eth
-        amount.is_a?(BigDecimal) ? amount : BigDecimal(amount.to_s)
+        big_amount * Coinbase::WEI_PER_ETHER
       when :gwei
-        BigDecimal(amount / Coinbase::GWEI_PER_ETHER)
+        big_amount * Coinbase::GWEI_PER_ETHER * Coinbase::WEI_PER_GWEI
       when :wei
-        BigDecimal(amount / Coinbase::WEI_PER_ETHER)
+        big_amount
       else
         raise ArgumentError, "Unsupported asset: #{asset_id}"
+      end
+    end
+
+    # Normalizes the asset ID to use during requests.
+    # @param asset_id [Symbol] The asset ID to normalize
+    # @return [Symbol] The normalized asset ID
+    def normalize_asset_id(asset_id)
+      if %i[wei gwei].include?(asset_id)
+        :eth
+      else
+        asset_id
       end
     end
   end

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -64,14 +64,7 @@ module Coinbase
 
       amount = BigDecimal(response.amount)
 
-      case asset_id
-      when :eth
-        amount / BigDecimal(Coinbase::WEI_PER_ETHER.to_s)
-      when :gwei
-        amount / BigDecimal(Coinbase::GWEI_PER_ETHER.to_s)
-      else
-        amount
-      end
+      normalize_eth_amount(amount, asset_id)
     end
 
     # Transfers the given amount of the given Asset to the given address. Only same-Network Transfers are supported.
@@ -140,7 +133,26 @@ module Coinbase
       when :eth
         big_amount * Coinbase::WEI_PER_ETHER
       when :gwei
-        big_amount * Coinbase::GWEI_PER_ETHER * Coinbase::WEI_PER_GWEI
+        big_amount * Coinbase::WEI_PER_GWEI
+      when :wei
+        big_amount
+      else
+        raise ArgumentError, "Unsupported asset: #{asset_id}"
+      end
+    end
+
+    # Normalizes the amount of ETH based on the asset ID.
+    # @param amount [Integer, Float, BigDecimal] The amount to normalize
+    # @param asset_id [Symbol] The ID of the Asset
+    # @return [BigDecimal] The normalized amount in units of ETH
+    def normalize_eth_amount(amount, asset_id)
+      big_amount = BigDecimal(amount.to_s)
+
+      case asset_id
+      when :eth
+        big_amount / BigDecimal(Coinbase::WEI_PER_ETHER.to_s)
+      when :gwei
+        big_amount / BigDecimal(Coinbase::GWEI_PER_ETHER.to_s)
       when :wei
         big_amount
       else

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -99,7 +99,7 @@ module Coinbase
         raise ArgumentError, "Insufficient funds: #{amount} requested, but only #{current_balance} available"
       end
 
-      normalized_amount = normalize_eth_amount(amount, asset_id)
+      normalized_amount = normalize_wei_amount(amount, asset_id)
 
       normalized_asset_id = normalize_asset_id(asset_id)
 
@@ -129,11 +129,11 @@ module Coinbase
 
     private
 
-    # Normalizes the amount of ETH to send based on the asset ID.
+    # Normalizes the amount of Wei to send based on the asset ID.
     # @param amount [Integer, Float, BigDecimal] The amount to normalize
     # @param asset_id [Symbol] The ID of the Asset being transferred
     # @return [BigDecimal] The normalized amount in units of Wei
-    def normalize_eth_amount(amount, asset_id)
+    def normalize_wei_amount(amount, asset_id)
       big_amount = BigDecimal(amount.to_s)
 
       case asset_id

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -64,7 +64,14 @@ module Coinbase
 
       amount = BigDecimal(response.amount)
 
-      normalize_eth_amount(amount, asset_id)
+      case asset_id
+      when :eth
+        amount / BigDecimal(Coinbase::WEI_PER_ETHER.to_s)
+      when :gwei
+        amount / BigDecimal(Coinbase::GWEI_PER_ETHER.to_s)
+      else
+        amount
+      end
     end
 
     # Transfers the given amount of the given Asset to the given address. Only same-Network Transfers are supported.
@@ -134,25 +141,6 @@ module Coinbase
         big_amount * Coinbase::WEI_PER_ETHER
       when :gwei
         big_amount * Coinbase::WEI_PER_GWEI
-      when :wei
-        big_amount
-      else
-        raise ArgumentError, "Unsupported asset: #{asset_id}"
-      end
-    end
-
-    # Normalizes the amount of ETH based on the asset ID.
-    # @param amount [Integer, Float, BigDecimal] The amount to normalize
-    # @param asset_id [Symbol] The ID of the Asset
-    # @return [BigDecimal] The normalized amount in units of ETH
-    def normalize_eth_amount(amount, asset_id)
-      big_amount = BigDecimal(amount.to_s)
-
-      case asset_id
-      when :eth
-        big_amount / BigDecimal(Coinbase::WEI_PER_ETHER.to_s)
-      when :gwei
-        big_amount / BigDecimal(Coinbase::GWEI_PER_ETHER.to_s)
       when :wei
         big_amount
       else

--- a/lib/coinbase/client.rb
+++ b/lib/coinbase/client.rb
@@ -27,6 +27,7 @@ Coinbase::Client.autoload :CreateTransferRequest, 'coinbase/client/models/create
 Coinbase::Client.autoload :CreateWalletRequest, 'coinbase/client/models/create_wallet_request'
 Coinbase::Client.autoload :Error, 'coinbase/client/models/error'
 Coinbase::Client.autoload :Transfer, 'coinbase/client/models/transfer'
+Coinbase::Client.autoload :TransferList, 'coinbase/client/models/transfer_list'
 Coinbase::Client.autoload :User, 'coinbase/client/models/user'
 Coinbase::Client.autoload :Wallet, 'coinbase/client/models/wallet'
 Coinbase::Client.autoload :WalletList, 'coinbase/client/models/wallet_list'

--- a/lib/coinbase/client/api/addresses_api.rb
+++ b/lib/coinbase/client/api/addresses_api.rb
@@ -238,6 +238,7 @@ module Coinbase::Client
     # @param wallet_id [String] The ID of the wallet to fetch the balances for
     # @param address_id [String] The onchain address of the address that is being fetched.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :page A cursor for pagination across multiple pages of results. Don&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
     # @return [AddressBalanceList]
     def list_address_balances(wallet_id, address_id, opts = {})
       data, _status_code, _headers = list_address_balances_with_http_info(wallet_id, address_id, opts)
@@ -249,6 +250,7 @@ module Coinbase::Client
     # @param wallet_id [String] The ID of the wallet to fetch the balances for
     # @param address_id [String] The onchain address of the address that is being fetched.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :page A cursor for pagination across multiple pages of results. Don&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
     # @return [Array<(AddressBalanceList, Integer, Hash)>] AddressBalanceList data, response status code and response headers
     def list_address_balances_with_http_info(wallet_id, address_id, opts = {})
       if @api_client.config.debugging
@@ -262,11 +264,16 @@ module Coinbase::Client
       if @api_client.config.client_side_validation && address_id.nil?
         fail ArgumentError, "Missing the required parameter 'address_id' when calling AddressesApi.list_address_balances"
       end
+      if @api_client.config.client_side_validation && !opts[:'page'].nil? && opts[:'page'].to_s.length > 5000
+        fail ArgumentError, 'invalid value for "opts[:"page"]" when calling AddressesApi.list_address_balances, the character length must be smaller than or equal to 5000.'
+      end
+
       # resource path
       local_var_path = '/v1/wallets/{wallet_id}/addresses/{address_id}/balances'.sub('{' + 'wallet_id' + '}', CGI.escape(wallet_id.to_s)).sub('{' + 'address_id' + '}', CGI.escape(address_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
+      query_params[:'page'] = opts[:'page'] if !opts[:'page'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}
@@ -304,7 +311,7 @@ module Coinbase::Client
 
     # List addresses in a wallet.
     # List addresses in the wallet.
-    # @param wallet_id [String] The ID of the wallet whose addresess to fetch
+    # @param wallet_id [String] The ID of the wallet whose addresses to fetch
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :limit A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
     # @option opts [String] :page A cursor for pagination across multiple pages of results. Don&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
@@ -316,7 +323,7 @@ module Coinbase::Client
 
     # List addresses in a wallet.
     # List addresses in the wallet.
-    # @param wallet_id [String] The ID of the wallet whose addresess to fetch
+    # @param wallet_id [String] The ID of the wallet whose addresses to fetch
     # @param [Hash] opts the optional parameters
     # @option opts [Integer] :limit A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
     # @option opts [String] :page A cursor for pagination across multiple pages of results. Don&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.

--- a/lib/coinbase/client/api/transfers_api.rb
+++ b/lib/coinbase/client/api/transfers_api.rb
@@ -98,5 +98,159 @@ module Coinbase::Client
       end
       return data, status_code, headers
     end
+
+    # Get a transfer by ID
+    # Get a transfer by ID
+    # @param wallet_id [String] The ID of the wallet the address belongs to
+    # @param address_id [String] The ID of the address the transfer belongs to
+    # @param transfer_id [String] The ID of the transfer to fetch
+    # @param [Hash] opts the optional parameters
+    # @return [Transfer]
+    def get_transfer(wallet_id, address_id, transfer_id, opts = {})
+      data, _status_code, _headers = get_transfer_with_http_info(wallet_id, address_id, transfer_id, opts)
+      data
+    end
+
+    # Get a transfer by ID
+    # Get a transfer by ID
+    # @param wallet_id [String] The ID of the wallet the address belongs to
+    # @param address_id [String] The ID of the address the transfer belongs to
+    # @param transfer_id [String] The ID of the transfer to fetch
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(Transfer, Integer, Hash)>] Transfer data, response status code and response headers
+    def get_transfer_with_http_info(wallet_id, address_id, transfer_id, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: TransfersApi.get_transfer ...'
+      end
+      # verify the required parameter 'wallet_id' is set
+      if @api_client.config.client_side_validation && wallet_id.nil?
+        fail ArgumentError, "Missing the required parameter 'wallet_id' when calling TransfersApi.get_transfer"
+      end
+      # verify the required parameter 'address_id' is set
+      if @api_client.config.client_side_validation && address_id.nil?
+        fail ArgumentError, "Missing the required parameter 'address_id' when calling TransfersApi.get_transfer"
+      end
+      # verify the required parameter 'transfer_id' is set
+      if @api_client.config.client_side_validation && transfer_id.nil?
+        fail ArgumentError, "Missing the required parameter 'transfer_id' when calling TransfersApi.get_transfer"
+      end
+      # resource path
+      local_var_path = '/v1/wallets/{wallet_id}/addresses/{address_id}/transfers/{transfer_id}'.sub('{' + 'wallet_id' + '}', CGI.escape(wallet_id.to_s)).sub('{' + 'address_id' + '}', CGI.escape(address_id.to_s)).sub('{' + 'transfer_id' + '}', CGI.escape(transfer_id.to_s))
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body]
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'Transfer'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || []
+
+      new_options = opts.merge(
+        :operation => :"TransfersApi.get_transfer",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: TransfersApi#get_transfer\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
+    # List transfers for an address.
+    # List transfers for an address.
+    # @param wallet_id [String] The ID of the wallet the address belongs to
+    # @param address_id [String] The ID of the address to list transfers for
+    # @param [Hash] opts the optional parameters
+    # @option opts [Integer] :limit A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+    # @option opts [String] :page A cursor for pagination across multiple pages of results. Don&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+    # @return [TransferList]
+    def list_transfers(wallet_id, address_id, opts = {})
+      data, _status_code, _headers = list_transfers_with_http_info(wallet_id, address_id, opts)
+      data
+    end
+
+    # List transfers for an address.
+    # List transfers for an address.
+    # @param wallet_id [String] The ID of the wallet the address belongs to
+    # @param address_id [String] The ID of the address to list transfers for
+    # @param [Hash] opts the optional parameters
+    # @option opts [Integer] :limit A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+    # @option opts [String] :page A cursor for pagination across multiple pages of results. Don&#39;t include this parameter on the first call. Use the next_page value returned in a previous response to request subsequent results.
+    # @return [Array<(TransferList, Integer, Hash)>] TransferList data, response status code and response headers
+    def list_transfers_with_http_info(wallet_id, address_id, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: TransfersApi.list_transfers ...'
+      end
+      # verify the required parameter 'wallet_id' is set
+      if @api_client.config.client_side_validation && wallet_id.nil?
+        fail ArgumentError, "Missing the required parameter 'wallet_id' when calling TransfersApi.list_transfers"
+      end
+      # verify the required parameter 'address_id' is set
+      if @api_client.config.client_side_validation && address_id.nil?
+        fail ArgumentError, "Missing the required parameter 'address_id' when calling TransfersApi.list_transfers"
+      end
+      if @api_client.config.client_side_validation && !opts[:'page'].nil? && opts[:'page'].to_s.length > 5000
+        fail ArgumentError, 'invalid value for "opts[:"page"]" when calling TransfersApi.list_transfers, the character length must be smaller than or equal to 5000.'
+      end
+
+      # resource path
+      local_var_path = '/v1/wallets/{wallet_id}/addresses/{address_id}/transfers'.sub('{' + 'wallet_id' + '}', CGI.escape(wallet_id.to_s)).sub('{' + 'address_id' + '}', CGI.escape(address_id.to_s))
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+      query_params[:'limit'] = opts[:'limit'] if !opts[:'limit'].nil?
+      query_params[:'page'] = opts[:'page'] if !opts[:'page'].nil?
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body]
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'TransferList'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || []
+
+      new_options = opts.merge(
+        :operation => :"TransfersApi.list_transfers",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: TransfersApi#list_transfers\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
   end
 end

--- a/lib/coinbase/client/models/transfer.rb
+++ b/lib/coinbase/client/models/transfer.rb
@@ -16,6 +16,24 @@ require 'time'
 module Coinbase::Client
   # A transfer of an asset from one address to another
   class Transfer
+    # The ID of the blockchain network
+    attr_accessor :network_id
+
+    # The ID of the wallet that owns the from address
+    attr_accessor :wallet_id
+
+    # The onchain address of the sender
+    attr_accessor :address_id
+
+    # The onchain address of the recipient
+    attr_accessor :destination
+
+    # The amount in the atomic units of the asset
+    attr_accessor :amount
+
+    # The ID of the asset being transferred
+    attr_accessor :asset_id
+
     # The ID of the transfer
     attr_accessor :transfer_id
 
@@ -50,6 +68,12 @@ module Coinbase::Client
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
+        :'network_id' => :'network_id',
+        :'wallet_id' => :'wallet_id',
+        :'address_id' => :'address_id',
+        :'destination' => :'destination',
+        :'amount' => :'amount',
+        :'asset_id' => :'asset_id',
         :'transfer_id' => :'transfer_id',
         :'unsigned_payload' => :'unsigned_payload',
         :'status' => :'status'
@@ -64,6 +88,12 @@ module Coinbase::Client
     # Attribute type mapping.
     def self.openapi_types
       {
+        :'network_id' => :'String',
+        :'wallet_id' => :'String',
+        :'address_id' => :'String',
+        :'destination' => :'String',
+        :'amount' => :'String',
+        :'asset_id' => :'String',
         :'transfer_id' => :'String',
         :'unsigned_payload' => :'String',
         :'status' => :'String'
@@ -91,6 +121,42 @@ module Coinbase::Client
         h[k.to_sym] = v
       }
 
+      if attributes.key?(:'network_id')
+        self.network_id = attributes[:'network_id']
+      else
+        self.network_id = nil
+      end
+
+      if attributes.key?(:'wallet_id')
+        self.wallet_id = attributes[:'wallet_id']
+      else
+        self.wallet_id = nil
+      end
+
+      if attributes.key?(:'address_id')
+        self.address_id = attributes[:'address_id']
+      else
+        self.address_id = nil
+      end
+
+      if attributes.key?(:'destination')
+        self.destination = attributes[:'destination']
+      else
+        self.destination = nil
+      end
+
+      if attributes.key?(:'amount')
+        self.amount = attributes[:'amount']
+      else
+        self.amount = nil
+      end
+
+      if attributes.key?(:'asset_id')
+        self.asset_id = attributes[:'asset_id']
+      else
+        self.asset_id = nil
+      end
+
       if attributes.key?(:'transfer_id')
         self.transfer_id = attributes[:'transfer_id']
       else
@@ -115,6 +181,30 @@ module Coinbase::Client
     def list_invalid_properties
       warn '[DEPRECATED] the `list_invalid_properties` method is obsolete'
       invalid_properties = Array.new
+      if @network_id.nil?
+        invalid_properties.push('invalid value for "network_id", network_id cannot be nil.')
+      end
+
+      if @wallet_id.nil?
+        invalid_properties.push('invalid value for "wallet_id", wallet_id cannot be nil.')
+      end
+
+      if @address_id.nil?
+        invalid_properties.push('invalid value for "address_id", address_id cannot be nil.')
+      end
+
+      if @destination.nil?
+        invalid_properties.push('invalid value for "destination", destination cannot be nil.')
+      end
+
+      if @amount.nil?
+        invalid_properties.push('invalid value for "amount", amount cannot be nil.')
+      end
+
+      if @asset_id.nil?
+        invalid_properties.push('invalid value for "asset_id", asset_id cannot be nil.')
+      end
+
       if @transfer_id.nil?
         invalid_properties.push('invalid value for "transfer_id", transfer_id cannot be nil.')
       end
@@ -134,6 +224,12 @@ module Coinbase::Client
     # @return true if the model is valid
     def valid?
       warn '[DEPRECATED] the `valid?` method is obsolete'
+      return false if @network_id.nil?
+      return false if @wallet_id.nil?
+      return false if @address_id.nil?
+      return false if @destination.nil?
+      return false if @amount.nil?
+      return false if @asset_id.nil?
       return false if @transfer_id.nil?
       return false if @unsigned_payload.nil?
       return false if @status.nil?
@@ -157,6 +253,12 @@ module Coinbase::Client
     def ==(o)
       return true if self.equal?(o)
       self.class == o.class &&
+          network_id == o.network_id &&
+          wallet_id == o.wallet_id &&
+          address_id == o.address_id &&
+          destination == o.destination &&
+          amount == o.amount &&
+          asset_id == o.asset_id &&
           transfer_id == o.transfer_id &&
           unsigned_payload == o.unsigned_payload &&
           status == o.status
@@ -171,7 +273,7 @@ module Coinbase::Client
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [transfer_id, unsigned_payload, status].hash
+      [network_id, wallet_id, address_id, destination, amount, asset_id, transfer_id, unsigned_payload, status].hash
     end
 
     # Builds the object from hash

--- a/lib/coinbase/client/models/transfer_list.rb
+++ b/lib/coinbase/client/models/transfer_list.rb
@@ -14,26 +14,26 @@ require 'date'
 require 'time'
 
 module Coinbase::Client
-  class CreateTransferRequest
-    # The amount to transfer
-    attr_accessor :amount
+  # 
+  class TransferList
+    attr_accessor :data
 
-    # The ID of the blockchain network
-    attr_accessor :network_id
+    # True if this list has another page of items after this one that can be fetched.
+    attr_accessor :has_more
 
-    # The ID of the asset to transfer
-    attr_accessor :asset_id
+    # The page token to be used to fetch the next page.
+    attr_accessor :next_page
 
-    # The destination address
-    attr_accessor :destination
+    # The total number of transfers for the address in the wallet.
+    attr_accessor :total_count
 
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
-        :'amount' => :'amount',
-        :'network_id' => :'network_id',
-        :'asset_id' => :'asset_id',
-        :'destination' => :'destination'
+        :'data' => :'data',
+        :'has_more' => :'has_more',
+        :'next_page' => :'next_page',
+        :'total_count' => :'total_count'
       }
     end
 
@@ -45,10 +45,10 @@ module Coinbase::Client
     # Attribute type mapping.
     def self.openapi_types
       {
-        :'amount' => :'String',
-        :'network_id' => :'String',
-        :'asset_id' => :'String',
-        :'destination' => :'String'
+        :'data' => :'Array<Transfer>',
+        :'has_more' => :'Boolean',
+        :'next_page' => :'String',
+        :'total_count' => :'Integer'
       }
     end
 
@@ -62,39 +62,41 @@ module Coinbase::Client
     # @param [Hash] attributes Model attributes in the form of hash
     def initialize(attributes = {})
       if (!attributes.is_a?(Hash))
-        fail ArgumentError, "The input argument (attributes) must be a hash in `Coinbase::Client::CreateTransferRequest` initialize method"
+        fail ArgumentError, "The input argument (attributes) must be a hash in `Coinbase::Client::TransferList` initialize method"
       end
 
       # check to see if the attribute exists and convert string to symbol for hash key
       attributes = attributes.each_with_object({}) { |(k, v), h|
         if (!self.class.attribute_map.key?(k.to_sym))
-          fail ArgumentError, "`#{k}` is not a valid attribute in `Coinbase::Client::CreateTransferRequest`. Please check the name to make sure it's valid. List of attributes: " + self.class.attribute_map.keys.inspect
+          fail ArgumentError, "`#{k}` is not a valid attribute in `Coinbase::Client::TransferList`. Please check the name to make sure it's valid. List of attributes: " + self.class.attribute_map.keys.inspect
         end
         h[k.to_sym] = v
       }
 
-      if attributes.key?(:'amount')
-        self.amount = attributes[:'amount']
+      if attributes.key?(:'data')
+        if (value = attributes[:'data']).is_a?(Array)
+          self.data = value
+        end
       else
-        self.amount = nil
+        self.data = nil
       end
 
-      if attributes.key?(:'network_id')
-        self.network_id = attributes[:'network_id']
+      if attributes.key?(:'has_more')
+        self.has_more = attributes[:'has_more']
       else
-        self.network_id = nil
+        self.has_more = nil
       end
 
-      if attributes.key?(:'asset_id')
-        self.asset_id = attributes[:'asset_id']
+      if attributes.key?(:'next_page')
+        self.next_page = attributes[:'next_page']
       else
-        self.asset_id = nil
+        self.next_page = nil
       end
 
-      if attributes.key?(:'destination')
-        self.destination = attributes[:'destination']
+      if attributes.key?(:'total_count')
+        self.total_count = attributes[:'total_count']
       else
-        self.destination = nil
+        self.total_count = nil
       end
     end
 
@@ -103,20 +105,20 @@ module Coinbase::Client
     def list_invalid_properties
       warn '[DEPRECATED] the `list_invalid_properties` method is obsolete'
       invalid_properties = Array.new
-      if @amount.nil?
-        invalid_properties.push('invalid value for "amount", amount cannot be nil.')
+      if @data.nil?
+        invalid_properties.push('invalid value for "data", data cannot be nil.')
       end
 
-      if @network_id.nil?
-        invalid_properties.push('invalid value for "network_id", network_id cannot be nil.')
+      if @has_more.nil?
+        invalid_properties.push('invalid value for "has_more", has_more cannot be nil.')
       end
 
-      if @asset_id.nil?
-        invalid_properties.push('invalid value for "asset_id", asset_id cannot be nil.')
+      if @next_page.nil?
+        invalid_properties.push('invalid value for "next_page", next_page cannot be nil.')
       end
 
-      if @destination.nil?
-        invalid_properties.push('invalid value for "destination", destination cannot be nil.')
+      if @total_count.nil?
+        invalid_properties.push('invalid value for "total_count", total_count cannot be nil.')
       end
 
       invalid_properties
@@ -126,10 +128,10 @@ module Coinbase::Client
     # @return true if the model is valid
     def valid?
       warn '[DEPRECATED] the `valid?` method is obsolete'
-      return false if @amount.nil?
-      return false if @network_id.nil?
-      return false if @asset_id.nil?
-      return false if @destination.nil?
+      return false if @data.nil?
+      return false if @has_more.nil?
+      return false if @next_page.nil?
+      return false if @total_count.nil?
       true
     end
 
@@ -138,10 +140,10 @@ module Coinbase::Client
     def ==(o)
       return true if self.equal?(o)
       self.class == o.class &&
-          amount == o.amount &&
-          network_id == o.network_id &&
-          asset_id == o.asset_id &&
-          destination == o.destination
+          data == o.data &&
+          has_more == o.has_more &&
+          next_page == o.next_page &&
+          total_count == o.total_count
     end
 
     # @see the `==` method
@@ -153,7 +155,7 @@ module Coinbase::Client
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [amount, network_id, asset_id, destination].hash
+      [data, has_more, next_page, total_count].hash
     end
 
     # Builds the object from hash

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -77,7 +77,7 @@ module Coinbase
     # Returns the amount of the asset for the Transfer.
     # @return [BigDecimal] The amount in units of ETH
     def amount
-      BigDecimal(@model.amount) / BigDecimal(Coinbase::WEI_PER_ETHER)
+      BigDecimal(@model.amount) / BigDecimal(Coinbase::WEI_PER_ETHER.to_s)
     end
 
     # Returns the Unsigned Payload of the Transfer.

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -62,9 +62,9 @@ module Coinbase
       @model.address_id
     end
 
-    # Returns the To Address ID of the Transfer.
-    # @return [String] The To Address ID
-    def to_address_id
+    # Returns the Destination Address ID of the Transfer.
+    # @return [String] The Destination Address ID
+    def destination_address_id
       @model.destination
     end
 
@@ -74,10 +74,10 @@ module Coinbase
       @model.asset_id.to_sym
     end
 
-    # Returns the amount of ETH for the Transfer.
+    # Returns the amount of the asset for the Transfer.
     # @return [BigDecimal] The amount in units of ETH
     def amount
-      BigDecimal(@model.amount)
+      BigDecimal(@model.amount) / BigDecimal(Coinbase::WEI_PER_ETHER)
     end
 
     # Returns the Unsigned Payload of the Transfer.
@@ -101,7 +101,7 @@ module Coinbase
         max_gas_fee: parsed_payload['maxFeePerGas'].to_i(16),
         gas_limit: parsed_payload['gas'].to_i(16), # TODO: Handle multiple currencies.
         from: Eth::Address.new(from_address_id),
-        to: Eth::Address.new(to_address_id),
+        to: Eth::Address.new(destination_address_id),
         value: parsed_payload['value'].to_i(16)
       }
 

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -3,6 +3,7 @@
 require_relative 'constants'
 require 'bigdecimal'
 require 'eth'
+require 'json'
 
 module Coinbase
   # A representation of a Transfer, which moves an amount of an Asset from
@@ -10,8 +11,6 @@ module Coinbase
   # in the native Asset of the Network. Currently only ETH transfers are supported. Transfers
   # should be created through {link:Wallet#transfer} or {link:Address#transfer}.
   class Transfer
-    attr_reader :network_id, :wallet_id, :from_address_id, :amount, :asset_id, :to_address_id
-
     # A representation of a Transfer status.
     module Status
       # The Transfer is awaiting being broadcast to the Network. At this point, transaction
@@ -30,27 +29,61 @@ module Coinbase
     end
 
     # Returns a new Transfer object.
-    # @param network_id [Symbol] The ID of the Network on which the Transfer originated
-    # @param wallet_id [String] The ID of the Wallet from which the Transfer originated
-    # @param from_address_id [String] The ID of the address from which the Transfer originated
-    # @param amount [Integer, Float, BigDecimal] The amount of the Asset to send. Integers are interpreted as
-    #  the smallest denomination of the Asset (e.g. Wei for Ether). Floats and BigDecimals are interpreted as the Asset
-    #  itself (e.g. Ether).
-    # @param asset_id [Symbol] The ID of the Asset being transferred. Currently only ETH is supported.
-    # @param to_address_id [String] The address to which the Transfer is being sent
+    # @param model [Coinbase::Client::Transfer] The underlying Transfer object
+    # @param transfers_api [Coinbase::Client::TransfersApi] The Transfers API object
     # @param client [Jimson::Client] (Optional) The JSON RPC client to use for interacting with the Network
-    def initialize(network_id, wallet_id, from_address_id, amount, asset_id, to_address_id,
-                   client: Jimson::Client.new(Coinbase.base_sepolia_rpc_url))
-
-      raise ArgumentError, "Unsupported asset: #{asset_id}" if asset_id != :eth
-
-      @network_id = network_id
-      @wallet_id = wallet_id
-      @from_address_id = from_address_id
-      @amount = normalize_eth_amount(amount)
-      @asset_id = asset_id
-      @to_address_id = to_address_id
+    def initialize(model, transfers_api, client: Jimson::Client.new(Coinbase.base_sepolia_rpc_url))
+      @model = model
+      @transfers_api = transfers_api
       @client = client
+    end
+
+    # Returns the Transfer ID.
+    # @return [String] The Transfer ID
+    def transfer_id
+      @model.transfer_id
+    end
+
+    # Returns the Network ID of the Transfer.
+    # @return [String] The Network ID
+    def network_id
+      @model.network_id
+    end
+
+    # Returns the Wallet ID of the Transfer.
+    # @return [String] The Wallet ID
+    def wallet_id
+      @model.wallet_id
+    end
+
+    # Returns the From Address ID of the Transfer.
+    # @return [String] The From Address ID
+    def from_address_id
+      @model.address_id
+    end
+
+    # Returns the To Address ID of the Transfer.
+    # @return [String] The To Address ID
+    def to_address_id
+      @model.destination
+    end
+
+    # Returns the Asset ID of the Transfer.
+    # @return [Symbol] The Asset ID
+    def asset_id
+      @model.asset_id.to_sym
+    end
+
+    # Returns the amount of ETH for the Transfer.
+    # @return [BigDecimal] The amount in units of ETH
+    def amount
+      BigDecimal(@model.amount)
+    end
+
+    # Returns the Unsigned Payload of the Transfer.
+    # @return [String] The Unsigned Payload
+    def unsigned_payload
+      @model.unsigned_payload
     end
 
     # Returns the underlying Transfer transaction, creating it if it has not been yet.
@@ -58,18 +91,18 @@ module Coinbase
     def transaction
       return @transaction unless @transaction.nil?
 
-      nonce = @client.eth_getTransactionCount(@from_address_id.to_s, 'latest').to_i(16)
-      gas_price = @client.eth_gasPrice.to_i(16)
+      raw_payload = [unsigned_payload].pack('H*')
+      parsed_payload = JSON.parse(raw_payload)
 
       params = {
-        chain_id: BASE_SEPOLIA.chain_id, # TODO: Don't hardcode Base Sepolia.
-        nonce: nonce,
-        priority_fee: gas_price, # TODO: Optimize this.
-        max_gas_fee: gas_price,
-        gas_limit: 21_000, # TODO: Handle multiple currencies.
-        from: Eth::Address.new(@from_address_id),
-        to: Eth::Address.new(@to_address_id),
-        value: (@amount * Coinbase::WEI_PER_ETHER).to_i
+        chain_id: parsed_payload['chainId'].to_i(16),
+        nonce: parsed_payload['nonce'].to_i(16),
+        priority_fee: parsed_payload['maxPriorityFeePerGas'].to_i(16),
+        max_gas_fee: parsed_payload['maxFeePerGas'].to_i(16),
+        gas_limit: parsed_payload['gas'].to_i(16), # TODO: Handle multiple currencies.
+        from: Eth::Address.new(from_address_id),
+        to: Eth::Address.new(to_address_id),
+        value: parsed_payload['value'].to_i(16)
       }
 
       @transaction = Eth::Tx::Eip1559.new(Eth::Tx.validate_eip1559_params(params))
@@ -132,22 +165,6 @@ module Coinbase
       "0x#{transaction.hash}"
     rescue Eth::Signature::SignatureError
       nil
-    end
-
-    private
-
-    # Normalizes the given Ether amount into a BigDecimal.
-    # @param amount [Integer, Float, BigDecimal] The amount to normalize
-    # @return [BigDecimal] The normalized amount
-    def normalize_eth_amount(amount)
-      case amount
-      when BigDecimal
-        amount
-      when Integer, Float
-        BigDecimal(amount.to_s)
-      else
-        raise ArgumentError, "Invalid amount: #{amount}"
-      end
     end
   end
 end

--- a/lib/coinbase/user.rb
+++ b/lib/coinbase/user.rb
@@ -11,10 +11,12 @@ module Coinbase
     # @param model [Coinbase::Client::User] the underlying User object
     # @param wallets_api [Coinbase::Client::WalletsApi] the Wallets API to use
     # @param addresses_api [Coinbase::Client::AddressesApi] the Addresses API to use
-    def initialize(model, wallets_api, addresses_api)
+    # @param transfers_api [Coinbase::Client::TransfersApi] the Transfers API to use
+    def initialize(model, wallets_api, addresses_api, transfers_api)
       @model = model
       @wallets_api = wallets_api
       @addresses_api = addresses_api
+      @transfers_api = transfers_api
     end
 
     # Returns the User ID.
@@ -36,7 +38,7 @@ module Coinbase
 
       model = @wallets_api.create_wallet(opts)
 
-      Wallet.new(model, @wallets_api, @addresses_api)
+      Wallet.new(model, @wallets_api, @addresses_api, @transfers_api)
     end
 
     # Imports a Wallet belonging to the User.
@@ -45,7 +47,7 @@ module Coinbase
     def import_wallet(data)
       model = @wallets_api.get_wallet(data.wallet_id)
       address_count = @addresses_api.list_addresses(model.id).total_count
-      Wallet.new(model, @wallets_api, @addresses_api, seed: data.seed, address_count: address_count)
+      Wallet.new(model, @wallets_api, @addresses_api, @transfers_api, seed: data.seed, address_count: address_count)
     end
 
     # Lists the IDs of the Wallets belonging to the User.

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -16,17 +16,19 @@ module Coinbase
     # @param model [Coinbase::Client::Wallet] The underlying Wallet object
     # @param wallets_api [Coinbase::Client::WalletsApi] the Wallets API to use
     # @param addresses_api [Coinbase::Client::AddressesApi] the Addresses API to use
+    # @param transfers_api [Coinbase::Client::TransferApi] the Transfers API to use
     # @param seed [String] (Optional) The seed to use for the Wallet. Expects a 32-byte hexadecimal with no 0x prefix.
     #   If not provided, a new seed will be generated.
     # @param address_count [Integer] (Optional) The number of addresses already registered for the Wallet.
     # @param client [Jimson::Client] (Optional) The JSON RPC client to use for interacting with the Network
-    def initialize(model, wallets_api, addresses_api, seed: nil, address_count: 0,
+    def initialize(model, wallets_api, addresses_api, transfers_api, seed: nil, address_count: 0,
                    client: Jimson::Client.new(Coinbase.base_sepolia_rpc_url))
       raise ArgumentError, 'Seed must be 32 bytes' if !seed.nil? && seed.length != 64
 
       @model = model
       @wallets_api = wallets_api
       @addresses_api = addresses_api
+      @transfers_api = transfers_api
 
       @master = seed.nil? ? MoneyTree::Master.new : MoneyTree::Master.new(seed_hex: seed)
 
@@ -198,7 +200,7 @@ module Coinbase
     # @param client [Jimson::Client] The JSON RPC client to use for interacting with the Network
     # @return [Address] The new Address
     def cache_address(address_model, key, client)
-      address = Address.new(address_model, @addresses_api, key, client: client)
+      address = Address.new(address_model, @addresses_api, @transfers_api, key, client: client)
       @addresses << address
       @address_index += 1
       address

--- a/spec/coinbase/address_spec.rb
+++ b/spec/coinbase/address_spec.rb
@@ -130,7 +130,6 @@ describe Coinbase::Address do
   end
 
   describe '#transfer' do
-    let(:amount) { 500_000_000_000_000_000 }
     let(:balance_response) do
       Coinbase::Client::Balance.new(
         {
@@ -143,7 +142,6 @@ describe Coinbase::Address do
         }
       )
     end
-    let(:asset_id) { :wei }
     let(:to_key) { Eth::Key.new }
     let(:to_address_id) { to_key.address.to_s }
     let(:transaction_hash) { '0xdeadbeef' }
@@ -161,6 +159,8 @@ describe Coinbase::Address do
     # TODO: Add test case for when the destination is a Wallet.
 
     context 'when the destination is a valid Address' do
+      let(:asset_id) { :wei }
+      let(:amount) { 500_000_000_000_000_000 }
       let(:destination) { described_class.new(model, addresses_api, transfers_api, to_key, client: client) }
       let(:create_transfer_request) do
         { amount: amount.to_s, network_id: network_id, asset_id: 'eth', destination: destination.address_id }
@@ -178,6 +178,8 @@ describe Coinbase::Address do
     end
 
     context 'when the destination is a valid Address ID' do
+      let(:asset_id) { :wei }
+      let(:amount) { 500_000_000_000_000_000 }
       let(:destination) { to_address_id }
       let(:create_transfer_request) do
         { amount: amount.to_s, network_id: network_id, asset_id: 'eth', destination: to_address_id }
@@ -194,7 +196,28 @@ describe Coinbase::Address do
       end
     end
 
+    context 'when the destination is a valid Address ID and asset is Gwei' do
+      let(:asset_id) { :gwei }
+      let(:amount) { 500_000_000 }
+      let(:wei_amount) { 500_000_000_000_000_000 }
+      let(:destination) { to_address_id }
+      let(:create_transfer_request) do
+        { amount: wei_amount.to_s, network_id: network_id, asset_id: 'eth', destination: to_address_id }
+      end
+      it 'creates a Transfer' do
+        expect(addresses_api)
+          .to receive(:get_address_balance)
+          .with(wallet_id, address_id, 'eth')
+          .and_return(balance_response)
+        expect(transfers_api)
+          .to receive(:create_transfer)
+          .with(wallet_id, address_id,  create_transfer_request)
+        expect(address.transfer(amount, asset_id, destination)).to eq(transfer)
+      end
+    end
+
     context 'when the asset is unsupported' do
+      let(:amount) { 500_000_000_000_000_000 }
       it 'raises an ArgumentError' do
         expect { address.transfer(amount, :uni, to_address_id) }.to raise_error(ArgumentError, 'Unsupported asset: uni')
       end
@@ -203,6 +226,8 @@ describe Coinbase::Address do
     # TODO: Add test case for when the destination is a Wallet.
 
     context 'when the destination Address is on a different network' do
+      let(:asset_id) { :wei }
+      let(:amount) { 500_000_000_000_000_000 }
       let(:new_model) do
         Coinbase::Client::Address.new({
                                         'network_id' => 'base-mainnet',
@@ -226,6 +251,7 @@ describe Coinbase::Address do
     end
 
     context 'when the balance is insufficient' do
+      let(:asset_id) { :wei }
       let(:excessive_amount) { 9_000_000_000_000_000_000_000 }
       before do
         expect(addresses_api)

--- a/spec/coinbase/transfer_spec.rb
+++ b/spec/coinbase/transfer_spec.rb
@@ -7,6 +7,7 @@ describe Coinbase::Transfer do
   let(:wallet_id) { SecureRandom.uuid }
   let(:from_address_id) { from_key.address.to_s }
   let(:amount) { BigDecimal(100) }
+  let(:eth_amount) { amount / BigDecimal(Coinbase::WEI_PER_ETHER.to_s) }
   let(:to_address_id) { to_key.address.to_s }
   let(:transfer_id) { SecureRandom.uuid }
   let(:unsigned_payload) do \
@@ -79,7 +80,7 @@ describe Coinbase::Transfer do
 
   describe '#amount' do
     it 'returns the amount' do
-      expect(transfer.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+      expect(transfer.amount).to eq(eth_amount)
     end
   end
 

--- a/spec/coinbase/transfer_spec.rb
+++ b/spec/coinbase/transfer_spec.rb
@@ -79,7 +79,7 @@ describe Coinbase::Transfer do
 
   describe '#amount' do
     it 'returns the amount' do
-      expect(transfer.amount).to eq(amount)
+      expect(transfer.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
     end
   end
 
@@ -89,9 +89,9 @@ describe Coinbase::Transfer do
     end
   end
 
-  describe '#to_address_id' do
+  describe '#destination_address_id' do
     it 'returns the destination address ID' do
-      expect(transfer.to_address_id).to eq(to_address_id)
+      expect(transfer.destination_address_id).to eq(to_address_id)
     end
   end
 

--- a/spec/coinbase/transfer_spec.rb
+++ b/spec/coinbase/transfer_spec.rb
@@ -6,23 +6,56 @@ describe Coinbase::Transfer do
   let(:network_id) { :base_sepolia }
   let(:wallet_id) { SecureRandom.uuid }
   let(:from_address_id) { from_key.address.to_s }
-  let(:amount) { 5 }
+  let(:amount) { BigDecimal(100) }
   let(:to_address_id) { to_key.address.to_s }
+  let(:transfer_id) { SecureRandom.uuid }
+  let(:unsigned_payload) do \
+    '7b2274797065223a22307832222c22636861696e4964223a2230783134613334222c226e6f6e63' \
+'65223a22307830222c22746f223a22307834643965346633663464316138623566346637623166' \
+'356235633762386436623262336231623062222c22676173223a22307835323038222c22676173' \
+'5072696365223a6e756c6c2c226d61785072696f72697479466565506572476173223a223078' \
+'3539363832663030222c226d6178466565506572476173223a2230783539363832663030222c22' \
+'76616c7565223a2230783536626337356532643633313030303030222c22696e707574223a22' \
+'3078222c226163636573734c697374223a5b5d2c2276223a22307830222c2272223a2230783022' \
+'2c2273223a22307830222c2279506172697479223a22307830222c2268617368223a2230783664' \
+'633334306534643663323633653363396561396135656438646561346332383966613861363966' \
+'3031653635393462333732386230386138323335333433227d'
+  end
+  let(:model) do
+    Coinbase::Client::Transfer.new({
+                                     'network_id' => network_id,
+                                     'wallet_id' => wallet_id,
+                                     'address_id' => from_address_id,
+                                     'destination' => to_address_id,
+                                     'asset_id' => 'eth',
+                                     'amount' => amount.to_s,
+                                     'transfer_id' => transfer_id,
+                                     'status' => 'pending',
+                                     'unsigned_payload' => unsigned_payload
+                                   })
+  end
+  let(:transfers_api) { double('Coinbase::Client::TransfersApi') }
   let(:client) { double('Jimson::Client') }
 
   subject(:transfer) do
-    described_class.new(network_id, wallet_id, from_address_id, amount, :eth, to_address_id, client: client)
+    described_class.new(model, transfers_api, client: client)
   end
 
   describe '#initialize' do
     it 'initializes a new Transfer' do
       expect(transfer).to be_a(Coinbase::Transfer)
     end
+  end
 
-    it 'does not initialize a new transfer for an invalid asset' do
-      expect do
-        Coinbase::Transfer.new(network_id, wallet_id, from_address_id, amount, :uni, to_address_id, client: client)
-      end.to raise_error(ArgumentError, 'Unsupported asset: uni')
+  describe '#transfer_id' do
+    it 'returns the transfer ID' do
+      expect(transfer.transfer_id).to eq(transfer_id)
+    end
+  end
+
+  describe '#unsigned_payload' do
+    it 'returns the unsigned payload' do
+      expect(transfer.unsigned_payload).to eq(unsigned_payload)
     end
   end
 
@@ -48,40 +81,6 @@ describe Coinbase::Transfer do
     it 'returns the amount' do
       expect(transfer.amount).to eq(amount)
     end
-
-    context 'when the amount is a Float' do
-      let(:float_amount) { 0.5 }
-      let(:float_transfer) do
-        described_class.new(network_id, wallet_id, from_address_id, float_amount, :eth, to_address_id, client: client)
-      end
-
-      it 'normalizes the amount' do
-        expect(float_transfer.amount).to eq(BigDecimal('0.5'))
-      end
-    end
-
-    context 'when the amount is an Integer' do
-      let(:integer_amount) { 5 }
-      let(:integer_transfer) do
-        described_class.new(network_id, wallet_id, from_address_id, integer_amount, :eth, to_address_id, client: client)
-      end
-
-      it 'normalizes the amount' do
-        expect(integer_transfer.amount).to eq(BigDecimal('5'))
-      end
-    end
-
-    context 'when the amount is a BigDecimal' do
-      let(:big_decimal_amount) { BigDecimal('0.5') }
-      let(:big_decimal_transfer) do
-        described_class.new(network_id, wallet_id, from_address_id, big_decimal_amount, :eth, to_address_id,
-                            client: client)
-      end
-
-      it 'normalizes the amount' do
-        expect(big_decimal_transfer.amount).to eq(big_decimal_amount)
-      end
-    end
   end
 
   describe '#asset_id' do
@@ -97,11 +96,6 @@ describe Coinbase::Transfer do
   end
 
   describe '#transaction' do
-    before do
-      allow(client).to receive(:eth_getTransactionCount).with(from_address_id, 'latest').and_return('0x7')
-      allow(client).to receive(:eth_gasPrice).and_return('0x7b')
-    end
-
     it 'returns the Transfer transaction' do
       expect(transfer.transaction).to be_a(Eth::Tx::Eip1559)
       expect(transfer.transaction.amount).to eq(amount * Coinbase::WEI_PER_ETHER)
@@ -109,11 +103,6 @@ describe Coinbase::Transfer do
   end
 
   describe '#transaction_hash' do
-    before do
-      allow(client).to receive(:eth_getTransactionCount).with(from_address_id, 'latest').and_return('0x7')
-      allow(client).to receive(:eth_gasPrice).and_return('0x7b')
-    end
-
     context 'when the transaction has been signed' do
       it 'returns the transaction hash' do
         transfer.transaction.sign(from_key)
@@ -136,11 +125,6 @@ describe Coinbase::Transfer do
   end
 
   describe '#status' do
-    before do
-      allow(client).to receive(:eth_getTransactionCount).with(from_address_id, 'latest').and_return('0x7')
-      allow(client).to receive(:eth_gasPrice).and_return('0x7b')
-    end
-
     context 'when the transaction has not been created' do
       it 'returns PENDING' do
         expect(transfer.status).to eq(Coinbase::Transfer::Status::PENDING)
@@ -226,8 +210,6 @@ describe Coinbase::Transfer do
 
   describe '#wait!' do
     before do
-      allow(client).to receive(:eth_getTransactionCount).with(from_address_id, 'latest').and_return('0x7')
-      allow(client).to receive(:eth_gasPrice).and_return('0x7b')
       # TODO: This isn't working for some reason.
       allow(transfer).to receive(:sleep)
     end

--- a/spec/coinbase/user_spec.rb
+++ b/spec/coinbase/user_spec.rb
@@ -5,7 +5,8 @@ describe Coinbase::User do
   let(:model) { Coinbase::Client::User.new({ 'id': user_id }) }
   let(:wallets_api) { instance_double(Coinbase::Client::WalletsApi) }
   let(:addresses_api) { instance_double(Coinbase::Client::AddressesApi) }
-  let(:user) { described_class.new(model, wallets_api, addresses_api) }
+  let(:transfers_api) { instance_double(Coinbase::Client::TransfersApi) }
+  let(:user) { described_class.new(model, wallets_api, addresses_api, transfers_api) }
 
   describe '#user_id' do
     it 'returns the user ID' do


### PR DESCRIPTION
### What changed? Why?
- Transfers are tracked on the server
- Transfers are currently still signed and broadcasted by the client SDK
- Update Ruby Client to include current `Transfer` model + `create_transfer` input arguments

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->