### PR TITLE
[PSDK-40] Parameterize debug mode for API clients

### DIFF
--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -45,13 +45,14 @@ module Coinbase
   # Configuration object for the Coinbase SDK.
   class Configuration
     attr_reader :base_sepolia_rpc_url, :base_sepolia_client
-    attr_accessor :api_url, :api_key_name, :api_key_private_key
+    attr_accessor :api_url, :api_key_name, :api_key_private_key, :debug_api
 
     # Initializes the configuration object.
     def initialize
       @base_sepolia_rpc_url = 'https://sepolia.base.org'
       @base_sepolia_client = Jimson::Client.new(@base_sepolia_rpc_url)
       @api_url = 'https://api.cdp.coinbase.com'
+      @debug_api = false
     end
 
     # Sets configuration values based on the provided CDP API Key JSON file.

--- a/lib/coinbase/balance_map.rb
+++ b/lib/coinbase/balance_map.rb
@@ -42,7 +42,7 @@ module Coinbase
         result[asset_id] = str
       end
 
-      result
+      result.to_s
     end
   end
 end

--- a/lib/coinbase/middleware.rb
+++ b/lib/coinbase/middleware.rb
@@ -12,7 +12,7 @@ module Coinbase
     # Returns the default middleware configuration for the Coinbase SDK.
     def self.config
       Coinbase::Client::Configuration.default.tap do |config|
-        config.debugging = true
+        config.debugging = Coinbase.configuration.debug_api
         config.host = Coinbase.configuration.api_url
         config.request(:authenticator)
       end


### PR DESCRIPTION
### What changed? Why?
Parameterize debug mode for API clients

Note how E2E tests now no longer have trace logs: https://github.com/coinbase/coinbase-sdk-ruby/actions/runs/8929414587/job/24527152498?pr=27

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->