### PR TITLE
Fix user import_wallet

### DIFF
--- a/lib/coinbase/user.rb
+++ b/lib/coinbase/user.rb
@@ -39,7 +39,7 @@ module Coinbase
     # @param data [Coinbase::Wallet::Data] the Wallet data to import
     # @return [Coinbase::Wallet] the imported Wallet
     def import_wallet(data)
-      model = @wallets_api.get_wallet(data.wallet_id)
+      model = wallets_api.get_wallet(data.wallet_id)
       address_count = addresses_api.list_addresses(model.id).total_count
       Wallet.new(model, seed: data.seed, address_count: address_count)
     end


### PR DESCRIPTION


### What changed? Why?
This fixes the user import_wallet to ensure that it uses the memoized wallets_api helper.

This currently is returning an error when importing a wallet in the following manner:

```ruby
user = Coinbase.default_user
cb_wallet = user.import_wallet(Coinbase::Wallet::Data.new(wallet.seed, wallet.wallet_id))
```

#### Qualified Impact
This impacts wallet import flows