### PR TITLE
[PSDK-53] List Tranfers for an Address

### DIFF
--- a/docs/Coinbase/APIError.html
+++ b/docs/Coinbase/APIError.html
@@ -565,7 +565,7 @@
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Creates a specific APIError based on the API error code.</p>
+<p>Creates a specific APIError based on the API error code. rubocop:disable Metrics/MethodLength</p>
 
 
   </div>
@@ -630,7 +630,6 @@
       <pre class="lines">
 
 
-27
 28
 29
 30
@@ -684,10 +683,11 @@
 78
 79
 80
-81</pre>
+81
+82</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/errors.rb', line 27</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/errors.rb', line 28</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_from_error'>from_error</span><span class='lparen'>(</span><span class='id identifier rubyid_err'>err</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise'>raise</span> <span class='const'>ArgumentError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>Argument must be a Coinbase::Client::APIError</span><span class='tstring_end'>&#39;</span></span> <span class='kw'>unless</span> <span class='id identifier rubyid_err'>err</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span> <span class='const'><span class='object_link'><a href="../Coinbase.html" title="Coinbase (module)">Coinbase</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Client.html" title="Coinbase::Client (module)">Client</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Client/ApiError.html" title="Coinbase::Client::ApiError (class)">ApiError</a></span></span>
@@ -799,12 +799,12 @@
       <pre class="lines">
 
 
-91
-92
-93</pre>
+93
+94
+95</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/errors.rb', line 91</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/errors.rb', line 93</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_inspect'>inspect</span>
   <span class='id identifier rubyid_to_s'>to_s</span>
@@ -858,12 +858,12 @@
       <pre class="lines">
 
 
-85
-86
-87</pre>
+87
+88
+89</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/errors.rb', line 85</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/errors.rb', line 87</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_s'>to_s</span>
   <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>APIError{http_code: </span><span class='embexpr_beg'>#{</span><span class='ivar'>@http_code</span><span class='embexpr_end'>}</span><span class='tstring_content'>, api_code: </span><span class='embexpr_beg'>#{</span><span class='ivar'>@api_code</span><span class='embexpr_end'>}</span><span class='tstring_content'>, api_message: </span><span class='embexpr_beg'>#{</span><span class='ivar'>@api_message</span><span class='embexpr_end'>}</span><span class='tstring_content'>}</span><span class='tstring_end'>&quot;</span></span>

--- a/docs/Coinbase/Address.html
+++ b/docs/Coinbase/Address.html
@@ -1024,9 +1024,7 @@
 181
 182
 183
-184
-185
-186</pre>
+184</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/coinbase/address.rb', line 167</span>
@@ -1036,10 +1034,8 @@
   <span class='id identifier rubyid_page'>page</span> <span class='op'>=</span> <span class='kw'>nil</span>
 
   <span class='id identifier rubyid_loop'>loop</span> <span class='kw'>do</span>
-    <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span> <span class='label'>limit:</span> <span class='int'>100</span><span class='comma'>,</span> <span class='label'>page:</span> <span class='id identifier rubyid_page'>page</span> <span class='rbrace'>}</span>
-
     <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="../Coinbase.html" title="Coinbase (module)">Coinbase</a></span></span><span class='period'>.</span><span class='id identifier rubyid_call_api'><span class='object_link'><a href="../Coinbase.html#call_api-class_method" title="Coinbase.call_api (method)">call_api</a></span></span> <span class='kw'>do</span>
-      <span class='id identifier rubyid_transfers_api'>transfers_api</span><span class='period'>.</span><span class='id identifier rubyid_list_transfers'>list_transfers</span><span class='lparen'>(</span><span class='id identifier rubyid_wallet_id'>wallet_id</span><span class='comma'>,</span> <span class='id identifier rubyid_address_id'>address_id</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
+      <span class='id identifier rubyid_transfers_api'>transfers_api</span><span class='period'>.</span><span class='id identifier rubyid_list_transfers'>list_transfers</span><span class='lparen'>(</span><span class='id identifier rubyid_wallet_id'>wallet_id</span><span class='comma'>,</span> <span class='id identifier rubyid_address_id'>address_id</span><span class='comma'>,</span> <span class='lbrace'>{</span> <span class='label'>limit:</span> <span class='int'>100</span><span class='comma'>,</span> <span class='label'>page:</span> <span class='id identifier rubyid_page'>page</span> <span class='rbrace'>}</span><span class='rparen'>)</span>
     <span class='kw'>end</span>
 
     <span class='id identifier rubyid_transfer_ids'>transfer_ids</span><span class='period'>.</span><span class='id identifier rubyid_concat'>concat</span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_data'>data</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:transfer_id</span><span class='rparen'>)</span><span class='rparen'>)</span> <span class='kw'>if</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_data'>data</span>

--- a/docs/Coinbase/Address.html
+++ b/docs/Coinbase/Address.html
@@ -298,6 +298,30 @@
         <li class="public ">
   <span class="summary_signature">
     
+      <a href="#list_transfer_ids-instance_method" title="#list_transfer_ids (instance method)">#<strong>list_transfer_ids</strong>  &#x21d2; Array&lt;String&gt; </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Lists the IDs of all Transfers associated with the given Wallet and Address.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
       <a href="#network_id-instance_method" title="#network_id (instance method)">#<strong>network_id</strong>  &#x21d2; Symbol </a>
     
 
@@ -933,6 +957,99 @@
   <span class='kw'>end</span>
 
   <span class='const'><span class='object_link'><a href="../Coinbase.html" title="Coinbase (module)">Coinbase</a></span></span><span class='period'>.</span><span class='id identifier rubyid_to_balance_map'><span class='object_link'><a href="../Coinbase.html#to_balance_map-class_method" title="Coinbase.to_balance_map (method)">to_balance_map</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='rparen'>)</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="list_transfer_ids-instance_method">
+  
+    #<strong>list_transfer_ids</strong>  &#x21d2; <tt>Array&lt;String&gt;</tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Lists the IDs of all Transfers associated with the given Wallet and Address.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array&lt;String&gt;</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>The IDs of all Transfers belonging to the Wallet and Address</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+167
+168
+169
+170
+171
+172
+173
+174
+175
+176
+177
+178
+179
+180
+181
+182
+183
+184
+185
+186</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/address.rb', line 167</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_list_transfer_ids'>list_transfer_ids</span>
+  <span class='id identifier rubyid_transfer_ids'>transfer_ids</span> <span class='op'>=</span> <span class='lbracket'>[</span><span class='rbracket'>]</span>
+  <span class='id identifier rubyid_page'>page</span> <span class='op'>=</span> <span class='kw'>nil</span>
+
+  <span class='id identifier rubyid_loop'>loop</span> <span class='kw'>do</span>
+    <span class='id identifier rubyid_opts'>opts</span> <span class='op'>=</span> <span class='lbrace'>{</span> <span class='label'>limit:</span> <span class='int'>100</span><span class='comma'>,</span> <span class='label'>page:</span> <span class='id identifier rubyid_page'>page</span> <span class='rbrace'>}</span>
+
+    <span class='id identifier rubyid_response'>response</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="../Coinbase.html" title="Coinbase (module)">Coinbase</a></span></span><span class='period'>.</span><span class='id identifier rubyid_call_api'><span class='object_link'><a href="../Coinbase.html#call_api-class_method" title="Coinbase.call_api (method)">call_api</a></span></span> <span class='kw'>do</span>
+      <span class='id identifier rubyid_transfers_api'>transfers_api</span><span class='period'>.</span><span class='id identifier rubyid_list_transfers'>list_transfers</span><span class='lparen'>(</span><span class='id identifier rubyid_wallet_id'>wallet_id</span><span class='comma'>,</span> <span class='id identifier rubyid_address_id'>address_id</span><span class='comma'>,</span> <span class='id identifier rubyid_opts'>opts</span><span class='rparen'>)</span>
+    <span class='kw'>end</span>
+
+    <span class='id identifier rubyid_transfer_ids'>transfer_ids</span><span class='period'>.</span><span class='id identifier rubyid_concat'>concat</span><span class='lparen'>(</span><span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_data'>data</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:transfer_id</span><span class='rparen'>)</span><span class='rparen'>)</span> <span class='kw'>if</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_data'>data</span>
+
+    <span class='kw'>break</span> <span class='kw'>unless</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_has_more'>has_more</span>
+
+    <span class='id identifier rubyid_page'>page</span> <span class='op'>=</span> <span class='id identifier rubyid_response'>response</span><span class='period'>.</span><span class='id identifier rubyid_next_page'>next_page</span>
+  <span class='kw'>end</span>
+
+  <span class='id identifier rubyid_transfer_ids'>transfer_ids</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>

--- a/docs/Coinbase/Transfer.html
+++ b/docs/Coinbase/Transfer.html
@@ -650,7 +650,7 @@
       
         &mdash;
         <div class='inline'>
-<p>The amount in units of ETH</p>
+<p>The amount of the asset</p>
 </div>
       
     </li>
@@ -665,13 +665,23 @@
 
 76
 77
-78</pre>
+78
+79
+80
+81
+82
+83</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 76</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_amount'>amount</span>
-  <span class='const'>BigDecimal</span><span class='lparen'>(</span><span class='ivar'>@model</span><span class='period'>.</span><span class='id identifier rubyid_amount'>amount</span><span class='rparen'>)</span> <span class='op'>/</span> <span class='const'>BigDecimal</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Coinbase.html" title="Coinbase (module)">Coinbase</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Coinbase.html#WEI_PER_ETHER-constant" title="Coinbase::WEI_PER_ETHER (constant)">WEI_PER_ETHER</a></span></span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span><span class='rparen'>)</span>
+  <span class='kw'>case</span> <span class='id identifier rubyid_asset_id'>asset_id</span>
+  <span class='kw'>when</span> <span class='symbol'>:eth</span>
+    <span class='const'>BigDecimal</span><span class='lparen'>(</span><span class='ivar'>@model</span><span class='period'>.</span><span class='id identifier rubyid_amount'>amount</span><span class='rparen'>)</span> <span class='op'>/</span> <span class='const'>BigDecimal</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Coinbase.html" title="Coinbase (module)">Coinbase</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Coinbase.html#WEI_PER_ETHER-constant" title="Coinbase::WEI_PER_ETHER (constant)">WEI_PER_ETHER</a></span></span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span><span class='rparen'>)</span>
+  <span class='kw'>else</span>
+    <span class='const'>BigDecimal</span><span class='lparen'>(</span><span class='ivar'>@model</span><span class='period'>.</span><span class='id identifier rubyid_amount'>amount</span><span class='rparen'>)</span>
+  <span class='kw'>end</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -899,12 +909,12 @@
       <pre class="lines">
 
 
-185
-186
-187</pre>
+190
+191
+192</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 185</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 190</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_inspect'>inspect</span>
   <span class='id identifier rubyid_to_s'>to_s</span>
@@ -1017,12 +1027,12 @@
       <pre class="lines">
 
 
-95
-96
-97</pre>
+100
+101
+102</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 95</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 100</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_signed_payload'>signed_payload</span>
   <span class='ivar'>@model</span><span class='period'>.</span><span class='id identifier rubyid_signed_payload'>signed_payload</span>
@@ -1076,11 +1086,6 @@
       <pre class="lines">
 
 
-131
-132
-133
-134
-135
 136
 137
 138
@@ -1098,10 +1103,15 @@
 150
 151
 152
-153</pre>
+153
+154
+155
+156
+157
+158</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 131</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 136</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_status'>status</span>
   <span class='comment'># Check if the transfer has been signed yet.
@@ -1175,15 +1185,15 @@
       <pre class="lines">
 
 
-176
-177
-178
-179
-180
-181</pre>
+181
+182
+183
+184
+185
+186</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 176</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 181</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_s'>to_s</span>
   <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Coinbase::Transfer{transfer_id: &#39;</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_transfer_id'>transfer_id</span><span class='embexpr_end'>}</span><span class='tstring_content'>&#39;, network_id: &#39;</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_network_id'>network_id</span><span class='embexpr_end'>}</span><span class='tstring_content'>&#39;, </span><span class='tstring_end'>&quot;</span></span> \
@@ -1240,11 +1250,6 @@
       <pre class="lines">
 
 
-107
-108
-109
-110
-111
 112
 113
 114
@@ -1260,10 +1265,15 @@
 124
 125
 126
-127</pre>
+127
+128
+129
+130
+131
+132</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 107</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 112</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_transaction'>transaction</span>
   <span class='kw'>return</span> <span class='ivar'>@transaction</span> <span class='kw'>unless</span> <span class='ivar'>@transaction</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
@@ -1335,12 +1345,12 @@
       <pre class="lines">
 
 
-101
-102
-103</pre>
+106
+107
+108</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 101</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 106</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_transaction_hash'>transaction_hash</span>
   <span class='ivar'>@model</span><span class='period'>.</span><span class='id identifier rubyid_transaction_hash'>transaction_hash</span>
@@ -1394,13 +1404,13 @@
       <pre class="lines">
 
 
-82
-83
-84
-85</pre>
+87
+88
+89
+90</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 82</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 87</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_transaction_link'>transaction_link</span>
   <span class='comment'># TODO: Parameterize this by Network.
@@ -1514,12 +1524,12 @@
       <pre class="lines">
 
 
-89
-90
-91</pre>
+94
+95
+96</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 89</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 94</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_unsigned_payload'>unsigned_payload</span>
   <span class='ivar'>@model</span><span class='period'>.</span><span class='id identifier rubyid_unsigned_payload'>unsigned_payload</span>
@@ -1613,11 +1623,6 @@
       <pre class="lines">
 
 
-160
-161
-162
-163
-164
 165
 166
 167
@@ -1625,10 +1630,15 @@
 169
 170
 171
-172</pre>
+172
+173
+174
+175
+176
+177</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 160</span>
+      <pre class="code"><span class="info file"># File 'lib/coinbase/transfer.rb', line 165</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_wait!'>wait!</span><span class='lparen'>(</span><span class='id identifier rubyid_interval_seconds'>interval_seconds</span> <span class='op'>=</span> <span class='float'>0.2</span><span class='comma'>,</span> <span class='id identifier rubyid_timeout_seconds'>timeout_seconds</span> <span class='op'>=</span> <span class='int'>10</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_start_time'>start_time</span> <span class='op'>=</span> <span class='const'>Time</span><span class='period'>.</span><span class='id identifier rubyid_now'>now</span>

--- a/docs/method_list.html
+++ b/docs/method_list.html
@@ -46,22 +46,6 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#==-instance_method" title="Coinbase::Client::FaucetTransaction#== (method)">#==</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#==-instance_method" title="Coinbase::Client::Balance#== (method)">#==</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#==-instance_method" title="Coinbase::Client::CreateTransferRequest#== (method)">#==</a></span>
       <small>Coinbase::Client::CreateTransferRequest</small>
     </div>
@@ -70,8 +54,24 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#==-instance_method" title="Coinbase::Client::CreateWalletRequest#== (method)">#==</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Wallet.html#==-instance_method" title="Coinbase::Client::Wallet#== (method)">#==</a></span>
       <small>Coinbase::Client::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#==-instance_method" title="Coinbase::Client::WalletList#== (method)">#==</a></span>
+      <small>Coinbase::Client::WalletList</small>
     </div>
   </li>
   
@@ -86,16 +86,32 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#==-instance_method" title="Coinbase::Client::Asset#== (method)">#==</a></span>
-      <small>Coinbase::Client::Asset</small>
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#==-instance_method" title="Coinbase::Client::FaucetTransaction#== (method)">#==</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#==-instance_method" title="Coinbase::Client::AddressList#== (method)">#==</a></span>
-      <small>Coinbase::Client::AddressList</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#==-instance_method" title="Coinbase::Client::CreateAddressRequest#== (method)">#==</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/User.html#==-instance_method" title="Coinbase::Client::User#== (method)">#==</a></span>
+      <small>Coinbase::Client::User</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#==-instance_method" title="Coinbase::Client::Asset#== (method)">#==</a></span>
+      <small>Coinbase::Client::Asset</small>
     </div>
   </li>
   
@@ -118,24 +134,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#==-instance_method" title="Coinbase::Client::WalletList#== (method)">#==</a></span>
-      <small>Coinbase::Client::WalletList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#==-instance_method" title="Coinbase::Client::CreateAddressRequest#== (method)">#==</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#==-instance_method" title="Coinbase::Client::CreateWalletRequest#== (method)">#==</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/Error.html#==-instance_method" title="Coinbase::Client::Error#== (method)">#==</a></span>
+      <small>Coinbase::Client::Error</small>
     </div>
   </li>
   
@@ -150,71 +150,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#==-instance_method" title="Coinbase::Client::BroadcastTransferRequest#== (method)">#==</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#==-instance_method" title="Coinbase::Client::User#== (method)">#==</a></span>
-      <small>Coinbase::Client::User</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#==-instance_method" title="Coinbase::Client::Error#== (method)">#==</a></span>
-      <small>Coinbase::Client::Error</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#_deserialize-class_method" title="Coinbase::Client::Asset._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::Asset</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#_deserialize-class_method" title="Coinbase::Client::CreateWalletRequest._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#_deserialize-class_method" title="Coinbase::Client::FaucetTransaction._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#_deserialize-class_method" title="Coinbase::Client::AddressBalanceList._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#_deserialize-class_method" title="Coinbase::Client::Transfer._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#_deserialize-class_method" title="Coinbase::Client::Balance._deserialize (method)">_deserialize</a></span>
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#==-instance_method" title="Coinbase::Client::Balance#== (method)">#==</a></span>
       <small>Coinbase::Client::Balance</small>
     </div>
   </li>
@@ -222,64 +158,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#_deserialize-class_method" title="Coinbase::Client::CreateTransferRequest._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::CreateTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#_deserialize-class_method" title="Coinbase::Client::Wallet._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#_deserialize-class_method" title="Coinbase::Client::WalletList._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::WalletList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#_deserialize-class_method" title="Coinbase::Client::BroadcastTransferRequest._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#_deserialize-class_method" title="Coinbase::Client::Address._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#_deserialize-class_method" title="Coinbase::Client::CreateAddressRequest._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#_deserialize-class_method" title="Coinbase::Client::User._deserialize (method)">_deserialize</a></span>
-      <small>Coinbase::Client::User</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#_deserialize-class_method" title="Coinbase::Client::AddressList._deserialize (method)">_deserialize</a></span>
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#==-instance_method" title="Coinbase::Client::AddressList#== (method)">#==</a></span>
       <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#==-instance_method" title="Coinbase::Client::BroadcastTransferRequest#== (method)">#==</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
     </div>
   </li>
   
@@ -294,6 +182,118 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#_deserialize-class_method" title="Coinbase::Client::AddressList._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#_deserialize-class_method" title="Coinbase::Client::WalletList._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::WalletList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#_deserialize-class_method" title="Coinbase::Client::Asset._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::Asset</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#_deserialize-class_method" title="Coinbase::Client::CreateTransferRequest._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::CreateTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#_deserialize-class_method" title="Coinbase::Client::BroadcastTransferRequest._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#_deserialize-class_method" title="Coinbase::Client::Wallet._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#_deserialize-class_method" title="Coinbase::Client::CreateAddressRequest._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#_deserialize-class_method" title="Coinbase::Client::CreateWalletRequest._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Address.html#_deserialize-class_method" title="Coinbase::Client::Address._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/User.html#_deserialize-class_method" title="Coinbase::Client::User._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::User</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#_deserialize-class_method" title="Coinbase::Client::Balance._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#_deserialize-class_method" title="Coinbase::Client::AddressBalanceList._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#_deserialize-class_method" title="Coinbase::Client::FaucetTransaction._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#_deserialize-class_method" title="Coinbase::Client::Transfer._deserialize (method)">_deserialize</a></span>
+      <small>Coinbase::Client::Transfer</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/TransferList.html#_deserialize-class_method" title="Coinbase::Client::TransferList._deserialize (method)">_deserialize</a></span>
       <small>Coinbase::Client::TransferList</small>
     </div>
@@ -302,24 +302,40 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#_to_hash-instance_method" title="Coinbase::Client::User#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::User</small>
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#_to_hash-instance_method" title="Coinbase::Client::WalletList#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::WalletList</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#_to_hash-instance_method" title="Coinbase::Client::Address#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::Address</small>
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#_to_hash-instance_method" title="Coinbase::Client::AddressBalanceList#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#_to_hash-instance_method" title="Coinbase::Client::Wallet#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::Wallet</small>
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#_to_hash-instance_method" title="Coinbase::Client::AddressList#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#_to_hash-instance_method" title="Coinbase::Client::Balance#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#_to_hash-instance_method" title="Coinbase::Client::Transfer#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::Transfer</small>
     </div>
   </li>
   
@@ -334,8 +350,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#_to_hash-instance_method" title="Coinbase::Client::CreateTransferRequest#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::CreateTransferRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/User.html#_to_hash-instance_method" title="Coinbase::Client::User#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::User</small>
     </div>
   </li>
   
@@ -350,24 +366,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#_to_hash-instance_method" title="Coinbase::Client::CreateAddressRequest#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#_to_hash-instance_method" title="Coinbase::Client::Wallet#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::Wallet</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#_to_hash-instance_method" title="Coinbase::Client::CreateWalletRequest#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#_to_hash-instance_method" title="Coinbase::Client::CreateAddressRequest#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#_to_hash-instance_method" title="Coinbase::Client::AddressBalanceList#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#_to_hash-instance_method" title="Coinbase::Client::CreateWalletRequest#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
     </div>
   </li>
   
@@ -390,40 +406,24 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#_to_hash-instance_method" title="Coinbase::Client::AddressList#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::AddressList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Error.html#_to_hash-instance_method" title="Coinbase::Client::Error#_to_hash (method)">#_to_hash</a></span>
       <small>Coinbase::Client::Error</small>
     </div>
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#_to_hash-instance_method" title="Coinbase::Client::WalletList#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::WalletList</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#_to_hash-instance_method" title="Coinbase::Client::Transfer#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::Transfer</small>
+      <span class='object_link'><a href="Coinbase/Client/Address.html#_to_hash-instance_method" title="Coinbase::Client::Address#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::Address</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#_to_hash-instance_method" title="Coinbase::Client::Balance#_to_hash (method)">#_to_hash</a></span>
-      <small>Coinbase::Client::Balance</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#_to_hash-instance_method" title="Coinbase::Client::CreateTransferRequest#_to_hash (method)">#_to_hash</a></span>
+      <small>Coinbase::Client::CreateTransferRequest</small>
     </div>
   </li>
   
@@ -438,40 +438,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#acceptable_attributes-class_method" title="Coinbase::Client::Balance.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#acceptable_attributes-class_method" title="Coinbase::Client::FaucetTransaction.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#acceptable_attributes-class_method" title="Coinbase::Client::AddressBalanceList.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#acceptable_attributes-class_method" title="Coinbase::Client::Error.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::Error</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#acceptable_attributes-class_method" title="Coinbase::Client::Transfer.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::Transfer</small>
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#acceptable_attributes-class_method" title="Coinbase::Client::BroadcastTransferRequest.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
     </div>
   </li>
   
@@ -486,16 +454,32 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#acceptable_attributes-class_method" title="Coinbase::Client::CreateWalletRequest.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#acceptable_attributes-class_method" title="Coinbase::Client::CreateAddressRequest.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#acceptable_attributes-class_method" title="Coinbase::Client::Asset.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::Asset</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#acceptable_attributes-class_method" title="Coinbase::Client::CreateWalletRequest.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#acceptable_attributes-class_method" title="Coinbase::Client::AddressBalanceList.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#acceptable_attributes-class_method" title="Coinbase::Client::FaucetTransaction.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
     </div>
   </li>
   
@@ -510,29 +494,37 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#acceptable_attributes-class_method" title="Coinbase::Client::AddressList.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/WalletList.html#acceptable_attributes-class_method" title="Coinbase::Client::WalletList.acceptable_attributes (method)">acceptable_attributes</a></span>
       <small>Coinbase::Client::WalletList</small>
     </div>
   </li>
   
 
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#acceptable_attributes-class_method" title="Coinbase::Client::Transfer.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::Transfer</small>
+    </div>
+  </li>
+  
+
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#acceptable_attributes-class_method" title="Coinbase::Client::CreateAddressRequest.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#acceptable_attributes-class_method" title="Coinbase::Client::Balance.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::Balance</small>
     </div>
   </li>
   
 
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#acceptable_attributes-class_method" title="Coinbase::Client::User.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::User</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Address.html#acceptable_attributes-class_method" title="Coinbase::Client::Address.acceptable_attributes (method)">acceptable_attributes</a></span>
       <small>Coinbase::Client::Address</small>
@@ -540,18 +532,26 @@
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Error.html#acceptable_attributes-class_method" title="Coinbase::Client::Error.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::Error</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#acceptable_attributes-class_method" title="Coinbase::Client::BroadcastTransferRequest.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#acceptable_attributes-class_method" title="Coinbase::Client::Asset.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::Asset</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#acceptable_attributes-class_method" title="Coinbase::Client::AddressList.acceptable_attributes (method)">acceptable_attributes</a></span>
-      <small>Coinbase::Client::AddressList</small>
+      <span class='object_link'><a href="Coinbase/Client/User.html#acceptable_attributes-class_method" title="Coinbase::Client::User.acceptable_attributes (method)">acceptable_attributes</a></span>
+      <small>Coinbase::Client::User</small>
     </div>
   </li>
   
@@ -582,21 +582,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Address.html#address_id-instance_method" title="Coinbase::Address#address_id (method)">#address_id</a></span>
-      <small>Coinbase::Address</small>
+      <span class='object_link'><a href="Coinbase/Asset.html#address_id-instance_method" title="Coinbase::Asset#address_id (method)">#address_id</a></span>
+      <small>Coinbase::Asset</small>
     </div>
   </li>
   
 
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#address_id-instance_method" title="Coinbase::Client::Address#address_id (method)">#address_id</a></span>
-      <small>Coinbase::Client::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Transfer.html#address_id-instance_method" title="Coinbase::Client::Transfer#address_id (method)">#address_id</a></span>
       <small>Coinbase::Client::Transfer</small>
@@ -604,10 +596,18 @@
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Address.html#address_id-instance_method" title="Coinbase::Client::Address#address_id (method)">#address_id</a></span>
+      <small>Coinbase::Client::Address</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Asset.html#address_id-instance_method" title="Coinbase::Asset#address_id (method)">#address_id</a></span>
-      <small>Coinbase::Asset</small>
+      <span class='object_link'><a href="Coinbase/Address.html#address_id-instance_method" title="Coinbase::Address#address_id (method)">#address_id</a></span>
+      <small>Coinbase::Address</small>
     </div>
   </li>
   
@@ -622,24 +622,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#amount-instance_method" title="Coinbase::Client::Balance#amount (method)">#amount</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#amount-instance_method" title="Coinbase::Client::CreateTransferRequest#amount (method)">#amount</a></span>
       <small>Coinbase::Client::CreateTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Transfer.html#amount-instance_method" title="Coinbase::Transfer#amount (method)">#amount</a></span>
-      <small>Coinbase::Transfer</small>
     </div>
   </li>
   
@@ -654,24 +638,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletsApi.html#api_client-instance_method" title="Coinbase::Client::WalletsApi#api_client (method)">#api_client</a></span>
-      <small>Coinbase::Client::WalletsApi</small>
+      <span class='object_link'><a href="Coinbase/Transfer.html#amount-instance_method" title="Coinbase::Transfer#amount (method)">#amount</a></span>
+      <small>Coinbase::Transfer</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Configuration.html#api_client-instance_method" title="Coinbase::Configuration#api_client (method)">#api_client</a></span>
-      <small>Coinbase::Configuration</small>
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#amount-instance_method" title="Coinbase::Client::Balance#amount (method)">#amount</a></span>
+      <small>Coinbase::Client::Balance</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/UsersApi.html#api_client-instance_method" title="Coinbase::Client::UsersApi#api_client (method)">#api_client</a></span>
-      <small>Coinbase::Client::UsersApi</small>
+      <span class='object_link'><a href="Coinbase/Configuration.html#api_client-instance_method" title="Coinbase::Configuration#api_client (method)">#api_client</a></span>
+      <small>Coinbase::Configuration</small>
     </div>
   </li>
   
@@ -680,6 +664,22 @@
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/AddressesApi.html#api_client-instance_method" title="Coinbase::Client::AddressesApi#api_client (method)">#api_client</a></span>
       <small>Coinbase::Client::AddressesApi</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/WalletsApi.html#api_client-instance_method" title="Coinbase::Client::WalletsApi#api_client (method)">#api_client</a></span>
+      <small>Coinbase::Client::WalletsApi</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/UsersApi.html#api_client-instance_method" title="Coinbase::Client::UsersApi#api_client (method)">#api_client</a></span>
+      <small>Coinbase::Client::UsersApi</small>
     </div>
   </li>
   
@@ -766,24 +766,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Transfer.html#asset_id-instance_method" title="Coinbase::Transfer#asset_id (method)">#asset_id</a></span>
-      <small>Coinbase::Transfer</small>
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#asset_id-instance_method" title="Coinbase::Client::Transfer#asset_id (method)">#asset_id</a></span>
+      <small>Coinbase::Client::Transfer</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Asset.html#asset_id-instance_method" title="Coinbase::Asset#asset_id (method)">#asset_id</a></span>
-      <small>Coinbase::Asset</small>
+      <span class='object_link'><a href="Coinbase/Transfer.html#asset_id-instance_method" title="Coinbase::Transfer#asset_id (method)">#asset_id</a></span>
+      <small>Coinbase::Transfer</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#asset_id-instance_method" title="Coinbase::Client::Asset#asset_id (method)">#asset_id</a></span>
-      <small>Coinbase::Client::Asset</small>
+      <span class='object_link'><a href="Coinbase/Asset.html#asset_id-instance_method" title="Coinbase::Asset#asset_id (method)">#asset_id</a></span>
+      <small>Coinbase::Asset</small>
     </div>
   </li>
   
@@ -798,8 +798,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#asset_id-instance_method" title="Coinbase::Client::Transfer#asset_id (method)">#asset_id</a></span>
-      <small>Coinbase::Client::Transfer</small>
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#asset_id-instance_method" title="Coinbase::Client::Asset#asset_id (method)">#asset_id</a></span>
+      <small>Coinbase::Client::Asset</small>
     </div>
   </li>
   
@@ -814,53 +814,13 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#attribute_map-class_method" title="Coinbase::Client::Asset.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::Asset</small>
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#attribute_map-class_method" title="Coinbase::Client::Wallet.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::Wallet</small>
     </div>
   </li>
   
 
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#attribute_map-class_method" title="Coinbase::Client::BroadcastTransferRequest.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#attribute_map-class_method" title="Coinbase::Client::CreateTransferRequest.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::CreateTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#attribute_map-class_method" title="Coinbase::Client::CreateAddressRequest.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#attribute_map-class_method" title="Coinbase::Client::CreateWalletRequest.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#attribute_map-class_method" title="Coinbase::Client::AddressBalanceList.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#attribute_map-class_method" title="Coinbase::Client::FaucetTransaction.attribute_map (method)">attribute_map</a></span>
       <small>Coinbase::Client::FaucetTransaction</small>
@@ -868,18 +828,10 @@
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#attribute_map-class_method" title="Coinbase::Client::TransferList.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::TransferList</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#attribute_map-class_method" title="Coinbase::Client::AddressList.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::AddressList</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#attribute_map-class_method" title="Coinbase::Client::CreateAddressRequest.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
     </div>
   </li>
   
@@ -894,22 +846,6 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#attribute_map-class_method" title="Coinbase::Client::Transfer.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#attribute_map-class_method" title="Coinbase::Client::Balance.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Address.html#attribute_map-class_method" title="Coinbase::Client::Address.attribute_map (method)">attribute_map</a></span>
       <small>Coinbase::Client::Address</small>
     </div>
@@ -918,8 +854,56 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#attribute_map-class_method" title="Coinbase::Client::Wallet.attribute_map (method)">attribute_map</a></span>
-      <small>Coinbase::Client::Wallet</small>
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#attribute_map-class_method" title="Coinbase::Client::AddressList.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#attribute_map-class_method" title="Coinbase::Client::Balance.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#attribute_map-class_method" title="Coinbase::Client::TransferList.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::TransferList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#attribute_map-class_method" title="Coinbase::Client::Asset.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::Asset</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#attribute_map-class_method" title="Coinbase::Client::CreateTransferRequest.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::CreateTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#attribute_map-class_method" title="Coinbase::Client::CreateWalletRequest.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#attribute_map-class_method" title="Coinbase::Client::BroadcastTransferRequest.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
     </div>
   </li>
   
@@ -936,6 +920,22 @@
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Error.html#attribute_map-class_method" title="Coinbase::Client::Error.attribute_map (method)">attribute_map</a></span>
       <small>Coinbase::Client::Error</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#attribute_map-class_method" title="Coinbase::Client::Transfer.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::Transfer</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#attribute_map-class_method" title="Coinbase::Client::AddressBalanceList.attribute_map (method)">attribute_map</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
     </div>
   </li>
   
@@ -1038,16 +1038,32 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#build_from_hash-class_method" title="Coinbase::Client::CreateTransferRequest.build_from_hash (method)">build_from_hash</a></span>
-      <small>Coinbase::Client::CreateTransferRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#build_from_hash-class_method" title="Coinbase::Client::AddressList.build_from_hash (method)">build_from_hash</a></span>
+      <small>Coinbase::Client::AddressList</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#build_from_hash-class_method" title="Coinbase::Client::Address.build_from_hash (method)">build_from_hash</a></span>
-      <small>Coinbase::Client::Address</small>
+      <span class='object_link'><a href="Coinbase/Client/User.html#build_from_hash-class_method" title="Coinbase::Client::User.build_from_hash (method)">build_from_hash</a></span>
+      <small>Coinbase::Client::User</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#build_from_hash-class_method" title="Coinbase::Client::Asset.build_from_hash (method)">build_from_hash</a></span>
+      <small>Coinbase::Client::Asset</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Error.html#build_from_hash-class_method" title="Coinbase::Client::Error.build_from_hash (method)">build_from_hash</a></span>
+      <small>Coinbase::Client::Error</small>
     </div>
   </li>
   
@@ -1062,8 +1078,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#build_from_hash-class_method" title="Coinbase::Client::BroadcastTransferRequest.build_from_hash (method)">build_from_hash</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/Address.html#build_from_hash-class_method" title="Coinbase::Client::Address.build_from_hash (method)">build_from_hash</a></span>
+      <small>Coinbase::Client::Address</small>
     </div>
   </li>
   
@@ -1094,24 +1110,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#build_from_hash-class_method" title="Coinbase::Client::AddressList.build_from_hash (method)">build_from_hash</a></span>
-      <small>Coinbase::Client::AddressList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/TransferList.html#build_from_hash-class_method" title="Coinbase::Client::TransferList.build_from_hash (method)">build_from_hash</a></span>
       <small>Coinbase::Client::TransferList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#build_from_hash-class_method" title="Coinbase::Client::Error.build_from_hash (method)">build_from_hash</a></span>
-      <small>Coinbase::Client::Error</small>
     </div>
   </li>
   
@@ -1142,24 +1142,24 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#build_from_hash-class_method" title="Coinbase::Client::User.build_from_hash (method)">build_from_hash</a></span>
-      <small>Coinbase::Client::User</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#build_from_hash-class_method" title="Coinbase::Client::CreateAddressRequest.build_from_hash (method)">build_from_hash</a></span>
       <small>Coinbase::Client::CreateAddressRequest</small>
     </div>
   </li>
   
 
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#build_from_hash-class_method" title="Coinbase::Client::CreateTransferRequest.build_from_hash (method)">build_from_hash</a></span>
+      <small>Coinbase::Client::CreateTransferRequest</small>
+    </div>
+  </li>
+  
+
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#build_from_hash-class_method" title="Coinbase::Client::Asset.build_from_hash (method)">build_from_hash</a></span>
-      <small>Coinbase::Client::Asset</small>
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#build_from_hash-class_method" title="Coinbase::Client::BroadcastTransferRequest.build_from_hash (method)">build_from_hash</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
     </div>
   </li>
   
@@ -1238,16 +1238,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/ApiError.html#code-instance_method" title="Coinbase::Client::ApiError#code (method)">#code</a></span>
-      <small>Coinbase::Client::ApiError</small>
+      <span class='object_link'><a href="Coinbase/Client/Error.html#code-instance_method" title="Coinbase::Client::Error#code (method)">#code</a></span>
+      <small>Coinbase::Client::Error</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#code-instance_method" title="Coinbase::Client::Error#code (method)">#code</a></span>
-      <small>Coinbase::Client::Error</small>
+      <span class='object_link'><a href="Coinbase/Client/ApiError.html#code-instance_method" title="Coinbase::Client::ApiError#code (method)">#code</a></span>
+      <small>Coinbase::Client::ApiError</small>
     </div>
   </li>
   
@@ -1278,8 +1278,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client.html#configure-class_method" title="Coinbase::Client.configure (method)">configure</a></span>
-      <small>Coinbase::Client</small>
+      <span class='object_link'><a href="Coinbase.html#configure-class_method" title="Coinbase.configure (method)">configure</a></span>
+      <small>Coinbase</small>
     </div>
   </li>
   
@@ -1294,8 +1294,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase.html#configure-class_method" title="Coinbase.configure (method)">configure</a></span>
-      <small>Coinbase</small>
+      <span class='object_link'><a href="Coinbase/Client.html#configure-class_method" title="Coinbase::Client.configure (method)">configure</a></span>
+      <small>Coinbase::Client</small>
     </div>
   </li>
   
@@ -1374,16 +1374,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressesApi.html#create_address-instance_method" title="Coinbase::Client::AddressesApi#create_address (method)">#create_address</a></span>
-      <small>Coinbase::Client::AddressesApi</small>
+      <span class='object_link'><a href="Coinbase/Wallet.html#create_address-instance_method" title="Coinbase::Wallet#create_address (method)">#create_address</a></span>
+      <small>Coinbase::Wallet</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Wallet.html#create_address-instance_method" title="Coinbase::Wallet#create_address (method)">#create_address</a></span>
-      <small>Coinbase::Wallet</small>
+      <span class='object_link'><a href="Coinbase/Client/AddressesApi.html#create_address-instance_method" title="Coinbase::Client::AddressesApi#create_address (method)">#create_address</a></span>
+      <small>Coinbase::Client::AddressesApi</small>
     </div>
   </li>
   
@@ -1414,16 +1414,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletsApi.html#create_wallet-instance_method" title="Coinbase::Client::WalletsApi#create_wallet (method)">#create_wallet</a></span>
-      <small>Coinbase::Client::WalletsApi</small>
+      <span class='object_link'><a href="Coinbase/User.html#create_wallet-instance_method" title="Coinbase::User#create_wallet (method)">#create_wallet</a></span>
+      <small>Coinbase::User</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/User.html#create_wallet-instance_method" title="Coinbase::User#create_wallet (method)">#create_wallet</a></span>
-      <small>Coinbase::User</small>
+      <span class='object_link'><a href="Coinbase/Client/WalletsApi.html#create_wallet-instance_method" title="Coinbase::Client::WalletsApi#create_wallet (method)">#create_wallet</a></span>
+      <small>Coinbase::Client::WalletsApi</small>
     </div>
   </li>
   
@@ -1438,24 +1438,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#data-instance_method" title="Coinbase::Client::AddressList#data (method)">#data</a></span>
-      <small>Coinbase::Client::AddressList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#data-instance_method" title="Coinbase::Client::AddressBalanceList#data (method)">#data</a></span>
       <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#data-instance_method" title="Coinbase::Client::TransferList#data (method)">#data</a></span>
-      <small>Coinbase::Client::TransferList</small>
     </div>
   </li>
   
@@ -1464,6 +1448,22 @@
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/WalletList.html#data-instance_method" title="Coinbase::Client::WalletList#data (method)">#data</a></span>
       <small>Coinbase::Client::WalletList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#data-instance_method" title="Coinbase::Client::AddressList#data (method)">#data</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#data-instance_method" title="Coinbase::Client::TransferList#data (method)">#data</a></span>
+      <small>Coinbase::Client::TransferList</small>
     </div>
   </li>
   
@@ -1566,16 +1566,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#destination-instance_method" title="Coinbase::Client::Transfer#destination (method)">#destination</a></span>
-      <small>Coinbase::Client::Transfer</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#destination-instance_method" title="Coinbase::Client::CreateTransferRequest#destination (method)">#destination</a></span>
+      <small>Coinbase::Client::CreateTransferRequest</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#destination-instance_method" title="Coinbase::Client::CreateTransferRequest#destination (method)">#destination</a></span>
-      <small>Coinbase::Client::CreateTransferRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#destination-instance_method" title="Coinbase::Client::Transfer#destination (method)">#destination</a></span>
+      <small>Coinbase::Client::Transfer</small>
     </div>
   </li>
   
@@ -1590,16 +1590,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#display_name-instance_method" title="Coinbase::Client::User#display_name (method)">#display_name</a></span>
-      <small>Coinbase::Client::User</small>
+      <span class='object_link'><a href="Coinbase/Asset.html#display_name-instance_method" title="Coinbase::Asset#display_name (method)">#display_name</a></span>
+      <small>Coinbase::Asset</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Asset.html#display_name-instance_method" title="Coinbase::Asset#display_name (method)">#display_name</a></span>
-      <small>Coinbase::Asset</small>
+      <span class='object_link'><a href="Coinbase/Client/User.html#display_name-instance_method" title="Coinbase::Client::User#display_name (method)">#display_name</a></span>
+      <small>Coinbase::Client::User</small>
     </div>
   </li>
   
@@ -1614,8 +1614,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#eql%3F-instance_method" title="Coinbase::Client::CreateWalletRequest#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#eql%3F-instance_method" title="Coinbase::Client::BroadcastTransferRequest#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#eql%3F-instance_method" title="Coinbase::Client::Balance#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Address.html#eql%3F-instance_method" title="Coinbase::Client::Address#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::Address</small>
     </div>
   </li>
   
@@ -1630,40 +1646,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#eql%3F-instance_method" title="Coinbase::Client::Transfer#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#eql%3F-instance_method" title="Coinbase::Client::FaucetTransaction#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#eql%3F-instance_method" title="Coinbase::Client::Balance#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#eql%3F-instance_method" title="Coinbase::Client::TransferList#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::TransferList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#eql%3F-instance_method" title="Coinbase::Client::AddressBalanceList#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#eql%3F-instance_method" title="Coinbase::Client::CreateAddressRequest#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
     </div>
   </li>
   
@@ -1678,16 +1662,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#eql%3F-instance_method" title="Coinbase::Client::BroadcastTransferRequest#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#eql%3F-instance_method" title="Coinbase::Client::CreateWalletRequest#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#eql%3F-instance_method" title="Coinbase::Client::WalletList#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::WalletList</small>
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#eql%3F-instance_method" title="Coinbase::Client::AddressBalanceList#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
     </div>
   </li>
   
@@ -1702,29 +1686,21 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#eql%3F-instance_method" title="Coinbase::Client::CreateAddressRequest#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#eql%3F-instance_method" title="Coinbase::Client::FaucetTransaction#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#eql%3F-instance_method" title="Coinbase::Client::Wallet#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::Wallet</small>
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#eql%3F-instance_method" title="Coinbase::Client::TransferList#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::TransferList</small>
     </div>
   </li>
   
 
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#eql%3F-instance_method" title="Coinbase::Client::User#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::User</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/AddressList.html#eql%3F-instance_method" title="Coinbase::Client::AddressList#eql? (method)">#eql?</a></span>
       <small>Coinbase::Client::AddressList</small>
@@ -1732,26 +1708,50 @@
   </li>
   
 
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#eql%3F-instance_method" title="Coinbase::Client::WalletList#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::WalletList</small>
+    </div>
+  </li>
+  
+
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#eql%3F-instance_method" title="Coinbase::Client::Address#eql? (method)">#eql?</a></span>
-      <small>Coinbase::Client::Address</small>
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#eql%3F-instance_method" title="Coinbase::Client::Transfer#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::Transfer</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Address.html#export-instance_method" title="Coinbase::Address#export (method)">#export</a></span>
-      <small>Coinbase::Address</small>
+      <span class='object_link'><a href="Coinbase/Client/User.html#eql%3F-instance_method" title="Coinbase::Client::User#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::User</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#eql%3F-instance_method" title="Coinbase::Client::Wallet#eql? (method)">#eql?</a></span>
+      <small>Coinbase::Client::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Wallet.html#export-instance_method" title="Coinbase::Wallet#export (method)">#export</a></span>
       <small>Coinbase::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Address.html#export-instance_method" title="Coinbase::Address#export (method)">#export</a></span>
+      <small>Coinbase::Address</small>
     </div>
   </li>
   
@@ -1934,24 +1934,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#has_more-instance_method" title="Coinbase::Client::TransferList#has_more (method)">#has_more</a></span>
-      <small>Coinbase::Client::TransferList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#has_more-instance_method" title="Coinbase::Client::AddressBalanceList#has_more (method)">#has_more</a></span>
       <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#has_more-instance_method" title="Coinbase::Client::WalletList#has_more (method)">#has_more</a></span>
-      <small>Coinbase::Client::WalletList</small>
     </div>
   </li>
   
@@ -1966,32 +1950,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#hash-instance_method" title="Coinbase::Client::AddressList#hash (method)">#hash</a></span>
-      <small>Coinbase::Client::AddressList</small>
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#has_more-instance_method" title="Coinbase::Client::WalletList#has_more (method)">#has_more</a></span>
+      <small>Coinbase::Client::WalletList</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#hash-instance_method" title="Coinbase::Client::TransferList#hash (method)">#hash</a></span>
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#has_more-instance_method" title="Coinbase::Client::TransferList#has_more (method)">#has_more</a></span>
       <small>Coinbase::Client::TransferList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#hash-instance_method" title="Coinbase::Client::Transfer#hash (method)">#hash</a></span>
-      <small>Coinbase::Client::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#hash-instance_method" title="Coinbase::Client::AddressBalanceList#hash (method)">#hash</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
     </div>
   </li>
   
@@ -2000,6 +1968,22 @@
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#hash-instance_method" title="Coinbase::Client::CreateWalletRequest#hash (method)">#hash</a></span>
       <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/User.html#hash-instance_method" title="Coinbase::Client::User#hash (method)">#hash</a></span>
+      <small>Coinbase::Client::User</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#hash-instance_method" title="Coinbase::Client::CreateAddressRequest#hash (method)">#hash</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
     </div>
   </li>
   
@@ -2022,24 +2006,24 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#hash-instance_method" title="Coinbase::Client::Error#hash (method)">#hash</a></span>
-      <small>Coinbase::Client::Error</small>
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#hash-instance_method" title="Coinbase::Client::BroadcastTransferRequest#hash (method)">#hash</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#hash-instance_method" title="Coinbase::Client::CreateAddressRequest#hash (method)">#hash</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#hash-instance_method" title="Coinbase::Client::AddressList#hash (method)">#hash</a></span>
+      <small>Coinbase::Client::AddressList</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#hash-instance_method" title="Coinbase::Client::User#hash (method)">#hash</a></span>
-      <small>Coinbase::Client::User</small>
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#hash-instance_method" title="Coinbase::Client::Asset#hash (method)">#hash</a></span>
+      <small>Coinbase::Client::Asset</small>
     </div>
   </li>
   
@@ -2062,32 +2046,48 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#hash-instance_method" title="Coinbase::Client::BroadcastTransferRequest#hash (method)">#hash</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#hash-instance_method" title="Coinbase::Client::Transfer#hash (method)">#hash</a></span>
+      <small>Coinbase::Client::Transfer</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#hash-instance_method" title="Coinbase::Client::Asset#hash (method)">#hash</a></span>
-      <small>Coinbase::Client::Asset</small>
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#hash-instance_method" title="Coinbase::Client::AddressBalanceList#hash (method)">#hash</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#hash-instance_method" title="Coinbase::Client::Balance#hash (method)">#hash</a></span>
-      <small>Coinbase::Client::Balance</small>
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#hash-instance_method" title="Coinbase::Client::TransferList#hash (method)">#hash</a></span>
+      <small>Coinbase::Client::TransferList</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Error.html#hash-instance_method" title="Coinbase::Client::Error#hash (method)">#hash</a></span>
+      <small>Coinbase::Client::Error</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#hash-instance_method" title="Coinbase::Client::FaucetTransaction#hash (method)">#hash</a></span>
       <small>Coinbase::Client::FaucetTransaction</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#hash-instance_method" title="Coinbase::Client::Balance#hash (method)">#hash</a></span>
+      <small>Coinbase::Client::Balance</small>
     </div>
   </li>
   
@@ -2110,16 +2110,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#id-instance_method" title="Coinbase::Client::User#id (method)">#id</a></span>
-      <small>Coinbase::Client::User</small>
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#id-instance_method" title="Coinbase::Client::Wallet#id (method)">#id</a></span>
+      <small>Coinbase::Client::Wallet</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#id-instance_method" title="Coinbase::Client::Wallet#id (method)">#id</a></span>
-      <small>Coinbase::Client::Wallet</small>
+      <span class='object_link'><a href="Coinbase/Client/User.html#id-instance_method" title="Coinbase::Client::User#id (method)">#id</a></span>
+      <small>Coinbase::Client::User</small>
     </div>
   </li>
   
@@ -2134,53 +2134,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Wallet/Data.html#initialize-instance_method" title="Coinbase::Wallet::Data#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Wallet::Data</small>
+      <span class='object_link'><a href="Coinbase/Client/ApiClient.html#initialize-instance_method" title="Coinbase::Client::ApiClient#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::ApiClient</small>
     </div>
   </li>
   
 
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Asset.html#initialize-instance_method" title="Coinbase::Asset#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Asset</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#initialize-instance_method" title="Coinbase::Client::CreateAddressRequest#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#initialize-instance_method" title="Coinbase::Client::User#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::User</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransfersApi.html#initialize-instance_method" title="Coinbase::Client::TransfersApi#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::TransfersApi</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#initialize-instance_method" title="Coinbase::Client::Balance#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Configuration.html#initialize-instance_method" title="Coinbase::Configuration#initialize (method)">#initialize</a></span>
       <small>Coinbase::Configuration</small>
@@ -2188,34 +2148,26 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Transfer.html#initialize-instance_method" title="Coinbase::Transfer#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Transfer</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer/EnumAttributeValidator.html#initialize-instance_method" title="Coinbase::Client::Transfer::EnumAttributeValidator#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::Transfer::EnumAttributeValidator</small>
+      <span class='object_link'><a href="Coinbase/FaucetTransaction.html#initialize-instance_method" title="Coinbase::FaucetTransaction#initialize (method)">#initialize</a></span>
+      <small>Coinbase::FaucetTransaction</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressesApi.html#initialize-instance_method" title="Coinbase::Client::AddressesApi#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::AddressesApi</small>
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#initialize-instance_method" title="Coinbase::Client::Asset#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::Asset</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/BalanceMap.html#initialize-instance_method" title="Coinbase::BalanceMap#initialize (method)">#initialize</a></span>
-      <small>Coinbase::BalanceMap</small>
+      <span class='object_link'><a href="Coinbase/Client/Error.html#initialize-instance_method" title="Coinbase::Client::Error#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::Error</small>
     </div>
   </li>
   
@@ -2230,176 +2182,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#initialize-instance_method" title="Coinbase::Client::AddressBalanceList#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletsApi.html#initialize-instance_method" title="Coinbase::Client::WalletsApi#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::WalletsApi</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#initialize-instance_method" title="Coinbase::Client::BroadcastTransferRequest#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/APIError.html#initialize-instance_method" title="Coinbase::APIError#initialize (method)">#initialize</a></span>
-      <small>Coinbase::APIError</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#initialize-instance_method" title="Coinbase::Client::AddressList#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::AddressList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#initialize-instance_method" title="Coinbase::Client::Wallet#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#initialize-instance_method" title="Coinbase::Client::FaucetTransaction#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Address.html#initialize-instance_method" title="Coinbase::Address#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#initialize-instance_method" title="Coinbase::Client::Asset#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::Asset</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#initialize-instance_method" title="Coinbase::Client::Error#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::Error</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/ApiClient.html#initialize-instance_method" title="Coinbase::Client::ApiClient#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::ApiClient</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#initialize-instance_method" title="Coinbase::Client::WalletList#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::WalletList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#initialize-instance_method" title="Coinbase::Client::Address#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Network.html#initialize-instance_method" title="Coinbase::Network#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Network</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Configuration.html#initialize-instance_method" title="Coinbase::Client::Configuration#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::Configuration</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#initialize-instance_method" title="Coinbase::Client::CreateTransferRequest#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::CreateTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#initialize-instance_method" title="Coinbase::Client::CreateWalletRequest#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/User.html#initialize-instance_method" title="Coinbase::User#initialize (method)">#initialize</a></span>
-      <small>Coinbase::User</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Wallet.html#initialize-instance_method" title="Coinbase::Wallet#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiError.html#initialize-instance_method" title="Coinbase::Client::ApiError#initialize (method)">#initialize</a></span>
       <small>Coinbase::Client::ApiError</small>
     </div>
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#initialize-instance_method" title="Coinbase::Client::Transfer#initialize (method)">#initialize</a></span>
-      <small>Coinbase::Client::Transfer</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/FaucetTransaction.html#initialize-instance_method" title="Coinbase::FaucetTransaction#initialize (method)">#initialize</a></span>
-      <small>Coinbase::FaucetTransaction</small>
+      <span class='object_link'><a href="Coinbase/Client/Configuration.html#initialize-instance_method" title="Coinbase::Client::Configuration#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::Configuration</small>
     </div>
   </li>
   
@@ -2414,8 +2206,216 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/BalanceMap.html#initialize-instance_method" title="Coinbase::BalanceMap#initialize (method)">#initialize</a></span>
+      <small>Coinbase::BalanceMap</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#initialize-instance_method" title="Coinbase::Client::Wallet#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#initialize-instance_method" title="Coinbase::Client::BroadcastTransferRequest#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Address.html#initialize-instance_method" title="Coinbase::Client::Address#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#initialize-instance_method" title="Coinbase::Client::Balance#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Transfer.html#initialize-instance_method" title="Coinbase::Transfer#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Transfer</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/WalletsApi.html#initialize-instance_method" title="Coinbase::Client::WalletsApi#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::WalletsApi</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Network.html#initialize-instance_method" title="Coinbase::Network#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Network</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer/EnumAttributeValidator.html#initialize-instance_method" title="Coinbase::Client::Transfer::EnumAttributeValidator#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::Transfer::EnumAttributeValidator</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#initialize-instance_method" title="Coinbase::Client::Transfer#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::Transfer</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressesApi.html#initialize-instance_method" title="Coinbase::Client::AddressesApi#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::AddressesApi</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/TransfersApi.html#initialize-instance_method" title="Coinbase::Client::TransfersApi#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::TransfersApi</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Address.html#initialize-instance_method" title="Coinbase::Address#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#initialize-instance_method" title="Coinbase::Client::WalletList#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::WalletList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Wallet/Data.html#initialize-instance_method" title="Coinbase::Wallet::Data#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Wallet::Data</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#initialize-instance_method" title="Coinbase::Client::AddressList#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/TransferList.html#initialize-instance_method" title="Coinbase::Client::TransferList#initialize (method)">#initialize</a></span>
       <small>Coinbase::Client::TransferList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#initialize-instance_method" title="Coinbase::Client::FaucetTransaction#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Wallet.html#initialize-instance_method" title="Coinbase::Wallet#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#initialize-instance_method" title="Coinbase::Client::AddressBalanceList#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/APIError.html#initialize-instance_method" title="Coinbase::APIError#initialize (method)">#initialize</a></span>
+      <small>Coinbase::APIError</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Asset.html#initialize-instance_method" title="Coinbase::Asset#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Asset</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#initialize-instance_method" title="Coinbase::Client::CreateWalletRequest#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#initialize-instance_method" title="Coinbase::Client::CreateAddressRequest#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/User.html#initialize-instance_method" title="Coinbase::User#initialize (method)">#initialize</a></span>
+      <small>Coinbase::User</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#initialize-instance_method" title="Coinbase::Client::CreateTransferRequest#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::CreateTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/User.html#initialize-instance_method" title="Coinbase::Client::User#initialize (method)">#initialize</a></span>
+      <small>Coinbase::Client::User</small>
     </div>
   </li>
   
@@ -2430,24 +2430,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/FaucetTransaction.html#inspect-instance_method" title="Coinbase::FaucetTransaction#inspect (method)">#inspect</a></span>
-      <small>Coinbase::FaucetTransaction</small>
+      <span class='object_link'><a href="Coinbase/User.html#inspect-instance_method" title="Coinbase::User#inspect (method)">#inspect</a></span>
+      <small>Coinbase::User</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Address.html#inspect-instance_method" title="Coinbase::Address#inspect (method)">#inspect</a></span>
-      <small>Coinbase::Address</small>
+      <span class='object_link'><a href="Coinbase/APIError.html#inspect-instance_method" title="Coinbase::APIError#inspect (method)">#inspect</a></span>
+      <small>Coinbase::APIError</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/APIError.html#inspect-instance_method" title="Coinbase::APIError#inspect (method)">#inspect</a></span>
-      <small>Coinbase::APIError</small>
+      <span class='object_link'><a href="Coinbase/FaucetTransaction.html#inspect-instance_method" title="Coinbase::FaucetTransaction#inspect (method)">#inspect</a></span>
+      <small>Coinbase::FaucetTransaction</small>
     </div>
   </li>
   
@@ -2462,24 +2462,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Wallet.html#inspect-instance_method" title="Coinbase::Wallet#inspect (method)">#inspect</a></span>
-      <small>Coinbase::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/BalanceMap.html#inspect-instance_method" title="Coinbase::BalanceMap#inspect (method)">#inspect</a></span>
       <small>Coinbase::BalanceMap</small>
     </div>
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Address.html#inspect-instance_method" title="Coinbase::Address#inspect (method)">#inspect</a></span>
+      <small>Coinbase::Address</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/User.html#inspect-instance_method" title="Coinbase::User#inspect (method)">#inspect</a></span>
-      <small>Coinbase::User</small>
+      <span class='object_link'><a href="Coinbase/Wallet.html#inspect-instance_method" title="Coinbase::Wallet#inspect (method)">#inspect</a></span>
+      <small>Coinbase::Wallet</small>
     </div>
   </li>
   
@@ -2542,29 +2542,21 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Wallet.html#list_balances-instance_method" title="Coinbase::Wallet#list_balances (method)">#list_balances</a></span>
-      <small>Coinbase::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Address.html#list_balances-instance_method" title="Coinbase::Address#list_balances (method)">#list_balances</a></span>
       <small>Coinbase::Address</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#list_invalid_properties-instance_method" title="Coinbase::Client::CreateAddressRequest#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
+      <span class='object_link'><a href="Coinbase/Wallet.html#list_balances-instance_method" title="Coinbase::Wallet#list_balances (method)">#list_balances</a></span>
+      <small>Coinbase::Wallet</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Asset.html#list_invalid_properties-instance_method" title="Coinbase::Client::Asset#list_invalid_properties (method)">#list_invalid_properties</a></span>
       <small>Coinbase::Client::Asset</small>
@@ -2572,50 +2564,26 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#list_invalid_properties-instance_method" title="Coinbase::Client::Error#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::Error</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#list_invalid_properties-instance_method" title="Coinbase::Client::User#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::User</small>
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#list_invalid_properties-instance_method" title="Coinbase::Client::AddressBalanceList#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#list_invalid_properties-instance_method" title="Coinbase::Client::Wallet#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::Wallet</small>
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#list_invalid_properties-instance_method" title="Coinbase::Client::FaucetTransaction#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#list_invalid_properties-instance_method" title="Coinbase::Client::Address#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#list_invalid_properties-instance_method" title="Coinbase::Client::Balance#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#list_invalid_properties-instance_method" title="Coinbase::Client::Transfer#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::Transfer</small>
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#list_invalid_properties-instance_method" title="Coinbase::Client::TransferList#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::TransferList</small>
     </div>
   </li>
   
@@ -2630,40 +2598,72 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#list_invalid_properties-instance_method" title="Coinbase::Client::CreateWalletRequest#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/AddressList.html#list_invalid_properties-instance_method" title="Coinbase::Client::AddressList#list_invalid_properties (method)">#list_invalid_properties</a></span>
       <small>Coinbase::Client::AddressList</small>
     </div>
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#list_invalid_properties-instance_method" title="Coinbase::Client::TransferList#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::TransferList</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#list_invalid_properties-instance_method" title="Coinbase::Client::FaucetTransaction#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
+      <span class='object_link'><a href="Coinbase/Client/User.html#list_invalid_properties-instance_method" title="Coinbase::Client::User#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::User</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#list_invalid_properties-instance_method" title="Coinbase::Client::AddressBalanceList#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#list_invalid_properties-instance_method" title="Coinbase::Client::Transfer#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::Transfer</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#list_invalid_properties-instance_method" title="Coinbase::Client::CreateWalletRequest#list_invalid_properties (method)">#list_invalid_properties</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/Error.html#list_invalid_properties-instance_method" title="Coinbase::Client::Error#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::Error</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#list_invalid_properties-instance_method" title="Coinbase::Client::CreateAddressRequest#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#list_invalid_properties-instance_method" title="Coinbase::Client::Balance#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Address.html#list_invalid_properties-instance_method" title="Coinbase::Client::Address#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#list_invalid_properties-instance_method" title="Coinbase::Client::Wallet#list_invalid_properties (method)">#list_invalid_properties</a></span>
+      <small>Coinbase::Client::Wallet</small>
     </div>
   </li>
   
@@ -2686,13 +2686,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Address.html#list_transfer_ids-instance_method" title="Coinbase::Address#list_transfer_ids (method)">#list_transfer_ids</a></span>
+      <small>Coinbase::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/TransfersApi.html#list_transfers-instance_method" title="Coinbase::Client::TransfersApi#list_transfers (method)">#list_transfers</a></span>
       <small>Coinbase::Client::TransfersApi</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/TransfersApi.html#list_transfers_with_http_info-instance_method" title="Coinbase::Client::TransfersApi#list_transfers_with_http_info (method)">#list_transfers_with_http_info</a></span>
       <small>Coinbase::Client::TransfersApi</small>
@@ -2700,7 +2708,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/WalletsApi.html#list_wallet_balances-instance_method" title="Coinbase::Client::WalletsApi#list_wallet_balances (method)">#list_wallet_balances</a></span>
       <small>Coinbase::Client::WalletsApi</small>
@@ -2708,7 +2716,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/WalletsApi.html#list_wallet_balances_with_http_info-instance_method" title="Coinbase::Client::WalletsApi#list_wallet_balances_with_http_info (method)">#list_wallet_balances_with_http_info</a></span>
       <small>Coinbase::Client::WalletsApi</small>
@@ -2716,7 +2724,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/User.html#list_wallet_ids-instance_method" title="Coinbase::User#list_wallet_ids (method)">#list_wallet_ids</a></span>
       <small>Coinbase::User</small>
@@ -2724,7 +2732,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/WalletsApi.html#list_wallets-instance_method" title="Coinbase::Client::WalletsApi#list_wallets (method)">#list_wallets</a></span>
       <small>Coinbase::Client::WalletsApi</small>
@@ -2732,7 +2740,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/WalletsApi.html#list_wallets_with_http_info-instance_method" title="Coinbase::Client::WalletsApi#list_wallets_with_http_info (method)">#list_wallets_with_http_info</a></span>
       <small>Coinbase::Client::WalletsApi</small>
@@ -2740,7 +2748,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase.html#load_default_user-class_method" title="Coinbase.load_default_user (method)">load_default_user</a></span>
       <small>Coinbase</small>
@@ -2748,7 +2756,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/User.html#load_wallets-instance_method" title="Coinbase::User#load_wallets (method)">#load_wallets</a></span>
       <small>Coinbase::User</small>
@@ -2756,7 +2764,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#logger-instance_method" title="Coinbase::Client::Configuration#logger (method)">#logger</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -2764,7 +2772,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Error.html#message-instance_method" title="Coinbase::Client::Error#message (method)">#message</a></span>
       <small>Coinbase::Client::Error</small>
@@ -2772,7 +2780,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiError.html#message-instance_method" title="Coinbase::Client::ApiError#message (method)">#message</a></span>
       <small>Coinbase::Client::ApiError</small>
@@ -2780,7 +2788,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/FaucetTransaction.html#model-instance_method" title="Coinbase::FaucetTransaction#model (method)">#model</a></span>
       <small>Coinbase::FaucetTransaction</small>
@@ -2788,10 +2796,18 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Network.html#native_asset-instance_method" title="Coinbase::Network#native_asset (method)">#native_asset</a></span>
       <small>Coinbase::Network</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#network_id-instance_method" title="Coinbase::Client::Wallet#network_id (method)">#network_id</a></span>
+      <small>Coinbase::Client::Wallet</small>
     </div>
   </li>
   
@@ -2806,56 +2822,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Transfer.html#network_id-instance_method" title="Coinbase::Transfer#network_id (method)">#network_id</a></span>
-      <small>Coinbase::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Address.html#network_id-instance_method" title="Coinbase::Address#network_id (method)">#network_id</a></span>
-      <small>Coinbase::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#network_id-instance_method" title="Coinbase::Client::CreateTransferRequest#network_id (method)">#network_id</a></span>
-      <small>Coinbase::Client::CreateTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#network_id-instance_method" title="Coinbase::Client::Wallet#network_id (method)">#network_id</a></span>
-      <small>Coinbase::Client::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Address.html#network_id-instance_method" title="Coinbase::Client::Address#network_id (method)">#network_id</a></span>
       <small>Coinbase::Client::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Asset.html#network_id-instance_method" title="Coinbase::Asset#network_id (method)">#network_id</a></span>
-      <small>Coinbase::Asset</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#network_id-instance_method" title="Coinbase::Client::Asset#network_id (method)">#network_id</a></span>
-      <small>Coinbase::Client::Asset</small>
     </div>
   </li>
   
@@ -2870,16 +2838,48 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#next_page-instance_method" title="Coinbase::Client::TransferList#next_page (method)">#next_page</a></span>
-      <small>Coinbase::Client::TransferList</small>
+      <span class='object_link'><a href="Coinbase/Address.html#network_id-instance_method" title="Coinbase::Address#network_id (method)">#network_id</a></span>
+      <small>Coinbase::Address</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#next_page-instance_method" title="Coinbase::Client::AddressList#next_page (method)">#next_page</a></span>
-      <small>Coinbase::Client::AddressList</small>
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#network_id-instance_method" title="Coinbase::Client::Asset#network_id (method)">#network_id</a></span>
+      <small>Coinbase::Client::Asset</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#network_id-instance_method" title="Coinbase::Client::CreateTransferRequest#network_id (method)">#network_id</a></span>
+      <small>Coinbase::Client::CreateTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Transfer.html#network_id-instance_method" title="Coinbase::Transfer#network_id (method)">#network_id</a></span>
+      <small>Coinbase::Transfer</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Asset.html#network_id-instance_method" title="Coinbase::Asset#network_id (method)">#network_id</a></span>
+      <small>Coinbase::Asset</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#next_page-instance_method" title="Coinbase::Client::TransferList#next_page (method)">#next_page</a></span>
+      <small>Coinbase::Client::TransferList</small>
     </div>
   </li>
   
@@ -2902,13 +2902,21 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#next_page-instance_method" title="Coinbase::Client::AddressList#next_page (method)">#next_page</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiClient.html#object_to_hash-instance_method" title="Coinbase::Client::ApiClient#object_to_hash (method)">#object_to_hash</a></span>
       <small>Coinbase::Client::ApiClient</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiClient.html#object_to_http_body-instance_method" title="Coinbase::Client::ApiClient#object_to_http_body (method)">#object_to_http_body</a></span>
       <small>Coinbase::Client::ApiClient</small>
@@ -2916,71 +2924,7 @@
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#openapi_nullable-class_method" title="Coinbase::Client::User.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::User</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#openapi_nullable-class_method" title="Coinbase::Client::Asset.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::Asset</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#openapi_nullable-class_method" title="Coinbase::Client::FaucetTransaction.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#openapi_nullable-class_method" title="Coinbase::Client::TransferList.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::TransferList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#openapi_nullable-class_method" title="Coinbase::Client::Address.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#openapi_nullable-class_method" title="Coinbase::Client::Transfer.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#openapi_nullable-class_method" title="Coinbase::Client::CreateAddressRequest.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#openapi_nullable-class_method" title="Coinbase::Client::Error.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::Error</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#openapi_nullable-class_method" title="Coinbase::Client::CreateTransferRequest.openapi_nullable (method)">openapi_nullable</a></span>
       <small>Coinbase::Client::CreateTransferRequest</small>
@@ -2988,18 +2932,10 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#openapi_nullable-class_method" title="Coinbase::Client::WalletList.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::WalletList</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#openapi_nullable-class_method" title="Coinbase::Client::Wallet.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::Wallet</small>
+      <span class='object_link'><a href="Coinbase/Client/Error.html#openapi_nullable-class_method" title="Coinbase::Client::Error.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::Error</small>
     </div>
   </li>
   
@@ -3014,6 +2950,70 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#openapi_nullable-class_method" title="Coinbase::Client::Balance.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#openapi_nullable-class_method" title="Coinbase::Client::TransferList.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::TransferList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#openapi_nullable-class_method" title="Coinbase::Client::AddressBalanceList.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#openapi_nullable-class_method" title="Coinbase::Client::FaucetTransaction.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#openapi_nullable-class_method" title="Coinbase::Client::CreateAddressRequest.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#openapi_nullable-class_method" title="Coinbase::Client::CreateWalletRequest.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#openapi_nullable-class_method" title="Coinbase::Client::Wallet.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#openapi_nullable-class_method" title="Coinbase::Client::Transfer.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::Transfer</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/AddressList.html#openapi_nullable-class_method" title="Coinbase::Client::AddressList.openapi_nullable (method)">openapi_nullable</a></span>
       <small>Coinbase::Client::AddressList</small>
     </div>
@@ -3022,55 +3022,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#openapi_nullable-class_method" title="Coinbase::Client::AddressBalanceList.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#openapi_nullable-class_method" title="Coinbase::Client::CreateWalletRequest.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#openapi_nullable-class_method" title="Coinbase::Client::Balance.openapi_nullable (method)">openapi_nullable</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#openapi_types-class_method" title="Coinbase::Client::CreateAddressRequest.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#openapi_types-class_method" title="Coinbase::Client::Balance.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#openapi_types-class_method" title="Coinbase::Client::WalletList.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::WalletList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#openapi_types-class_method" title="Coinbase::Client::Asset.openapi_types (method)">openapi_types</a></span>
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#openapi_nullable-class_method" title="Coinbase::Client::Asset.openapi_nullable (method)">openapi_nullable</a></span>
       <small>Coinbase::Client::Asset</small>
     </div>
   </li>
@@ -3078,7 +3030,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#openapi_types-class_method" title="Coinbase::Client::Address.openapi_types (method)">openapi_types</a></span>
+      <span class='object_link'><a href="Coinbase/Client/Address.html#openapi_nullable-class_method" title="Coinbase::Client::Address.openapi_nullable (method)">openapi_nullable</a></span>
       <small>Coinbase::Client::Address</small>
     </div>
   </li>
@@ -3086,16 +3038,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#openapi_types-class_method" title="Coinbase::Client::AddressList.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::AddressList</small>
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#openapi_nullable-class_method" title="Coinbase::Client::WalletList.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::WalletList</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#openapi_types-class_method" title="Coinbase::Client::Wallet.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::Wallet</small>
+      <span class='object_link'><a href="Coinbase/Client/User.html#openapi_nullable-class_method" title="Coinbase::Client::User.openapi_nullable (method)">openapi_nullable</a></span>
+      <small>Coinbase::Client::User</small>
     </div>
   </li>
   
@@ -3110,56 +3062,24 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#openapi_types-class_method" title="Coinbase::Client::Asset.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::Asset</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#openapi_types-class_method" title="Coinbase::Client::Wallet.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#openapi_types-class_method" title="Coinbase::Client::FaucetTransaction.openapi_types (method)">openapi_types</a></span>
       <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#openapi_types-class_method" title="Coinbase::Client::AddressBalanceList.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#openapi_types-class_method" title="Coinbase::Client::CreateWalletRequest.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#openapi_types-class_method" title="Coinbase::Client::User.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::User</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#openapi_types-class_method" title="Coinbase::Client::Error.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::Error</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#openapi_types-class_method" title="Coinbase::Client::CreateTransferRequest.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::CreateTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#openapi_types-class_method" title="Coinbase::Client::BroadcastTransferRequest.openapi_types (method)">openapi_types</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
     </div>
   </li>
   
@@ -3174,47 +3094,15 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Configuration.html#operation_server_settings-instance_method" title="Coinbase::Client::Configuration#operation_server_settings (method)">#operation_server_settings</a></span>
-      <small>Coinbase::Client::Configuration</small>
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#openapi_types-class_method" title="Coinbase::Client::WalletList.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::WalletList</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Configuration.html#params_encoder-instance_method" title="Coinbase::Client::Configuration#params_encoder (method)">#params_encoder</a></span>
-      <small>Coinbase::Client::Configuration</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Configuration.html#password-instance_method" title="Coinbase::Client::Configuration#password (method)">#password</a></span>
-      <small>Coinbase::Client::Configuration</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Configuration.html#proxy-instance_method" title="Coinbase::Client::Configuration#proxy (method)">#proxy</a></span>
-      <small>Coinbase::Client::Configuration</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#public_key-instance_method" title="Coinbase::Client::CreateAddressRequest#public_key (method)">#public_key</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#public_key-instance_method" title="Coinbase::Client::Address#public_key (method)">#public_key</a></span>
+      <span class='object_link'><a href="Coinbase/Client/Address.html#openapi_types-class_method" title="Coinbase::Client::Address.openapi_types (method)">openapi_types</a></span>
       <small>Coinbase::Client::Address</small>
     </div>
   </li>
@@ -3222,13 +3110,133 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Configuration.html#request-instance_method" title="Coinbase::Client::Configuration#request (method)">#request</a></span>
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#openapi_types-class_method" title="Coinbase::Client::AddressBalanceList.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#openapi_types-class_method" title="Coinbase::Client::Balance.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/User.html#openapi_types-class_method" title="Coinbase::Client::User.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::User</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#openapi_types-class_method" title="Coinbase::Client::CreateWalletRequest.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#openapi_types-class_method" title="Coinbase::Client::CreateTransferRequest.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::CreateTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Error.html#openapi_types-class_method" title="Coinbase::Client::Error.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::Error</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#openapi_types-class_method" title="Coinbase::Client::AddressList.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#openapi_types-class_method" title="Coinbase::Client::CreateAddressRequest.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#openapi_types-class_method" title="Coinbase::Client::BroadcastTransferRequest.openapi_types (method)">openapi_types</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Configuration.html#operation_server_settings-instance_method" title="Coinbase::Client::Configuration#operation_server_settings (method)">#operation_server_settings</a></span>
+      <small>Coinbase::Client::Configuration</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Configuration.html#params_encoder-instance_method" title="Coinbase::Client::Configuration#params_encoder (method)">#params_encoder</a></span>
       <small>Coinbase::Client::Configuration</small>
     </div>
   </li>
   
 
   <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Configuration.html#password-instance_method" title="Coinbase::Client::Configuration#password (method)">#password</a></span>
+      <small>Coinbase::Client::Configuration</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Configuration.html#proxy-instance_method" title="Coinbase::Client::Configuration#proxy (method)">#proxy</a></span>
+      <small>Coinbase::Client::Configuration</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#public_key-instance_method" title="Coinbase::Client::CreateAddressRequest#public_key (method)">#public_key</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Address.html#public_key-instance_method" title="Coinbase::Client::Address#public_key (method)">#public_key</a></span>
+      <small>Coinbase::Client::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Configuration.html#request-instance_method" title="Coinbase::Client::Configuration#request (method)">#request</a></span>
+      <small>Coinbase::Client::Configuration</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/AddressesApi.html#request_faucet_funds-instance_method" title="Coinbase::Client::AddressesApi#request_faucet_funds (method)">#request_faucet_funds</a></span>
       <small>Coinbase::Client::AddressesApi</small>
@@ -3236,7 +3244,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/AddressesApi.html#request_faucet_funds_with_http_info-instance_method" title="Coinbase::Client::AddressesApi#request_faucet_funds_with_http_info (method)">#request_faucet_funds_with_http_info</a></span>
       <small>Coinbase::Client::AddressesApi</small>
@@ -3244,7 +3252,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#response-instance_method" title="Coinbase::Client::Configuration#response (method)">#response</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3252,7 +3260,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiError.html#response_body-instance_method" title="Coinbase::Client::ApiError#response_body (method)">#response_body</a></span>
       <small>Coinbase::Client::ApiError</small>
@@ -3260,7 +3268,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiError.html#response_headers-instance_method" title="Coinbase::Client::ApiError#response_headers (method)">#response_headers</a></span>
       <small>Coinbase::Client::ApiError</small>
@@ -3268,7 +3276,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#return_binary_data-instance_method" title="Coinbase::Client::Configuration#return_binary_data (method)">#return_binary_data</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3276,7 +3284,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiClient.html#sanitize_filename-instance_method" title="Coinbase::Client::ApiClient#sanitize_filename (method)">#sanitize_filename</a></span>
       <small>Coinbase::Client::ApiClient</small>
@@ -3284,7 +3292,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/User.html#save_wallet-instance_method" title="Coinbase::User#save_wallet (method)">#save_wallet</a></span>
       <small>Coinbase::User</small>
@@ -3292,7 +3300,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#scheme-instance_method" title="Coinbase::Client::Configuration#scheme (method)">#scheme</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3300,7 +3308,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Wallet/Data.html#seed-instance_method" title="Coinbase::Wallet::Data#seed (method)">#seed</a></span>
       <small>Coinbase::Wallet::Data</small>
@@ -3308,7 +3316,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiClient.html#select_header_accept-instance_method" title="Coinbase::Client::ApiClient#select_header_accept (method)">#select_header_accept</a></span>
       <small>Coinbase::Client::ApiClient</small>
@@ -3316,7 +3324,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiClient.html#select_header_content_type-instance_method" title="Coinbase::Client::ApiClient#select_header_content_type (method)">#select_header_content_type</a></span>
       <small>Coinbase::Client::ApiClient</small>
@@ -3324,7 +3332,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#server_index-instance_method" title="Coinbase::Client::Configuration#server_index (method)">#server_index</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3332,7 +3340,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#server_operation_index-instance_method" title="Coinbase::Client::Configuration#server_operation_index (method)">#server_operation_index</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3340,7 +3348,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#server_operation_variables-instance_method" title="Coinbase::Client::Configuration#server_operation_variables (method)">#server_operation_variables</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3348,7 +3356,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#server_settings-instance_method" title="Coinbase::Client::Configuration#server_settings (method)">#server_settings</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3356,7 +3364,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#server_url-instance_method" title="Coinbase::Client::Configuration#server_url (method)">#server_url</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3364,7 +3372,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#server_variables-instance_method" title="Coinbase::Client::Configuration#server_variables (method)">#server_variables</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3372,7 +3380,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#set_faraday_middleware-instance_method" title="Coinbase::Client::Configuration#set_faraday_middleware (method)">#set_faraday_middleware</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3380,18 +3388,10 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Transfer.html#signed_payload-instance_method" title="Coinbase::Client::Transfer#signed_payload (method)">#signed_payload</a></span>
       <small>Coinbase::Client::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Transfer.html#signed_payload-instance_method" title="Coinbase::Transfer#signed_payload (method)">#signed_payload</a></span>
-      <small>Coinbase::Transfer</small>
     </div>
   </li>
   
@@ -3406,13 +3406,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Transfer.html#signed_payload-instance_method" title="Coinbase::Transfer#signed_payload (method)">#signed_payload</a></span>
+      <small>Coinbase::Transfer</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#ssl_ca_file-instance_method" title="Coinbase::Client::Configuration#ssl_ca_file (method)">#ssl_ca_file</a></span>
       <small>Coinbase::Client::Configuration</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#ssl_client_cert-instance_method" title="Coinbase::Client::Configuration#ssl_client_cert (method)">#ssl_client_cert</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3420,7 +3428,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#ssl_client_key-instance_method" title="Coinbase::Client::Configuration#ssl_client_key (method)">#ssl_client_key</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3428,7 +3436,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiClient.html#ssl_options-instance_method" title="Coinbase::Client::ApiClient#ssl_options (method)">#ssl_options</a></span>
       <small>Coinbase::Client::ApiClient</small>
@@ -3436,7 +3444,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#ssl_verify-instance_method" title="Coinbase::Client::Configuration#ssl_verify (method)">#ssl_verify</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3444,7 +3452,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#ssl_verify_mode-instance_method" title="Coinbase::Client::Configuration#ssl_verify_mode (method)">#ssl_verify_mode</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3452,7 +3460,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Transfer.html#status-instance_method" title="Coinbase::Client::Transfer#status (method)">#status</a></span>
       <small>Coinbase::Client::Transfer</small>
@@ -3460,7 +3468,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Transfer.html#status-instance_method" title="Coinbase::Transfer#status (method)">#status</a></span>
       <small>Coinbase::Transfer</small>
@@ -3468,7 +3476,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#temp_folder_path-instance_method" title="Coinbase::Client::Configuration#temp_folder_path (method)">#temp_folder_path</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3476,7 +3484,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#timeout-instance_method" title="Coinbase::Client::Configuration#timeout (method)">#timeout</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -3484,7 +3492,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase.html#to_balance_map-class_method" title="Coinbase.to_balance_map (method)">to_balance_map</a></span>
       <small>Coinbase</small>
@@ -3492,47 +3500,15 @@
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#to_body-instance_method" title="Coinbase::Client::AddressList#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::AddressList</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#to_body-instance_method" title="Coinbase::Client::CreateTransferRequest#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::CreateTransferRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#to_body-instance_method" title="Coinbase::Client::CreateAddressRequest#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
     </div>
   </li>
   
 
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#to_body-instance_method" title="Coinbase::Client::Asset#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::Asset</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#to_body-instance_method" title="Coinbase::Client::Address#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#to_body-instance_method" title="Coinbase::Client::User#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::User</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/TransferList.html#to_body-instance_method" title="Coinbase::Client::TransferList#to_body (method)">#to_body</a></span>
       <small>Coinbase::Client::TransferList</small>
@@ -3540,10 +3516,34 @@
   </li>
   
 
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Error.html#to_body-instance_method" title="Coinbase::Client::Error#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::Error</small>
+    </div>
+  </li>
+  
+
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#to_body-instance_method" title="Coinbase::Client::CreateAddressRequest#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#to_body-instance_method" title="Coinbase::Client::WalletList#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::WalletList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#to_body-instance_method" title="Coinbase::Client::BroadcastTransferRequest#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#to_body-instance_method" title="Coinbase::Client::FaucetTransaction#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
     </div>
   </li>
   
@@ -3558,6 +3558,38 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#to_body-instance_method" title="Coinbase::Client::Balance#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Address.html#to_body-instance_method" title="Coinbase::Client::Address#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#to_body-instance_method" title="Coinbase::Client::CreateTransferRequest#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::CreateTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/User.html#to_body-instance_method" title="Coinbase::Client::User#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::User</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#to_body-instance_method" title="Coinbase::Client::CreateWalletRequest#to_body (method)">#to_body</a></span>
       <small>Coinbase::Client::CreateWalletRequest</small>
     </div>
@@ -3566,79 +3598,15 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#to_body-instance_method" title="Coinbase::Client::FaucetTransaction#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#to_body-instance_method" title="Coinbase::Client::BroadcastTransferRequest#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#to_body-instance_method" title="Coinbase::Client::Balance#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#to_body-instance_method" title="Coinbase::Client::Error#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::Error</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#to_body-instance_method" title="Coinbase::Client::WalletList#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::WalletList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Wallet.html#to_body-instance_method" title="Coinbase::Client::Wallet#to_body (method)">#to_body</a></span>
       <small>Coinbase::Client::Wallet</small>
     </div>
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#to_body-instance_method" title="Coinbase::Client::AddressBalanceList#to_body (method)">#to_body</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#to_hash-instance_method" title="Coinbase::Client::Balance#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#to_hash-instance_method" title="Coinbase::Client::Wallet#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#to_hash-instance_method" title="Coinbase::Client::AddressList#to_hash (method)">#to_hash</a></span>
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#to_body-instance_method" title="Coinbase::Client::AddressList#to_body (method)">#to_body</a></span>
       <small>Coinbase::Client::AddressList</small>
     </div>
   </li>
@@ -3646,8 +3614,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#to_hash-instance_method" title="Coinbase::Client::BroadcastTransferRequest#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#to_body-instance_method" title="Coinbase::Client::Asset#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::Asset</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#to_body-instance_method" title="Coinbase::Client::AddressBalanceList#to_body (method)">#to_body</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#to_hash-instance_method" title="Coinbase::Client::Asset#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::Asset</small>
     </div>
   </li>
   
@@ -3662,40 +3646,88 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#to_hash-instance_method" title="Coinbase::Client::CreateWalletRequest#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#to_hash-instance_method" title="Coinbase::Client::TransferList#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::TransferList</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#to_hash-instance_method" title="Coinbase::Client::Asset#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::Asset</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#to_hash-instance_method" title="Coinbase::Client::CreateAddressRequest#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#to_hash-instance_method" title="Coinbase::Client::Error#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::Error</small>
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#to_hash-instance_method" title="Coinbase::Client::Wallet#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::Wallet</small>
     </div>
   </li>
   
 
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#to_hash-instance_method" title="Coinbase::Client::Address#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Wallet/Data.html#to_hash-instance_method" title="Coinbase::Wallet::Data#to_hash (method)">#to_hash</a></span>
       <small>Coinbase::Wallet::Data</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#to_hash-instance_method" title="Coinbase::Client::Balance#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#to_hash-instance_method" title="Coinbase::Client::AddressBalanceList#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#to_hash-instance_method" title="Coinbase::Client::BroadcastTransferRequest#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#to_hash-instance_method" title="Coinbase::Client::WalletList#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::WalletList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#to_hash-instance_method" title="Coinbase::Client::Transfer#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::Transfer</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#to_hash-instance_method" title="Coinbase::Client::AddressList#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#to_hash-instance_method" title="Coinbase::Client::FaucetTransaction#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
     </div>
   </li>
   
@@ -3710,175 +3742,15 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#to_hash-instance_method" title="Coinbase::Client::WalletList#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::WalletList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#to_hash-instance_method" title="Coinbase::Client::FaucetTransaction#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#to_hash-instance_method" title="Coinbase::Client::CreateAddressRequest#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#to_hash-instance_method" title="Coinbase::Client::TransferList#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::TransferList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#to_hash-instance_method" title="Coinbase::Client::AddressBalanceList#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#to_hash-instance_method" title="Coinbase::Client::Transfer#to_hash (method)">#to_hash</a></span>
-      <small>Coinbase::Client::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#to_s-instance_method" title="Coinbase::Client::Transfer#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/ApiError.html#to_s-instance_method" title="Coinbase::Client::ApiError#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::ApiError</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#to_s-instance_method" title="Coinbase::Client::Address#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#to_s-instance_method" title="Coinbase::Client::AddressList#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::AddressList</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#to_s-instance_method" title="Coinbase::Client::TransferList#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::TransferList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Wallet.html#to_s-instance_method" title="Coinbase::Wallet#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Wallet</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/FaucetTransaction.html#to_s-instance_method" title="Coinbase::FaucetTransaction#to_s (method)">#to_s</a></span>
-      <small>Coinbase::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#to_s-instance_method" title="Coinbase::Client::FaucetTransaction#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#to_s-instance_method" title="Coinbase::Client::BroadcastTransferRequest#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/BalanceMap.html#to_s-instance_method" title="Coinbase::BalanceMap#to_s (method)">#to_s</a></span>
-      <small>Coinbase::BalanceMap</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#to_s-instance_method" title="Coinbase::Client::AddressBalanceList#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::AddressBalanceList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/APIError.html#to_s-instance_method" title="Coinbase::APIError#to_s (method)">#to_s</a></span>
-      <small>Coinbase::APIError</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#to_s-instance_method" title="Coinbase::Client::Balance#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#to_s-instance_method" title="Coinbase::Client::CreateWalletRequest#to_s (method)">#to_s</a></span>
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#to_hash-instance_method" title="Coinbase::Client::CreateWalletRequest#to_hash (method)">#to_hash</a></span>
       <small>Coinbase::Client::CreateWalletRequest</small>
     </div>
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Transfer.html#to_s-instance_method" title="Coinbase::Transfer#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Transfer</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Error.html#to_s-instance_method" title="Coinbase::Client::Error#to_s (method)">#to_s</a></span>
+      <span class='object_link'><a href="Coinbase/Client/Error.html#to_hash-instance_method" title="Coinbase::Client::Error#to_hash (method)">#to_hash</a></span>
       <small>Coinbase::Client::Error</small>
     </div>
   </li>
@@ -3886,32 +3758,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/User.html#to_s-instance_method" title="Coinbase::User#to_s (method)">#to_s</a></span>
-      <small>Coinbase::User</small>
+      <span class='object_link'><a href="Coinbase/Client/Address.html#to_hash-instance_method" title="Coinbase::Client::Address#to_hash (method)">#to_hash</a></span>
+      <small>Coinbase::Client::Address</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#to_s-instance_method" title="Coinbase::Client::CreateAddressRequest#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/User.html#to_s-instance_method" title="Coinbase::Client::User#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::User</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#to_s-instance_method" title="Coinbase::Client::Asset#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::Asset</small>
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#to_s-instance_method" title="Coinbase::Client::BroadcastTransferRequest#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
     </div>
   </li>
   
@@ -3926,21 +3782,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#to_s-instance_method" title="Coinbase::Client::WalletList#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Client::WalletList</small>
+      <span class='object_link'><a href="Coinbase/Transfer.html#to_s-instance_method" title="Coinbase::Transfer#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Transfer</small>
     </div>
   </li>
   
 
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Address.html#to_s-instance_method" title="Coinbase::Address#to_s (method)">#to_s</a></span>
-      <small>Coinbase::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Wallet.html#to_s-instance_method" title="Coinbase::Client::Wallet#to_s (method)">#to_s</a></span>
       <small>Coinbase::Client::Wallet</small>
@@ -3948,7 +3796,167 @@
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/BalanceMap.html#to_s-instance_method" title="Coinbase::BalanceMap#to_s (method)">#to_s</a></span>
+      <small>Coinbase::BalanceMap</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#to_s-instance_method" title="Coinbase::Client::Transfer#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::Transfer</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Address.html#to_s-instance_method" title="Coinbase::Address#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#to_s-instance_method" title="Coinbase::Client::WalletList#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::WalletList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Wallet.html#to_s-instance_method" title="Coinbase::Wallet#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#to_s-instance_method" title="Coinbase::Client::AddressList#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/ApiError.html#to_s-instance_method" title="Coinbase::Client::ApiError#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::ApiError</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#to_s-instance_method" title="Coinbase::Client::TransferList#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::TransferList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Error.html#to_s-instance_method" title="Coinbase::Client::Error#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::Error</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#to_s-instance_method" title="Coinbase::Client::FaucetTransaction#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/APIError.html#to_s-instance_method" title="Coinbase::APIError#to_s (method)">#to_s</a></span>
+      <small>Coinbase::APIError</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/User.html#to_s-instance_method" title="Coinbase::Client::User#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::User</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#to_s-instance_method" title="Coinbase::Client::AddressBalanceList#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::AddressBalanceList</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#to_s-instance_method" title="Coinbase::Client::Asset#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::Asset</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#to_s-instance_method" title="Coinbase::Client::Balance#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#to_s-instance_method" title="Coinbase::Client::CreateWalletRequest#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/User.html#to_s-instance_method" title="Coinbase::User#to_s (method)">#to_s</a></span>
+      <small>Coinbase::User</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#to_s-instance_method" title="Coinbase::Client::CreateAddressRequest#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/FaucetTransaction.html#to_s-instance_method" title="Coinbase::FaucetTransaction#to_s (method)">#to_s</a></span>
+      <small>Coinbase::FaucetTransaction</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Address.html#to_s-instance_method" title="Coinbase::Client::Address#to_s (method)">#to_s</a></span>
+      <small>Coinbase::Client::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase.html#to_sym-class_method" title="Coinbase.to_sym (method)">to_sym</a></span>
       <small>Coinbase</small>
@@ -3956,10 +3964,18 @@
   </li>
   
 
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/AddressList.html#total_count-instance_method" title="Coinbase::Client::AddressList#total_count (method)">#total_count</a></span>
+      <small>Coinbase::Client::AddressList</small>
+    </div>
+  </li>
+  
+
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#total_count-instance_method" title="Coinbase::Client::WalletList#total_count (method)">#total_count</a></span>
-      <small>Coinbase::Client::WalletList</small>
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#total_count-instance_method" title="Coinbase::Client::TransferList#total_count (method)">#total_count</a></span>
+      <small>Coinbase::Client::TransferList</small>
     </div>
   </li>
   
@@ -3974,23 +3990,39 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/AddressList.html#total_count-instance_method" title="Coinbase::Client::AddressList#total_count (method)">#total_count</a></span>
-      <small>Coinbase::Client::AddressList</small>
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#total_count-instance_method" title="Coinbase::Client::WalletList#total_count (method)">#total_count</a></span>
+      <small>Coinbase::Client::WalletList</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#total_count-instance_method" title="Coinbase::Client::TransferList#total_count (method)">#total_count</a></span>
-      <small>Coinbase::Client::TransferList</small>
+      <span class='object_link'><a href="Coinbase/Transfer.html#transaction-instance_method" title="Coinbase::Transfer#transaction (method)">#transaction</a></span>
+      <small>Coinbase::Transfer</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Transfer.html#transaction-instance_method" title="Coinbase::Transfer#transaction (method)">#transaction</a></span>
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#transaction_hash-instance_method" title="Coinbase::Client::FaucetTransaction#transaction_hash (method)">#transaction_hash</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/FaucetTransaction.html#transaction_hash-instance_method" title="Coinbase::FaucetTransaction#transaction_hash (method)">#transaction_hash</a></span>
+      <small>Coinbase::FaucetTransaction</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Transfer.html#transaction_hash-instance_method" title="Coinbase::Transfer#transaction_hash (method)">#transaction_hash</a></span>
       <small>Coinbase::Transfer</small>
     </div>
   </li>
@@ -4006,48 +4038,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Transfer.html#transaction_hash-instance_method" title="Coinbase::Transfer#transaction_hash (method)">#transaction_hash</a></span>
-      <small>Coinbase::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/FaucetTransaction.html#transaction_hash-instance_method" title="Coinbase::FaucetTransaction#transaction_hash (method)">#transaction_hash</a></span>
-      <small>Coinbase::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#transaction_hash-instance_method" title="Coinbase::Client::FaucetTransaction#transaction_hash (method)">#transaction_hash</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Transfer.html#transaction_link-instance_method" title="Coinbase::Transfer#transaction_link (method)">#transaction_link</a></span>
       <small>Coinbase::Transfer</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/FaucetTransaction.html#transaction_link-instance_method" title="Coinbase::FaucetTransaction#transaction_link (method)">#transaction_link</a></span>
       <small>Coinbase::FaucetTransaction</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Address.html#transfer-instance_method" title="Coinbase::Address#transfer (method)">#transfer</a></span>
-      <small>Coinbase::Address</small>
     </div>
   </li>
   
@@ -4062,13 +4062,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Coinbase/Address.html#transfer-instance_method" title="Coinbase::Address#transfer (method)">#transfer</a></span>
+      <small>Coinbase::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Coinbase/Transfer.html#transfer_id-instance_method" title="Coinbase::Transfer#transfer_id (method)">#transfer_id</a></span>
       <small>Coinbase::Transfer</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Transfer.html#transfer_id-instance_method" title="Coinbase::Client::Transfer#transfer_id (method)">#transfer_id</a></span>
       <small>Coinbase::Client::Transfer</small>
@@ -4076,7 +4084,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Transfer.html#unsigned_payload-instance_method" title="Coinbase::Transfer#unsigned_payload (method)">#unsigned_payload</a></span>
       <small>Coinbase::Transfer</small>
@@ -4084,7 +4092,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Transfer.html#unsigned_payload-instance_method" title="Coinbase::Client::Transfer#unsigned_payload (method)">#unsigned_payload</a></span>
       <small>Coinbase::Client::Transfer</small>
@@ -4092,7 +4100,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiClient.html#update_params_for_auth!-instance_method" title="Coinbase::Client::ApiClient#update_params_for_auth! (method)">#update_params_for_auth!</a></span>
       <small>Coinbase::Client::ApiClient</small>
@@ -4100,7 +4108,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#use-instance_method" title="Coinbase::Client::Configuration#use (method)">#use</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -4108,7 +4116,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/ApiClient.html#user_agent=-instance_method" title="Coinbase::Client::ApiClient#user_agent= (method)">#user_agent=</a></span>
       <small>Coinbase::Client::ApiClient</small>
@@ -4116,7 +4124,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/User.html#user_id-instance_method" title="Coinbase::User#user_id (method)">#user_id</a></span>
       <small>Coinbase::User</small>
@@ -4124,7 +4132,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/Configuration.html#username-instance_method" title="Coinbase::Client::Configuration#username (method)">#username</a></span>
       <small>Coinbase::Client::Configuration</small>
@@ -4132,74 +4140,18 @@
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer/EnumAttributeValidator.html#valid%3F-instance_method" title="Coinbase::Client::Transfer::EnumAttributeValidator#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::Transfer::EnumAttributeValidator</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Wallet.html#valid%3F-instance_method" title="Coinbase::Client::Wallet#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::Wallet</small>
+      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#valid%3F-instance_method" title="Coinbase::Client::FaucetTransaction#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::FaucetTransaction</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Balance.html#valid%3F-instance_method" title="Coinbase::Client::Balance#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::Balance</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/TransferList.html#valid%3F-instance_method" title="Coinbase::Client::TransferList#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::TransferList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#valid%3F-instance_method" title="Coinbase::Client::CreateTransferRequest#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::CreateTransferRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/WalletList.html#valid%3F-instance_method" title="Coinbase::Client::WalletList#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::WalletList</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#valid%3F-instance_method" title="Coinbase::Client::Address#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::Address</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#valid%3F-instance_method" title="Coinbase::Client::Transfer#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::Transfer</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Asset.html#valid%3F-instance_method" title="Coinbase::Client::Asset#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::Asset</small>
+      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#valid%3F-instance_method" title="Coinbase::Client::CreateAddressRequest#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::CreateAddressRequest</small>
     </div>
   </li>
   
@@ -4214,21 +4166,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#valid%3F-instance_method" title="Coinbase::Client::CreateWalletRequest#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::CreateWalletRequest</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Coinbase/Client/User.html#valid%3F-instance_method" title="Coinbase::Client::User#valid? (method)">#valid?</a></span>
       <small>Coinbase::Client::User</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/AddressBalanceList.html#valid%3F-instance_method" title="Coinbase::Client::AddressBalanceList#valid? (method)">#valid?</a></span>
       <small>Coinbase::Client::AddressBalanceList</small>
@@ -4236,18 +4180,10 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/CreateAddressRequest.html#valid%3F-instance_method" title="Coinbase::Client::CreateAddressRequest#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::CreateAddressRequest</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#valid%3F-instance_method" title="Coinbase::Client::BroadcastTransferRequest#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::BroadcastTransferRequest</small>
+      <span class='object_link'><a href="Coinbase/Client/TransferList.html#valid%3F-instance_method" title="Coinbase::Client::TransferList#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::TransferList</small>
     </div>
   </li>
   
@@ -4262,13 +4198,85 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/FaucetTransaction.html#valid%3F-instance_method" title="Coinbase::Client::FaucetTransaction#valid? (method)">#valid?</a></span>
-      <small>Coinbase::Client::FaucetTransaction</small>
+      <span class='object_link'><a href="Coinbase/Client/BroadcastTransferRequest.html#valid%3F-instance_method" title="Coinbase::Client::BroadcastTransferRequest#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::BroadcastTransferRequest</small>
     </div>
   </li>
   
 
   <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/WalletList.html#valid%3F-instance_method" title="Coinbase::Client::WalletList#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::WalletList</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateTransferRequest.html#valid%3F-instance_method" title="Coinbase::Client::CreateTransferRequest#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::CreateTransferRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Address.html#valid%3F-instance_method" title="Coinbase::Client::Address#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::Address</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#valid%3F-instance_method" title="Coinbase::Client::Transfer#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::Transfer</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Transfer/EnumAttributeValidator.html#valid%3F-instance_method" title="Coinbase::Client::Transfer::EnumAttributeValidator#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::Transfer::EnumAttributeValidator</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Wallet.html#valid%3F-instance_method" title="Coinbase::Client::Wallet#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::Wallet</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Balance.html#valid%3F-instance_method" title="Coinbase::Client::Balance#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::Balance</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Asset.html#valid%3F-instance_method" title="Coinbase::Client::Asset#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::Asset</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#valid%3F-instance_method" title="Coinbase::Client::CreateWalletRequest#valid? (method)">#valid?</a></span>
+      <small>Coinbase::Client::CreateWalletRequest</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Transfer.html#wait!-instance_method" title="Coinbase::Transfer#wait! (method)">#wait!</a></span>
       <small>Coinbase::Transfer</small>
@@ -4276,7 +4284,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Coinbase/Client/CreateWalletRequest.html#wallet-instance_method" title="Coinbase::Client::CreateWalletRequest#wallet (method)">#wallet</a></span>
       <small>Coinbase::Client::CreateWalletRequest</small>
@@ -4284,26 +4292,18 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Coinbase/Wallet/Data.html#wallet_id-instance_method" title="Coinbase::Wallet::Data#wallet_id (method)">#wallet_id</a></span>
-      <small>Coinbase::Wallet::Data</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Address.html#wallet_id-instance_method" title="Coinbase::Client::Address#wallet_id (method)">#wallet_id</a></span>
-      <small>Coinbase::Client::Address</small>
+      <span class='object_link'><a href="Coinbase/Wallet.html#wallet_id-instance_method" title="Coinbase::Wallet#wallet_id (method)">#wallet_id</a></span>
+      <small>Coinbase::Wallet</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Client/Transfer.html#wallet_id-instance_method" title="Coinbase::Client::Transfer#wallet_id (method)">#wallet_id</a></span>
-      <small>Coinbase::Client::Transfer</small>
+      <span class='object_link'><a href="Coinbase/Transfer.html#wallet_id-instance_method" title="Coinbase::Transfer#wallet_id (method)">#wallet_id</a></span>
+      <small>Coinbase::Transfer</small>
     </div>
   </li>
   
@@ -4318,16 +4318,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Wallet.html#wallet_id-instance_method" title="Coinbase::Wallet#wallet_id (method)">#wallet_id</a></span>
-      <small>Coinbase::Wallet</small>
+      <span class='object_link'><a href="Coinbase/Client/Transfer.html#wallet_id-instance_method" title="Coinbase::Client::Transfer#wallet_id (method)">#wallet_id</a></span>
+      <small>Coinbase::Client::Transfer</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Coinbase/Transfer.html#wallet_id-instance_method" title="Coinbase::Transfer#wallet_id (method)">#wallet_id</a></span>
-      <small>Coinbase::Transfer</small>
+      <span class='object_link'><a href="Coinbase/Wallet/Data.html#wallet_id-instance_method" title="Coinbase::Wallet::Data#wallet_id (method)">#wallet_id</a></span>
+      <small>Coinbase::Wallet::Data</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Coinbase/Client/Address.html#wallet_id-instance_method" title="Coinbase::Client::Address#wallet_id (method)">#wallet_id</a></span>
+      <small>Coinbase::Client::Address</small>
     </div>
   </li>
   

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -169,10 +169,8 @@ module Coinbase
       page = nil
 
       loop do
-        opts = { limit: 100, page: page }
-
         response = Coinbase.call_api do
-          transfers_api.list_transfers(wallet_id, address_id, opts)
+          transfers_api.list_transfers(wallet_id, address_id, { limit: 100, page: page })
         end
 
         transfer_ids.concat(response.data.map(&:transfer_id)) if response.data

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -162,6 +162,29 @@ module Coinbase
       @key.private_hex
     end
 
+    # Lists the IDs of all Transfers associated with the given Wallet and Address.
+    # @return [Array<String>] The IDs of all Transfers belonging to the Wallet and Address
+    def list_transfer_ids
+      transfer_ids = []
+      page = nil
+
+      loop do
+        opts = { limit: 100, page: page }
+
+        response = Coinbase.call_api do
+          transfers_api.list_transfers(wallet_id, address_id, opts)
+        end
+
+        transfer_ids.concat(response.data.map(&:transfer_id)) if response.data
+
+        break unless response.has_more
+
+        page = response.next_page
+      end
+
+      transfer_ids
+    end
+
     private
 
     # Normalizes the amount of the Asset to send to the atomic unit.

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -190,18 +190,5 @@ module Coinbase
     def inspect
       to_s
     end
-
-    private
-
-    # Updates the Transfer model with the latest data.
-    def update_model
-      @model = Coinbase.call_api do
-        transfers_api.get_transfer(transfer_id)
-      end
-    end
-
-    def transfers_api
-      @transfers_api ||= Coinbase::Client::TransfersApi.new(Coinbase.configuration.api_client)
-    end
   end
 end

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -72,9 +72,14 @@ module Coinbase
     end
 
     # Returns the amount of the asset for the Transfer.
-    # @return [BigDecimal] The amount in units of ETH
+    # @return [BigDecimal] The amount of the asset
     def amount
-      BigDecimal(@model.amount) / BigDecimal(Coinbase::WEI_PER_ETHER.to_s)
+      case asset_id
+      when :eth
+        BigDecimal(@model.amount) / BigDecimal(Coinbase::WEI_PER_ETHER.to_s)
+      else
+        BigDecimal(@model.amount)
+      end
     end
 
     # Returns the link to the transaction on the blockchain explorer.
@@ -184,6 +189,19 @@ module Coinbase
     # @return [String] a String representation of the Transfer
     def inspect
       to_s
+    end
+
+    private
+
+    # Updates the Transfer model with the latest data.
+    def update_model
+      @model = Coinbase.call_api do
+        transfers_api.get_transfer(transfer_id)
+      end
+    end
+
+    def transfers_api
+      @transfers_api ||= Coinbase::Client::TransfersApi.new(Coinbase.configuration.api_client)
     end
   end
 end

--- a/spec/unit/coinbase/address_spec.rb
+++ b/spec/unit/coinbase/address_spec.rb
@@ -390,4 +390,17 @@ describe Coinbase::Address do
       expect(address.export).to eq(private_key)
     end
   end
+
+  describe '#list_transfer_ids' do
+    let(:transfer_ids) { [SecureRandom.uuid, SecureRandom.uuid] }
+    let(:data) do
+      transfer_ids.map { |id| Coinbase::Client::Transfer.new({ 'transfer_id': id, 'network_id': 'base-sepolia' }) }
+    end
+    let(:transfers_list) { Coinbase::Client::TransferList.new({ 'data' => data }) }
+    let(:opts) { { limit: 100, page: nil } }
+    it 'lists the transfer IDs' do
+      allow(transfers_api).to receive(:list_transfers).with(wallet_id, address_id, opts).and_return(transfers_list)
+      expect(address.list_transfer_ids).to eq(transfer_ids)
+    end
+  end
 end

--- a/spec/unit/coinbase/transfer_spec.rb
+++ b/spec/unit/coinbase/transfer_spec.rb
@@ -123,6 +123,7 @@ describe Coinbase::Transfer do
         expect(transfer.amount).to eq(eth_amount)
       end
     end
+
     context 'when the asset ID is :usdc' do
       subject(:transfer) do
         described_class.new(usdc_model)
@@ -152,6 +153,7 @@ describe Coinbase::Transfer do
         expect(transfer.signed_payload).to be_nil
       end
     end
+
     context 'when the transfer has been broadcast on chain' do
       subject(:transfer) do
         described_class.new(broadcast_model)

--- a/spec/unit/coinbase/transfer_spec.rb
+++ b/spec/unit/coinbase/transfer_spec.rb
@@ -41,6 +41,19 @@ describe Coinbase::Transfer do
                                      'unsigned_payload' => unsigned_payload
                                    })
   end
+  let(:usdc_model) do
+    Coinbase::Client::Transfer.new({
+                                     'network_id' => network_id,
+                                     'wallet_id' => wallet_id,
+                                     'address_id' => from_address_id,
+                                     'destination' => to_address_id,
+                                     'asset_id' => 'usdc',
+                                     'amount' => amount.to_s,
+                                     'transfer_id' => transfer_id,
+                                     'status' => 'pending',
+                                     'unsigned_payload' => unsigned_payload
+                                   })
+  end
   let(:broadcast_model) do
     Coinbase::Client::Transfer.new({
                                      'network_id' => network_id,
@@ -60,9 +73,8 @@ describe Coinbase::Transfer do
   let(:client) { double('Jimson::Client') }
 
   before(:each) do
-    configuration = double(Coinbase::Configuration)
-    allow(Coinbase).to receive(:configuration).and_return(configuration)
-    allow(configuration).to receive(:base_sepolia_client).and_return(client)
+    allow(Coinbase.configuration).to receive(:base_sepolia_client).and_return(client)
+    allow(Coinbase::Client::TransfersApi).to receive(:new).and_return(transfers_api)
   end
 
   subject(:transfer) do
@@ -106,8 +118,19 @@ describe Coinbase::Transfer do
   end
 
   describe '#amount' do
-    it 'returns the amount' do
-      expect(transfer.amount).to eq(eth_amount)
+    context 'when the asset ID is :eth' do
+      it 'returns the amount' do
+        expect(transfer.amount).to eq(eth_amount)
+      end
+    end
+    context 'when the asset ID is :usdc' do
+      subject(:transfer) do
+        described_class.new(usdc_model)
+      end
+
+      it 'returns the amount' do
+        expect(transfer.amount).to eq(amount)
+      end
     end
   end
 


### PR DESCRIPTION
### What changed? Why?
- `#list_transfer_ids` is added to `Address` to list `Transfer` IDs for a given `Address`
- We only surface the full list for now but the structure for pagination is ready whenever we decide to expose that
- `#amount` is updated on `Transfer` to handle non ETH assets such as `:usdc`

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->