### PR TITLE
Refactor method names and where asset, balance, and import logic lives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Trade
 
+## [0.0.4] - Pending
+
+* Refactor methods to be more idiomatic for Ruby.
+
 ## [0.0.3] - 2024-05-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ To import wallets that were persisted to your local file system using `save_wall
 # The Wallet can be re-instantiated using the exported data.
 # w5 will be equivalent to w3.
 wallets = u.load_wallets
-w5 = wallets[w3.wallet_id]
+w5 = wallets[w3.id]
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Coinbase.configure do |config|
 end
 ```
 
-Another way to initialize the SDK is by sourcing the API key from the json file that contains your API key, 
+Another way to initialize the SDK is by sourcing the API key from the json file that contains your API key,
 downloaded from CDP portal.
 
 ```ruby
@@ -151,7 +151,7 @@ u.save_wallet(w3)
 ```
 
 To encrypt the saved data, set encrypt to true. Note that your CDP API key also serves as the encryption key
-for the data persisted locally. To re-instantiate wallets with encrypted data, ensure that your SDK is configured with 
+for the data persisted locally. To re-instantiate wallets with encrypted data, ensure that your SDK is configured with
 the same API key when invoking `save_wallet` and `load_wallets`.
 
 ```ruby
@@ -163,7 +163,7 @@ The below code demonstrates how to re-instantiate a Wallet from the data export.
 ```ruby
 # The Wallet can be re-instantiated using the exported data.
 # w4 will be equivalent to w3.
-w4 = u.import_wallet(data)
+w4 = Coinbase::Wallet.import(data)
 ```
 
 To import wallets that were persisted to your local file system using `save_wallet`, use the below code.

--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -3,6 +3,7 @@
 require_relative 'coinbase/address'
 require_relative 'coinbase/asset'
 require_relative 'coinbase/authenticator'
+require_relative 'coinbase/balance'
 require_relative 'coinbase/balance_map'
 require_relative 'coinbase/client'
 require_relative 'coinbase/constants'
@@ -97,30 +98,6 @@ module Coinbase
   # @return [Symbol] the converted symbol
   def self.to_sym(value)
     value.to_s.gsub('-', '_').to_sym
-  end
-
-  # Converts a Coinbase::Client::AddressBalanceList to a BalanceMap.
-  # @param address_balance_list [Coinbase::Client::AddressBalanceList] The AddressBalanceList to convert
-  # @return [BalanceMap] The converted BalanceMap
-  def self.to_balance_map(address_balance_list)
-    balances = {}
-
-    address_balance_list.data.each do |balance|
-      asset_id = Coinbase.to_sym(balance.asset.asset_id.downcase)
-      amount = case asset_id
-               when :eth
-                 BigDecimal(balance.amount) / BigDecimal(Coinbase::WEI_PER_ETHER)
-               when :usdc
-                 BigDecimal(balance.amount) / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC)
-               when :weth
-                 BigDecimal(balance.amount) / BigDecimal(Coinbase::WEI_PER_ETHER)
-               else
-                 BigDecimal(balance.amount)
-               end
-      balances[asset_id] = amount
-    end
-
-    BalanceMap.new(balances)
   end
 
   # Loads the default user.

--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -18,7 +18,6 @@ require 'json'
 # The Coinbase SDK.
 module Coinbase
   class InvalidConfiguration < StandardError; end
-  class FaucetLimitReached < StandardError; end
 
   # Returns the configuration object.
   # @return [Configuration] the configuration object

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -42,7 +42,7 @@ module Coinbase
     # Returns the balances of the Address.
     # @return [BalanceMap] The balances of the Address, keyed by asset ID. Ether balances are denominated
     #  in ETH.
-    def list_balances
+    def balances
       response = Coinbase.call_api do
         addresses_api.list_address_balances(wallet_id, address_id)
       end
@@ -53,7 +53,7 @@ module Coinbase
     # Returns the balance of the provided Asset.
     # @param asset_id [Symbol] The Asset to retrieve the balance for
     # @return [BigDecimal] The balance of the Asset
-    def get_balance(asset_id)
+    def balance(asset_id)
       normalized_asset_id = normalize_asset_id(asset_id)
 
       response = Coinbase.call_api do
@@ -95,7 +95,7 @@ module Coinbase
         destination = destination.address_id
       end
 
-      current_balance = get_balance(asset_id)
+      current_balance = balance(asset_id)
       if current_balance < amount
         raise ArgumentError, "Insufficient funds: #{amount} requested, but only #{current_balance} available"
       end

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -110,7 +110,7 @@ module Coinbase
       }
 
       transfer_model = Coinbase.call_api do
-        transfers_api.broadcast_transfer(wallet_id, id, transfer.transfer_id, broadcast_transfer_request)
+        transfers_api.broadcast_transfer(wallet_id, id, transfer.id, broadcast_transfer_request)
       end
 
       Coinbase::Transfer.new(transfer_model)

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -145,25 +145,26 @@ module Coinbase
       @key.private_hex
     end
 
-    # Lists the IDs of all Transfers associated with the given Wallet and Address.
-    # @return [Array<String>] The IDs of all Transfers belonging to the Wallet and Address
-    def list_transfer_ids
-      transfer_ids = []
+    # Returns all of the transfers associated with the address.
+    # @return [Array<Coinbase::Transfer>] The transfers associated with the address
+    def transfers
+      transfers = []
       page = nil
 
       loop do
+        puts "fetch transfers page: #{page}"
         response = Coinbase.call_api do
           transfers_api.list_transfers(wallet_id, id, { limit: 100, page: page })
         end
 
-        transfer_ids.concat(response.data.map(&:transfer_id)) if response.data
+        transfers.concat(response.data.map { |transfer| Coinbase::Transfer.new(transfer) }) if response.data
 
         break unless response.has_more
 
         page = response.next_page
       end
 
-      transfer_ids
+      transfers
     end
 
     private

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -148,7 +148,7 @@ module Coinbase
     # Requests funds for the address from the faucet and returns the faucet transaction.
     # This is only supported on testnet networks.
     # @return [Coinbase::FaucetTransaction] The successful faucet transaction
-    # @raise [Coinbase::FaucetLimitReached] If the faucet limit has been reached for the address or user.
+    # @raise [Coinbase::FaucetLimitReachedError] If the faucet limit has been reached for the address or user.
     # @raise [Coinbase::Client::ApiError] If an unexpected error occurs while requesting faucet funds.
     def faucet
       Coinbase.call_api do

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -35,7 +35,7 @@ module Coinbase
 
     # Returns the Address ID.
     # @return [String] The Address ID
-    def address_id
+    def id
       @model.address_id
     end
 
@@ -44,7 +44,7 @@ module Coinbase
     #  in ETH.
     def balances
       response = Coinbase.call_api do
-        addresses_api.list_address_balances(wallet_id, address_id)
+        addresses_api.list_address_balances(wallet_id, id)
       end
 
       Coinbase::BalanceMap.from_balances(response.data)
@@ -57,7 +57,7 @@ module Coinbase
       normalized_asset_id = normalize_asset_id(asset_id)
 
       response = Coinbase.call_api do
-        addresses_api.get_address_balance(wallet_id, address_id, normalized_asset_id.to_s)
+        addresses_api.get_address_balance(wallet_id, id, normalized_asset_id.to_s)
       end
 
       return BigDecimal('0') if response.nil?
@@ -88,11 +88,11 @@ module Coinbase
       if destination.is_a?(Wallet)
         raise ArgumentError, 'Transfer must be on the same Network' if destination.network_id != network_id
 
-        destination = destination.default_address.address_id
+        destination = destination.default_address.id
       elsif destination.is_a?(Address)
         raise ArgumentError, 'Transfer must be on the same Network' if destination.network_id != network_id
 
-        destination = destination.address_id
+        destination = destination.id
       end
 
       current_balance = balance(asset_id)
@@ -112,7 +112,7 @@ module Coinbase
       }
 
       transfer_model = Coinbase.call_api do
-        transfers_api.create_transfer(wallet_id, address_id, create_transfer_request)
+        transfers_api.create_transfer(wallet_id, id, create_transfer_request)
       end
 
       transfer = Coinbase::Transfer.new(transfer_model)
@@ -127,7 +127,7 @@ module Coinbase
       }
 
       transfer_model = Coinbase.call_api do
-        transfers_api.broadcast_transfer(wallet_id, address_id, transfer.transfer_id, broadcast_transfer_request)
+        transfers_api.broadcast_transfer(wallet_id, id, transfer.transfer_id, broadcast_transfer_request)
       end
 
       Coinbase::Transfer.new(transfer_model)
@@ -136,7 +136,7 @@ module Coinbase
     # Returns a String representation of the Address.
     # @return [String] a String representation of the Address
     def to_s
-      "Coinbase::Address{address_id: '#{address_id}', network_id: '#{network_id}', wallet_id: '#{wallet_id}'}"
+      "Coinbase::Address{id: '#{id}', network_id: '#{network_id}', wallet_id: '#{wallet_id}'}"
     end
 
     # Same as to_s.
@@ -152,7 +152,7 @@ module Coinbase
     # @raise [Coinbase::Client::ApiError] If an unexpected error occurs while requesting faucet funds.
     def faucet
       Coinbase.call_api do
-        Coinbase::FaucetTransaction.new(addresses_api.request_faucet_funds(wallet_id, address_id))
+        Coinbase::FaucetTransaction.new(addresses_api.request_faucet_funds(wallet_id, id))
       end
     end
 
@@ -170,7 +170,7 @@ module Coinbase
 
       loop do
         response = Coinbase.call_api do
-          transfers_api.list_transfers(wallet_id, address_id, { limit: 100, page: page })
+          transfers_api.list_transfers(wallet_id, id, { limit: 100, page: page })
         end
 
         transfer_ids.concat(response.data.map(&:transfer_id)) if response.data

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -47,7 +47,7 @@ module Coinbase
         addresses_api.list_address_balances(wallet_id, address_id)
       end
 
-      Coinbase.to_balance_map(response)
+      Coinbase::BalanceMap.from_balances(response.data)
     end
 
     # Returns the balance of the provided Asset.

--- a/lib/coinbase/asset.rb
+++ b/lib/coinbase/asset.rb
@@ -75,5 +75,18 @@ module Coinbase
     end
 
     attr_reader :network_id, :asset_id, :display_name, :address_id
+
+    # Returns a string representation of the Asset.
+    # @return [String] a string representation of the Asset
+    def to_s
+      "Coinbase::Asset{network_id: '#{network_id}', asset_id: '#{asset_id}', display_name: '#{display_name}'" +
+        (address_id.nil? ? '}' : ", address_id: '#{address_id}'}")
+    end
+
+    # Same as to_s.
+    # @return [String] a string representation of the Balance
+    def inspect
+      to_s
+    end
   end
 end

--- a/lib/coinbase/asset.rb
+++ b/lib/coinbase/asset.rb
@@ -3,7 +3,63 @@
 module Coinbase
   # A representation of an Asset.
   class Asset
-    attr_reader :network_id, :asset_id, :display_name, :address_id
+    # Retuns whether the provided asset ID is supported.
+    # @param asset_id [Symbol] The Asset ID
+    # @return [Boolean] Whether the Asset ID is supported
+    def self.supported?(asset_id)
+      !!Coinbase::SUPPORTED_ASSET_IDS[asset_id]
+    end
+
+    # Converts the amount of the Asset to the atomic units of the primary denomination of the Asset.
+    # @param amount [Integer, Float, BigDecimal] The amount to normalize
+    # @param asset_id [Symbol] The ID of the Asset being transferred
+    # @return [BigDecimal] The normalized amount in atomic units
+    def self.to_atomic_amount(amount, asset_id)
+      case asset_id
+      when :eth
+        amount * BigDecimal(Coinbase::WEI_PER_ETHER.to_s)
+      when :gwei
+        amount * BigDecimal(Coinbase::WEI_PER_GWEI.to_s)
+      when :usdc
+        amount * BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC.to_s)
+      when :weth
+        amount * BigDecimal(Coinbase::WEI_PER_ETHER)
+      else
+        amount
+      end
+    end
+
+    # Converts an amount from the atomic value of the primary denomination of the provided Asset ID
+    # to whole units of the specified asset ID.
+    # @param atomic_amount [BigDecimal] The amount in atomic units
+    # @param asset_id [Symbol] The Asset ID
+    # @return [BigDecimal] The amount in whole units of the specified asset ID
+    def self.from_atomic_amount(atomic_amount, asset_id)
+      case asset_id
+      when :eth
+        atomic_amount / BigDecimal(Coinbase::WEI_PER_ETHER.to_s)
+      when :gwei
+        atomic_amount / BigDecimal(Coinbase::WEI_PER_GWEI.to_s)
+      when :usdc
+        atomic_amount / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC.to_s)
+      when :weth
+        atomic_amount / BigDecimal(Coinbase::WEI_PER_ETHER)
+      else
+        atomic_amount
+      end
+    end
+
+    # Returns the primary denomination for the provided Asset ID.
+    # For assets with multiple denominations, e.g. eth can also be denominated in wei and gwei,
+    # this method will return the primary denomination.
+    # e.g. eth.
+    # @param asset_id [Symbol] The Asset ID
+    # @return [Symbol] The primary denomination for the Asset ID
+    def self.primary_denomination(asset_id)
+      return :eth if %i[wei gwei].include?(asset_id)
+
+      asset_id
+    end
 
     # Returns a new Asset object. Do not use this method. Instead, use the Asset constants defined in
     # the Coinbase module.
@@ -17,5 +73,7 @@ module Coinbase
       @display_name = display_name
       @address_id = address_id
     end
+
+    attr_reader :network_id, :asset_id, :display_name, :address_id
   end
 end

--- a/lib/coinbase/balance.rb
+++ b/lib/coinbase/balance.rb
@@ -37,5 +37,17 @@ module Coinbase
     end
 
     attr_reader :amount, :asset_id
+
+    # Returns a string representation of the Balance.
+    # @return [String] a string representation of the Balance
+    def to_s
+      "Coinbase::Balance{amount: '#{amount.to_i}', asset_id: '#{asset_id}'}"
+    end
+
+    # Same as to_s.
+    # @return [String] a string representation of the Balance
+    def inspect
+      to_s
+    end
   end
 end

--- a/lib/coinbase/balance.rb
+++ b/lib/coinbase/balance.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Coinbase
+  # A representation of an Balance.
+  class Balance
+    # Converts a Coinbase::Client::Balance model to a Coinbase::Balance
+    # @param balance_model [Coinbase::Client::Balance] The balance fetched from the API.
+    # @return [Balance] The converted Balance object.
+    def self.from_model(balance_model)
+      asset_id = Coinbase.to_sym(balance_model.asset.asset_id.downcase)
+
+      # TODO: Migrate asset ID handling to the backend.
+      amount = case asset_id
+               when :eth
+                 BigDecimal(balance_model.amount) / BigDecimal(Coinbase::WEI_PER_ETHER)
+               when :usdc
+                 BigDecimal(balance_model.amount) / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC)
+               when :weth
+                 BigDecimal(balance_model.amount) / BigDecimal(Coinbase::WEI_PER_ETHER)
+               else
+                 BigDecimal(balance_model.amount)
+               end
+
+      new(amount: amount, asset_id: asset_id)
+    end
+
+    # Returns a new Asset object. Do not use this method. Instead, use the Asset constants defined in
+    # the Coinbase module.
+    # @param network_id [Symbol] The ID of the Network to which the Asset belongs
+    # @param asset_id [Symbol] The Asset ID
+    # @param display_name [String] The Asset's display name
+    # @param address_id [String] (Optional) The Asset's address ID, if one exists
+    def initialize(amount:, asset_id:)
+      @amount = amount
+      @asset_id = asset_id
+    end
+
+    attr_reader :amount, :asset_id
+  end
+end

--- a/lib/coinbase/balance_map.rb
+++ b/lib/coinbase/balance_map.rb
@@ -5,13 +5,25 @@ require 'bigdecimal'
 module Coinbase
   # A convenience class for printing out Asset balances in a human-readable format.
   class BalanceMap < Hash
-    # Returns a new BalanceMap object.
-    # @param hash [Map<Symbol, BigDecimal>] The hash to initialize with
-    def initialize(hash = {})
-      super()
-      hash.each do |key, value|
-        self[key] = value
+    # Converts a list of Coinbase::Client::Balance models to a Coinbase::BalanceMap.
+    # @param balances [Array<Coinbase::Client::Balance>] The list of balances fetched from the API.
+    # @return [BalanceMap] The converted BalanceMap object.
+    def self.from_balances(balances)
+      BalanceMap.new.tap do |balance_map|
+        balances.each do |balance_model|
+          balance = Coinbase::Balance.from_model(balance_model)
+
+          balance_map.add(balance)
+        end
       end
+    end
+
+    # Adds a balance to the map.
+    # @param balance [Coinbase::Balance] The balance to add to the map.
+    def add(balance)
+      raise ArgumentError, 'balance must be a Coinbase::Balance' unless balance.is_a?(Coinbase::Balance)
+
+      self[balance.asset_id] = balance.amount
     end
 
     # Returns a string representation of the balance map.

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -37,7 +37,7 @@ module Coinbase
 
     # Returns the Transfer ID.
     # @return [String] The Transfer ID
-    def transfer_id
+    def id
       @model.transfer_id
     end
 
@@ -179,7 +179,7 @@ module Coinbase
     # Returns a String representation of the Transfer.
     # @return [String] a String representation of the Transfer
     def to_s
-      "Coinbase::Transfer{transfer_id: '#{transfer_id}', network_id: '#{network_id}', " \
+      "Coinbase::Transfer{transfer_id: '#{id}', network_id: '#{network_id}', " \
         "from_address_id: '#{from_address_id}', destination_address_id: '#{destination_address_id}', " \
         "asset_id: '#{asset_id}', amount: '#{amount}', transaction_hash: '#{transaction_hash}', " \
         "transaction_link: '#{transaction_link}', status: '#{status}'}"

--- a/lib/coinbase/user.rb
+++ b/lib/coinbase/user.rb
@@ -15,7 +15,7 @@ module Coinbase
 
     # Returns the User ID.
     # @return [String] the User ID
-    def user_id
+    def id
       @model.id
     end
 

--- a/lib/coinbase/user.rb
+++ b/lib/coinbase/user.rb
@@ -133,7 +133,7 @@ module Coinbase
     # Returns a string representation of the User.
     # @return [String] a string representation of the User
     def to_s
-      "Coinbase::User{user_id: '#{user_id}'}"
+      "Coinbase::User{user_id: '#{id}'}"
     end
 
     # Same as to_s.

--- a/lib/coinbase/user.rb
+++ b/lib/coinbase/user.rb
@@ -41,15 +41,7 @@ module Coinbase
     # @param data [Coinbase::Wallet::Data] the Wallet data to import
     # @return [Coinbase::Wallet] the imported Wallet
     def import_wallet(data)
-      model = Coinbase.call_api do
-        wallets_api.get_wallet(data.wallet_id)
-      end
-
-      address_count = Coinbase.call_api do
-        addresses_api.list_addresses(model.id).total_count
-      end
-
-      Wallet.new(model, seed: data.seed, address_count: address_count)
+      Wallet.import(data)
     end
 
     # Lists the IDs of the Wallets belonging to the User.

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -43,6 +43,8 @@ module Coinbase
       end
     end
 
+    attr_reader :addresses
+
     # Returns the Wallet ID.
     # @return [String] The Wallet ID
     def wallet_id
@@ -84,14 +86,8 @@ module Coinbase
     # Returns the Address with the given ID.
     # @param address_id [String] The ID of the Address to retrieve
     # @return [Address] The Address
-    def get_address(address_id)
+    def address(address_id)
       @addresses.find { |address| address.address_id == address_id }
-    end
-
-    # Returns the list of Addresses in the Wallet.
-    # @return [Array<Address>] The list of Addresses
-    def list_addresses
-      @addresses
     end
 
     # Returns the list of balances of this Wallet. Balances are aggregated across all Addresses in the Wallet.

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -175,7 +175,7 @@ module Coinbase
     # @return [String] a String representation of the Wallet
     def to_s
       "Coinbase::Wallet{wallet_id: '#{id}', network_id: '#{network_id}', " \
-        "default_address: '#{default_address.address_id}'}"
+        "default_address: '#{default_address.id}'}"
     end
 
     # Same as to_s.

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -96,7 +96,7 @@ module Coinbase
 
     # Returns the list of balances of this Wallet. Balances are aggregated across all Addresses in the Wallet.
     # @return [BalanceMap] The list of balances. The key is the Asset ID, and the value is the balance.
-    def list_balances
+    def balances
       response = Coinbase.call_api do
         wallets_api.list_wallet_balances(wallet_id)
       end
@@ -107,7 +107,7 @@ module Coinbase
     # Returns the balance of the provided Asset. Balances are aggregated across all Addresses in the Wallet.
     # @param asset_id [Symbol] The ID of the Asset to retrieve the balance for
     # @return [BigDecimal] The balance of the Asset
-    def get_balance(asset_id)
+    def balance(asset_id)
       normalized_asset_id = if %i[wei gwei].include?(asset_id)
                               :eth
                             else

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -128,7 +128,7 @@ module Coinbase
         wallets_api.list_wallet_balances(wallet_id)
       end
 
-      Coinbase.to_balance_map(response)
+      Coinbase::BalanceMap.from_balances(response.data)
     end
 
     # Returns the balance of the provided Asset. Balances are aggregated across all Addresses in the Wallet.

--- a/spec/e2e/production.rb
+++ b/spec/e2e/production.rb
@@ -38,8 +38,8 @@ describe Coinbase do
       expect(addresses.length).to be > 1
       puts "Listed addresses: #{addresses.map(&:to_s).join(', ')}"
 
-      puts 'Fetching balances...'
-      balances = w2.list_balances
+      puts 'Fetching wallet balances...'
+      balances = w2.balances
       expect(balances.length).to be >= 1
       puts "Fetched balances: #{balances}"
 
@@ -51,8 +51,8 @@ describe Coinbase do
       puts "Transferred 1 Gwei from #{a1} to #{a2}"
 
       puts 'Fetching updated balances...'
-      first_balance = a1.list_balances
-      second_balance = a2.list_balances
+      first_balance = a1.balances
+      second_balance = a2.balances
       expect(first_balance[:eth]).to be > BigDecimal('0')
       expect(second_balance[:eth]).to be > BigDecimal('0')
       puts "First address balances: #{first_balance}"

--- a/spec/e2e/production.rb
+++ b/spec/e2e/production.rb
@@ -18,12 +18,12 @@ describe Coinbase do
       puts 'Fetching default user...'
       u = Coinbase.default_user
       expect(u).not_to be_nil
-      puts "Fetched default user with ID: #{u.user_id}"
+      puts "Fetched default user with ID: #{u.id}"
 
       puts 'Creating new wallet...'
       w1 = u.create_wallet
       expect(w1).not_to be_nil
-      puts "Created new wallet with ID: #{w1.wallet_id}, default address: #{w1.default_address}"
+      puts "Created new wallet with ID: #{w1.id}, default address: #{w1.default_address}"
 
       puts 'Importing wallet with balance...'
       data_string = ENV['WALLET_DATA']
@@ -31,7 +31,7 @@ describe Coinbase do
       data = Coinbase::Wallet::Data.from_hash(data_hash)
       w2 = u.import_wallet(data)
       expect(w2).not_to be_nil
-      puts "Imported wallet with ID: #{w2.wallet_id}, default address: #{w2.default_address}"
+      puts "Imported wallet with ID: #{w2.id}, default address: #{w2.default_address}"
 
       puts 'Listing wallet addresses...'
       addresses = w2.addresses

--- a/spec/e2e/production.rb
+++ b/spec/e2e/production.rb
@@ -33,8 +33,8 @@ describe Coinbase do
       expect(w2).not_to be_nil
       puts "Imported wallet with ID: #{w2.wallet_id}, default address: #{w2.default_address}"
 
-      puts 'Listing addresses...'
-      addresses = w2.list_addresses
+      puts 'Listing wallet addresses...'
+      addresses = w2.addresses
       expect(addresses.length).to be > 1
       puts "Listed addresses: #{addresses.map(&:to_s).join(', ')}"
 

--- a/spec/unit/coinbase/address_spec.rb
+++ b/spec/unit/coinbase/address_spec.rb
@@ -187,7 +187,7 @@ describe Coinbase::Address do
     end
     let(:transaction) { double('Transaction', sign: transaction_hash, hex: raw_signed_transaction) }
     let(:transfer) do
-      double('Transfer', transaction: transaction, transfer_id: transfer_id)
+      double('Transfer', transaction: transaction, id: transfer_id)
     end
 
     before do

--- a/spec/unit/coinbase/address_spec.rb
+++ b/spec/unit/coinbase/address_spec.rb
@@ -75,6 +75,16 @@ describe Coinbase::Address do
                                                        'decimals': 6
                                                      })
             }
+          ),
+          Coinbase::Client::Balance.new(
+            {
+              'amount' => '3000000000000000000',
+              'asset' => Coinbase::Client::Asset.new({
+                                                       'network_id': 'base-sepolia',
+                                                       'asset_id': 'weth',
+                                                       'decimals': 6
+                                                     })
+            }
           )
         ]
       )
@@ -86,7 +96,11 @@ describe Coinbase::Address do
         .with(wallet_id, address_id)
         .and_return(response)
 
-      expect(address.balances).to eq(eth: BigDecimal('1'), usdc: BigDecimal('5000'))
+      expect(address.balances).to eq(
+        eth: BigDecimal('1'),
+        usdc: BigDecimal('5000'),
+        weth: BigDecimal('3')
+      )
     end
   end
 

--- a/spec/unit/coinbase/address_spec.rb
+++ b/spec/unit/coinbase/address_spec.rb
@@ -40,9 +40,9 @@ describe Coinbase::Address do
     end
   end
 
-  describe '#address_id' do
+  describe '#id' do
     it 'returns the address ID' do
-      expect(address.address_id).to eq(address_id)
+      expect(address.id).to eq(address_id)
     end
   end
 
@@ -187,7 +187,7 @@ describe Coinbase::Address do
       let(:amount) { 500_000_000_000_000_000 }
       let(:destination) { described_class.new(model, to_key) }
       let(:create_transfer_request) do
-        { amount: amount.to_s, network_id: network_id, asset_id: 'eth', destination: destination.address_id }
+        { amount: amount.to_s, network_id: network_id, asset_id: 'eth', destination: destination.id }
       end
 
       it 'creates a Transfer' do
@@ -211,8 +211,12 @@ describe Coinbase::Address do
       let(:usdc_atomic_amount) { 5_000_000 }
       let(:destination) { described_class.new(model, to_key) }
       let(:create_transfer_request) do
-        { amount: usdc_atomic_amount.to_s, network_id: network_id, asset_id: 'usdc',
-          destination: destination.address_id }
+        {
+          amount: usdc_atomic_amount.to_s,
+          network_id: network_id,
+          asset_id: 'usdc',
+          destination: destination.id
+        }
       end
 
       it 'creates a Transfer' do
@@ -226,6 +230,7 @@ describe Coinbase::Address do
         expect(transfers_api)
           .to receive(:broadcast_transfer)
           .with(wallet_id, address_id, transfer_id, broadcast_transfer_request)
+
         expect(address.transfer(usdc_amount, asset_id, destination)).to eq(transfer)
       end
     end

--- a/spec/unit/coinbase/address_spec.rb
+++ b/spec/unit/coinbase/address_spec.rb
@@ -464,4 +464,14 @@ describe Coinbase::Address do
       end
     end
   end
+
+  describe '#inspect' do
+    it 'includes address details' do
+      expect(address.inspect).to include(address_id, Coinbase.to_sym(network_id).to_s, wallet_id)
+    end
+
+    it 'returns the same value as to_s' do
+      expect(address.inspect).to eq(address.to_s)
+    end
+  end
 end

--- a/spec/unit/coinbase/address_spec.rb
+++ b/spec/unit/coinbase/address_spec.rb
@@ -52,7 +52,7 @@ describe Coinbase::Address do
     end
   end
 
-  describe '#list_balances' do
+  describe '#balances' do
     let(:response) do
       Coinbase::Client::AddressBalanceList.new(
         'data' => [
@@ -85,11 +85,12 @@ describe Coinbase::Address do
         .to receive(:list_address_balances)
         .with(wallet_id, address_id)
         .and_return(response)
-      expect(address.list_balances).to eq(eth: BigDecimal('1'), usdc: BigDecimal('5000'))
+
+      expect(address.balances).to eq(eth: BigDecimal('1'), usdc: BigDecimal('5000'))
     end
   end
 
-  describe '#get_balance' do
+  describe '#balance' do
     let(:response) do
       Coinbase::Client::Balance.new(
         {
@@ -108,7 +109,7 @@ describe Coinbase::Address do
         .to receive(:get_address_balance)
         .with(wallet_id, address_id, 'eth')
         .and_return(response)
-      expect(address.get_balance(:eth)).to eq BigDecimal('1')
+      expect(address.balance(:eth)).to eq BigDecimal('1')
     end
 
     it 'returns the correct Gwei balance' do
@@ -116,7 +117,7 @@ describe Coinbase::Address do
         .to receive(:get_address_balance)
         .with(wallet_id, address_id, 'eth')
         .and_return(response)
-      expect(address.get_balance(:gwei)).to eq BigDecimal('1_000_000_000')
+      expect(address.balance(:gwei)).to eq BigDecimal('1_000_000_000')
     end
 
     it 'returns the correct Wei balance' do
@@ -124,7 +125,7 @@ describe Coinbase::Address do
         .to receive(:get_address_balance)
         .with(wallet_id, address_id, 'eth')
         .and_return(response)
-      expect(address.get_balance(:wei)).to eq BigDecimal('1_000_000_000_000_000_000')
+      expect(address.balance(:wei)).to eq BigDecimal('1_000_000_000_000_000_000')
     end
 
     it 'returns 0 for an unsupported asset' do
@@ -132,7 +133,7 @@ describe Coinbase::Address do
         .to receive(:get_address_balance)
         .with(wallet_id, address_id, 'uni')
         .and_return(nil)
-      expect(address.get_balance(:uni)).to eq BigDecimal('0')
+      expect(address.balance(:uni)).to eq BigDecimal('0')
     end
   end
 

--- a/spec/unit/coinbase/asset_spec.rb
+++ b/spec/unit/coinbase/asset_spec.rb
@@ -113,25 +113,72 @@ describe Coinbase::Asset do
     let(:display_name) { 'Ether' }
     let(:address_id) { '0x036CbD53842' }
 
-    subject do
-      described_class.new(network_id: network_id, asset_id: asset_id, display_name: display_name,
-                          address_id: address_id)
+    subject(:asset) do
+      described_class.new(
+        network_id: network_id,
+        asset_id: asset_id,
+        display_name: display_name,
+        address_id: address_id
+      )
     end
 
     it 'sets the network_id' do
-      expect(subject.network_id).to eq(network_id)
+      expect(asset.network_id).to eq(network_id)
     end
 
     it 'sets the asset_id' do
-      expect(subject.asset_id).to eq(asset_id)
+      expect(asset.asset_id).to eq(asset_id)
     end
 
     it 'sets the display_name' do
-      expect(subject.display_name).to eq(display_name)
+      expect(asset.display_name).to eq(display_name)
     end
 
     it 'sets the address_id' do
-      expect(subject.address_id).to eq(address_id)
+      expect(asset.address_id).to eq(address_id)
+    end
+  end
+
+  describe '#inspect' do
+    let(:network_id) { :base_sepolia }
+    let(:asset_id) { :eth }
+    let(:display_name) { 'Ether' }
+
+    subject(:asset) do
+      described_class.new(
+        network_id: network_id,
+        asset_id: asset_id,
+        display_name: display_name
+      )
+    end
+
+    it 'includes asset details' do
+      expect(asset.inspect).to include(
+        Coinbase.to_sym(network_id).to_s,
+        asset_id.to_s,
+        display_name
+      )
+    end
+
+    it 'returns the same value as to_s' do
+      expect(asset.inspect).to eq(asset.to_s)
+    end
+
+    context 'when the asset contains an address_id' do
+      let(:address_id) { '0x036CbD53842' }
+
+      subject(:asset) do
+        described_class.new(
+          network_id: network_id,
+          asset_id: asset_id,
+          display_name: display_name,
+          address_id: address_id
+        )
+      end
+
+      it 'includes the transaction hash' do
+        expect(asset.inspect).to include(address_id)
+      end
     end
   end
 end

--- a/spec/unit/coinbase/asset_spec.rb
+++ b/spec/unit/coinbase/asset_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+describe Coinbase::Asset do
+  describe '.supported?' do
+    %i[eth gwei wei usdc weth].each do |asset_id|
+      context "when the asset_id is #{asset_id}" do
+        it 'returns true' do
+          expect(described_class.supported?(asset_id)).to be true
+        end
+      end
+    end
+
+    context 'when the asset_id is not supported' do
+      it 'returns false' do
+        expect(described_class.supported?(:unsupported)).to be false
+      end
+    end
+  end
+
+  describe '.to_atomic_amount' do
+    let(:amount) { 123.0 }
+
+    context 'when the asset_id is :eth' do
+      it 'returns the amount in atomic units' do
+        expect(described_class.to_atomic_amount(amount, :eth)).to eq(BigDecimal('123000000000000000000'))
+      end
+    end
+
+    context 'when the asset_id is :gwei' do
+      it 'returns the amount in atomic units' do
+        expect(described_class.to_atomic_amount(amount, :gwei)).to eq(BigDecimal('123000000000'))
+      end
+    end
+
+    context 'when the asset_id is :usdc' do
+      it 'returns the amount in atomic units' do
+        expect(described_class.to_atomic_amount(amount, :usdc)).to eq(BigDecimal('123000000'))
+      end
+    end
+
+    context 'when the asset_id is :weth' do
+      it 'returns the amount in atomic units' do
+        expect(described_class.to_atomic_amount(amount, :weth)).to eq(BigDecimal('123000000000000000000'))
+      end
+    end
+
+    context 'when the asset_id is :wei' do
+      it 'returns the amount' do
+        expect(described_class.to_atomic_amount(amount, :wei)).to eq(BigDecimal('123.0'))
+      end
+    end
+
+    context 'when the asset_id is not explicitly handled' do
+      it 'returns the amount' do
+        expect(described_class.to_atomic_amount(amount, :other)).to eq(BigDecimal('123.0'))
+      end
+    end
+  end
+
+  describe '.from_atomic_amount' do
+    let(:atomic_amount) { BigDecimal('123000000000000000000') }
+
+    context 'when the asset_id is :eth' do
+      it 'returns the amount in whole units' do
+        expect(described_class.from_atomic_amount(atomic_amount, :eth)).to eq(BigDecimal('123.0'))
+      end
+    end
+
+    context 'when the asset_id is :gwei' do
+      it 'returns the amount in gwei' do
+        expect(described_class.from_atomic_amount(atomic_amount, :gwei)).to eq(BigDecimal('123000000000'))
+      end
+    end
+
+    context 'when the asset_id is :usdc' do
+      it 'returns the amount in whole units' do
+        expect(described_class.from_atomic_amount(atomic_amount, :usdc)).to eq(BigDecimal('123000000000000'))
+      end
+    end
+
+    context 'when the asset_id is :weth' do
+      it 'returns the amount in whole units' do
+        expect(described_class.from_atomic_amount(atomic_amount, :weth)).to eq(BigDecimal('123.0'))
+      end
+    end
+
+    context 'when the asset_id is :wei' do
+      it 'returns the amount' do
+        expect(described_class.from_atomic_amount(atomic_amount, :wei)).to eq(BigDecimal('123000000000000000000'))
+      end
+    end
+  end
+
+  describe '.primary_denomination' do
+    %i[wei gwei].each do |asset_id|
+      context "when the asset_id is #{asset_id}" do
+        it 'returns :eth' do
+          expect(described_class.primary_denomination(asset_id)).to eq(:eth)
+        end
+      end
+    end
+
+    context 'when the asset_id is not wei or gwei' do
+      it 'returns the asset_id' do
+        expect(described_class.primary_denomination(:other)).to eq(:other)
+      end
+    end
+  end
+
+  describe '#initialize' do
+    let(:network_id) { :base_sepolia }
+    let(:asset_id) { :eth }
+    let(:display_name) { 'Ether' }
+    let(:address_id) { '0x036CbD53842' }
+
+    subject do
+      described_class.new(network_id: network_id, asset_id: asset_id, display_name: display_name,
+                          address_id: address_id)
+    end
+
+    it 'sets the network_id' do
+      expect(subject.network_id).to eq(network_id)
+    end
+
+    it 'sets the asset_id' do
+      expect(subject.asset_id).to eq(asset_id)
+    end
+
+    it 'sets the display_name' do
+      expect(subject.display_name).to eq(display_name)
+    end
+
+    it 'sets the address_id' do
+      expect(subject.address_id).to eq(address_id)
+    end
+  end
+end

--- a/spec/unit/coinbase/balance_map_spec.rb
+++ b/spec/unit/coinbase/balance_map_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+describe Coinbase::BalanceMap do
+  describe '.from_balances' do
+    let(:eth_amount) { BigDecimal('123.0') }
+    let(:eth_asset) { instance_double('Coinbase::Client::Asset', asset_id: 'ETH') }
+    let(:eth_balance_model) { instance_double('Coinbase::Client::Balance', asset: eth_asset, amount: eth_amount) }
+
+    let(:usdc_amount) { BigDecimal('456.0') }
+    let(:usdc_asset) { instance_double('Coinbase::Client::Asset', asset_id: 'USDC') }
+    let(:usdc_balance_model) { instance_double('Coinbase::Client::Balance', asset: usdc_asset, amount: usdc_amount) }
+
+    let(:weth_amount) { BigDecimal('789.0') }
+    let(:weth_asset) { instance_double('Coinbase::Client::Asset', asset_id: 'WETH') }
+    let(:weth_balance_model) { instance_double('Coinbase::Client::Balance', asset: weth_asset, amount: weth_amount) }
+
+    let(:balances) { [eth_balance_model, usdc_balance_model, weth_balance_model] }
+
+    subject { described_class.from_balances(balances) }
+
+    it 'returns a new BalanceMap object with the correct balances' do
+      expect(subject[:eth]).to eq(eth_amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+      expect(subject[:usdc]).to eq(usdc_amount / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC))
+      expect(subject[:weth]).to eq(weth_amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+    end
+  end
+
+  describe '#add' do
+    let(:amount) { BigDecimal('123.0') }
+    let(:asset_id) { :eth }
+    let(:balance) { Coinbase::Balance.new(amount: amount, asset_id: asset_id) }
+
+    subject { described_class.new }
+
+    it 'sets the amount' do
+      subject.add(balance)
+
+      expect(subject[asset_id]).to eq(amount)
+    end
+
+    context 'when the balance is not a Coinbase::Balance' do
+      let(:balance) { instance_double('Coinbase::Balance') }
+
+      it 'raises an ArgumentError' do
+        expect { subject.add(balance) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#to_s' do
+    let(:amount) { BigDecimal('123.0') }
+    let(:asset_id) { :eth }
+    let(:balance) { Coinbase::Balance.new(amount: amount, asset_id: asset_id) }
+
+    let(:expected_result) { { eth: '123' }.to_s }
+
+    subject { described_class.new }
+
+    before { subject.add(balance) }
+
+    it 'returns a string representation of asset_id to floating-point number' do
+      expect(subject.to_s).to eq({ eth: '123' }.to_s)
+    end
+  end
+end

--- a/spec/unit/coinbase/balance_spec.rb
+++ b/spec/unit/coinbase/balance_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+describe Coinbase::Balance do
+  describe '.from_model' do
+    let(:amount) { BigDecimal('123.0') }
+    let(:balance_model) { instance_double('Coinbase::Client::Balance', asset: asset, amount: amount) }
+
+    subject { described_class.from_model(balance_model) }
+
+    context 'when the asset is :eth' do
+      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'ETH') }
+
+      it 'returns a new Balance object with the correct amount' do
+        expect(subject.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+      end
+
+      it 'returns a new Balance object with the correct asset_id' do
+        expect(subject.asset_id).to eq(:eth)
+      end
+    end
+
+    context 'when the asset is :usdc' do
+      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'USDC') }
+
+      it 'returns a new Balance object with the correct amount' do
+        expect(subject.amount).to eq(amount / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC))
+      end
+
+      it 'returns a new Balance object with the correct asset_id' do
+        expect(subject.asset_id).to eq(:usdc)
+      end
+    end
+
+    context 'when the asset is :weth' do
+      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'WETH') }
+
+      it 'returns a new Balance object with the correct amount' do
+        expect(subject.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+      end
+
+      it 'returns a new Balance object with the correct asset_id' do
+        expect(subject.asset_id).to eq(:weth)
+      end
+    end
+
+    context 'when the asset is another asset type' do
+      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'OTHER') }
+
+      it 'returns a new Balance object with the correct amount' do
+        expect(subject.amount).to eq(amount)
+      end
+
+      it 'returns a new Balance object with the correct asset_id' do
+        expect(subject.asset_id).to eq(:other)
+      end
+    end
+  end
+
+  describe '#initialize' do
+    let(:amount) { BigDecimal('123.0') }
+    let(:asset_id) { :eth }
+
+    subject { described_class.new(amount: amount, asset_id: asset_id) }
+
+    it 'sets the amount' do
+      expect(subject.amount).to eq(amount)
+    end
+
+    it 'sets the asset_id' do
+      expect(subject.asset_id).to eq(asset_id)
+    end
+  end
+end

--- a/spec/unit/coinbase/balance_spec.rb
+++ b/spec/unit/coinbase/balance_spec.rb
@@ -5,17 +5,17 @@ describe Coinbase::Balance do
     let(:amount) { BigDecimal('123.0') }
     let(:balance_model) { instance_double('Coinbase::Client::Balance', asset: asset, amount: amount) }
 
-    subject { described_class.from_model(balance_model) }
+    subject(:balance) { described_class.from_model(balance_model) }
 
     context 'when the asset is :eth' do
       let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'ETH') }
 
       it 'returns a new Balance object with the correct amount' do
-        expect(subject.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+        expect(balance.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
       end
 
       it 'returns a new Balance object with the correct asset_id' do
-        expect(subject.asset_id).to eq(:eth)
+        expect(balance.asset_id).to eq(:eth)
       end
     end
 
@@ -23,11 +23,11 @@ describe Coinbase::Balance do
       let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'USDC') }
 
       it 'returns a new Balance object with the correct amount' do
-        expect(subject.amount).to eq(amount / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC))
+        expect(balance.amount).to eq(amount / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC))
       end
 
       it 'returns a new Balance object with the correct asset_id' do
-        expect(subject.asset_id).to eq(:usdc)
+        expect(balance.asset_id).to eq(:usdc)
       end
     end
 
@@ -35,11 +35,11 @@ describe Coinbase::Balance do
       let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'WETH') }
 
       it 'returns a new Balance object with the correct amount' do
-        expect(subject.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+        expect(balance.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
       end
 
       it 'returns a new Balance object with the correct asset_id' do
-        expect(subject.asset_id).to eq(:weth)
+        expect(balance.asset_id).to eq(:weth)
       end
     end
 
@@ -47,11 +47,11 @@ describe Coinbase::Balance do
       let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'OTHER') }
 
       it 'returns a new Balance object with the correct amount' do
-        expect(subject.amount).to eq(amount)
+        expect(balance.amount).to eq(amount)
       end
 
       it 'returns a new Balance object with the correct asset_id' do
-        expect(subject.asset_id).to eq(:other)
+        expect(balance.asset_id).to eq(:other)
       end
     end
   end
@@ -60,7 +60,7 @@ describe Coinbase::Balance do
     let(:amount) { BigDecimal('123.0') }
     let(:balance_model) { instance_double('Coinbase::Client::Balance', asset: asset, amount: amount) }
 
-    subject { described_class.from_model_and_asset_id(balance_model, asset_id) }
+    subject(:balance) { described_class.from_model_and_asset_id(balance_model, asset_id) }
 
     context 'when the balance model asset is :eth' do
       let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'ETH') }
@@ -69,11 +69,11 @@ describe Coinbase::Balance do
         let(:asset_id) { :eth }
 
         it 'returns a new Balance object with the correct amount' do
-          expect(subject.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+          expect(balance.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
         end
 
         it 'returns a new Balance object with the correct asset_id' do
-          expect(subject.asset_id).to eq(asset_id)
+          expect(balance.asset_id).to eq(asset_id)
         end
       end
 
@@ -81,11 +81,11 @@ describe Coinbase::Balance do
         let(:asset_id) { :gwei }
 
         it 'returns a new Balance object with the correct amount' do
-          expect(subject.amount).to eq(amount / BigDecimal(Coinbase::GWEI_PER_ETHER))
+          expect(balance.amount).to eq(amount / BigDecimal(Coinbase::GWEI_PER_ETHER))
         end
 
         it 'returns a new Balance object with the correct asset_id' do
-          expect(subject.asset_id).to eq(asset_id)
+          expect(balance.asset_id).to eq(asset_id)
         end
       end
 
@@ -93,11 +93,11 @@ describe Coinbase::Balance do
         let(:asset_id) { :wei }
 
         it 'returns a new Balance object with the correct amount' do
-          expect(subject.amount).to eq(amount)
+          expect(balance.amount).to eq(amount)
         end
 
         it 'returns a new Balance object with the correct asset_id' do
-          expect(subject.asset_id).to eq(asset_id)
+          expect(balance.asset_id).to eq(asset_id)
         end
       end
     end
@@ -107,11 +107,11 @@ describe Coinbase::Balance do
       let(:asset_id) { :usdc }
 
       it 'returns a new Balance object with the correct amount' do
-        expect(subject.amount).to eq(amount / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC))
+        expect(balance.amount).to eq(amount / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC))
       end
 
       it 'returns a new Balance object with the correct asset_id' do
-        expect(subject.asset_id).to eq(asset_id)
+        expect(balance.asset_id).to eq(asset_id)
       end
     end
 
@@ -120,11 +120,11 @@ describe Coinbase::Balance do
       let(:asset_id) { :weth }
 
       it 'returns a new Balance object with the correct amount' do
-        expect(subject.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+        expect(balance.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
       end
 
       it 'returns a new Balance object with the correct asset_id' do
-        expect(subject.asset_id).to eq(asset_id)
+        expect(balance.asset_id).to eq(asset_id)
       end
     end
 
@@ -133,11 +133,11 @@ describe Coinbase::Balance do
       let(:asset_id) { :other }
 
       it 'returns a new Balance object with the correct amount' do
-        expect(subject.amount).to eq(amount)
+        expect(balance.amount).to eq(amount)
       end
 
       it 'returns a new Balance object with the correct asset_id' do
-        expect(subject.asset_id).to eq(asset_id)
+        expect(balance.asset_id).to eq(asset_id)
       end
     end
   end
@@ -146,14 +146,29 @@ describe Coinbase::Balance do
     let(:amount) { BigDecimal('123.0') }
     let(:asset_id) { :eth }
 
-    subject { described_class.new(amount: amount, asset_id: asset_id) }
+    subject(:balance) { described_class.new(amount: amount, asset_id: asset_id) }
 
     it 'sets the amount' do
-      expect(subject.amount).to eq(amount)
+      expect(balance.amount).to eq(amount)
     end
 
     it 'sets the asset_id' do
-      expect(subject.asset_id).to eq(asset_id)
+      expect(balance.asset_id).to eq(asset_id)
+    end
+  end
+
+  describe '#inspect' do
+    let(:amount) { BigDecimal('123.0') }
+    let(:asset_id) { :eth }
+
+    subject(:balance) { described_class.new(amount: amount, asset_id: asset_id) }
+
+    it 'includes balance details' do
+      expect(balance.inspect).to include('123', 'eth')
+    end
+
+    it 'returns the same value as to_s' do
+      expect(balance.inspect).to eq(balance.to_s)
     end
   end
 end

--- a/spec/unit/coinbase/balance_spec.rb
+++ b/spec/unit/coinbase/balance_spec.rb
@@ -56,6 +56,92 @@ describe Coinbase::Balance do
     end
   end
 
+  describe '.from_model_and_asset_id' do
+    let(:amount) { BigDecimal('123.0') }
+    let(:balance_model) { instance_double('Coinbase::Client::Balance', asset: asset, amount: amount) }
+
+    subject { described_class.from_model_and_asset_id(balance_model, asset_id) }
+
+    context 'when the balance model asset is :eth' do
+      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'ETH') }
+
+      context 'and the specified asset_id is :eth' do
+        let(:asset_id) { :eth }
+
+        it 'returns a new Balance object with the correct amount' do
+          expect(subject.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+        end
+
+        it 'returns a new Balance object with the correct asset_id' do
+          expect(subject.asset_id).to eq(asset_id)
+        end
+      end
+
+      context 'and the specified asset_id is :gwei' do
+        let(:asset_id) { :gwei }
+
+        it 'returns a new Balance object with the correct amount' do
+          expect(subject.amount).to eq(amount / BigDecimal(Coinbase::GWEI_PER_ETHER))
+        end
+
+        it 'returns a new Balance object with the correct asset_id' do
+          expect(subject.asset_id).to eq(asset_id)
+        end
+      end
+
+      context 'and the specified asset_id is :wei' do
+        let(:asset_id) { :wei }
+
+        it 'returns a new Balance object with the correct amount' do
+          expect(subject.amount).to eq(amount)
+        end
+
+        it 'returns a new Balance object with the correct asset_id' do
+          expect(subject.asset_id).to eq(asset_id)
+        end
+      end
+    end
+
+    context 'when the asset is :usdc' do
+      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'USDC') }
+      let(:asset_id) { :usdc }
+
+      it 'returns a new Balance object with the correct amount' do
+        expect(subject.amount).to eq(amount / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC))
+      end
+
+      it 'returns a new Balance object with the correct asset_id' do
+        expect(subject.asset_id).to eq(asset_id)
+      end
+    end
+
+    context 'when the asset is :weth' do
+      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'WETH') }
+      let(:asset_id) { :weth }
+
+      it 'returns a new Balance object with the correct amount' do
+        expect(subject.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+      end
+
+      it 'returns a new Balance object with the correct asset_id' do
+        expect(subject.asset_id).to eq(asset_id)
+      end
+    end
+
+    context 'when the asset is another asset type' do
+      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'OTHER') }
+      let(:asset_id) { :other }
+
+      it 'returns a new Balance object with the correct amount' do
+        expect(subject.amount).to eq(amount)
+      end
+
+      it 'returns a new Balance object with the correct asset_id' do
+        expect(subject.asset_id).to eq(asset_id)
+      end
+    end
+  end
+
   describe '#initialize' do
     let(:amount) { BigDecimal('123.0') }
     let(:asset_id) { :eth }

--- a/spec/unit/coinbase/user_spec.rb
+++ b/spec/unit/coinbase/user_spec.rb
@@ -6,7 +6,7 @@ describe Coinbase::User do
   let(:wallets_api) { instance_double(Coinbase::Client::WalletsApi) }
   let(:addresses_api) { instance_double(Coinbase::Client::AddressesApi) }
   let(:transfers_api) { instance_double(Coinbase::Client::TransfersApi) }
-  let(:user) { described_class.new(model) }
+  subject(:user) { described_class.new(model) }
 
   describe '#id' do
     it 'returns the user ID' do
@@ -271,7 +271,7 @@ describe Coinbase::User do
       wallet = wallets[wallet_id]
       expect(wallet).not_to be_nil
       expect(wallet.id).to eq(wallet_id)
-      expect(wallet.default_address.address_id).to eq(address_model.address_id)
+      expect(wallet.default_address.id).to eq(address_model.address_id)
     end
 
     it 'throws an error when the backup file is absent' do
@@ -324,6 +324,16 @@ describe Coinbase::User do
       expect do
         user.load_wallets
       end.to raise_error(ArgumentError, 'Malformed encrypted seed data')
+    end
+  end
+
+  describe '#inspect' do
+    it 'includes user details' do
+      expect(user.inspect).to include(user_id)
+    end
+
+    it 'returns the same value as to_s' do
+      expect(user.inspect).to eq(user.to_s)
     end
   end
 end

--- a/spec/unit/coinbase/user_spec.rb
+++ b/spec/unit/coinbase/user_spec.rb
@@ -107,7 +107,7 @@ describe Coinbase::User do
     end
 
     it 'loads the wallet addresses' do
-      expect(imported_wallet.list_addresses.length).to eq(address_list_model.total_count)
+      expect(imported_wallet.addresses.length).to eq(address_list_model.total_count)
     end
 
     it 'contains the same seed when re-exported' do

--- a/spec/unit/coinbase/user_spec.rb
+++ b/spec/unit/coinbase/user_spec.rb
@@ -5,12 +5,12 @@ describe Coinbase::User do
   let(:model) { Coinbase::Client::User.new({ 'id': user_id }) }
   let(:wallets_api) { instance_double(Coinbase::Client::WalletsApi) }
   let(:addresses_api) { instance_double(Coinbase::Client::AddressesApi) }
-  let(:user) { described_class.new(model) }
   let(:transfers_api) { instance_double(Coinbase::Client::TransfersApi) }
+  let(:user) { described_class.new(model) }
 
-  describe '#user_id' do
+  describe '#id' do
     it 'returns the user ID' do
-      expect(user.user_id).to eq(user_id)
+      expect(user.id).to eq(user_id)
     end
   end
 
@@ -52,7 +52,7 @@ describe Coinbase::User do
     it 'creates a new wallet' do
       wallet = user.create_wallet
       expect(wallet).to be_a(Coinbase::Wallet)
-      expect(wallet.wallet_id).to eq(wallet_id)
+      expect(wallet.id).to eq(wallet_id)
       expect(wallet.network_id).to eq(:base_sepolia)
     end
   end
@@ -109,7 +109,7 @@ describe Coinbase::User do
     let(:initial_seed_data) { JSON.pretty_generate({}) }
     let(:expected_seed_data) do
       {
-        seed_wallet.wallet_id => {
+        seed_wallet.id => {
           seed: seed,
           encrypted: false
         }
@@ -132,7 +132,7 @@ describe Coinbase::User do
       # Verify that the file has new wallet.
       stored_seed_data = File.read(Coinbase.configuration.backup_file_path)
       wallets = JSON.parse(stored_seed_data)
-      data = wallets[seed_wallet.wallet_id]
+      data = wallets[seed_wallet.id]
       expect(data).not_to be_empty
       expect(data['encrypted']).to eq(false)
       expect(data['iv']).to eq('')
@@ -146,7 +146,7 @@ describe Coinbase::User do
       # Verify that the file has new wallet.
       stored_seed_data = File.read(Coinbase.configuration.backup_file_path)
       wallets = JSON.parse(stored_seed_data)
-      data = wallets[seed_wallet.wallet_id]
+      data = wallets[seed_wallet.id]
       expect(data).not_to be_empty
       expect(data['encrypted']).to eq(true)
       expect(data['iv']).not_to be_empty
@@ -160,7 +160,7 @@ describe Coinbase::User do
       saved_wallet = user.save_wallet(seed_wallet)
       stored_seed_data = File.read(Coinbase.configuration.backup_file_path)
       wallets = JSON.parse(stored_seed_data)
-      data = wallets[seed_wallet.wallet_id]
+      data = wallets[seed_wallet.id]
       expect(data).not_to be_empty
       expect(data['encrypted']).to eq(false)
       expect(saved_wallet).to eq(seed_wallet)
@@ -270,7 +270,7 @@ describe Coinbase::User do
       wallets = user.load_wallets
       wallet = wallets[wallet_id]
       expect(wallet).not_to be_nil
-      expect(wallet.wallet_id).to eq(wallet_id)
+      expect(wallet.id).to eq(wallet_id)
       expect(wallet.default_address.address_id).to eq(address_model.address_id)
     end
 

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -138,7 +138,7 @@ describe Coinbase::Wallet do
     end
   end
 
-  describe '#list_balances' do
+  describe '#balances' do
     let(:response) do
       Coinbase::Client::AddressBalanceList.new(
         'data' => [
@@ -170,11 +170,11 @@ describe Coinbase::Wallet do
     end
 
     it 'returns a hash with an ETH and USDC balance' do
-      expect(@wallet.list_balances).to eq({ eth: BigDecimal(1), usdc: BigDecimal(5) })
+      expect(@wallet.balances).to eq({ eth: BigDecimal(1), usdc: BigDecimal(5) })
     end
   end
 
-  describe '#get_balance' do
+  describe '#balance' do
     let(:response) do
       Coinbase::Client::Balance.new(
         {
@@ -193,15 +193,15 @@ describe Coinbase::Wallet do
     end
 
     it 'returns the correct ETH balance' do
-      expect(@wallet.get_balance(:eth)).to eq(BigDecimal(5))
+      expect(@wallet.balance(:eth)).to eq(BigDecimal(5))
     end
 
     it 'returns the correct Gwei balance' do
-      expect(@wallet.get_balance(:gwei)).to eq(BigDecimal(5 * Coinbase::GWEI_PER_ETHER))
+      expect(@wallet.balance(:gwei)).to eq(BigDecimal(5 * Coinbase::GWEI_PER_ETHER))
     end
 
     it 'returns the correct Wei balance' do
-      expect(@wallet.get_balance(:wei)).to eq(BigDecimal(5 * Coinbase::WEI_PER_ETHER))
+      expect(@wallet.balance(:wei)).to eq(BigDecimal(5 * Coinbase::WEI_PER_ETHER))
     end
   end
 

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -312,4 +312,14 @@ describe Coinbase::Wallet do
       end
     end
   end
+
+  describe '#inspect' do
+    it 'includes wallet details' do
+      expect(wallet.inspect).to include(wallet_id, Coinbase.to_sym(network_id).to_s, address_model.address_id)
+    end
+
+    it 'returns the same value as to_s' do
+      expect(wallet.inspect).to eq(wallet.to_s)
+    end
+  end
 end

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -80,7 +80,7 @@ describe Coinbase::Wallet do
 
       it 'initializes a new Wallet with the provided address count' do
         expect(addresses_api).to receive(:get_address).exactly(address_count).times
-        expect(address_wallet.list_addresses.length).to eq(address_count)
+        expect(address_wallet.addresses.length).to eq(address_count)
       end
     end
   end
@@ -110,31 +110,31 @@ describe Coinbase::Wallet do
         .exactly(1).times
       address = @wallet.create_address
       expect(address).to be_a(Coinbase::Address)
-      expect(@wallet.list_addresses.length).to eq(2)
+      expect(@wallet.addresses.length).to eq(2)
       expect(address).not_to eq(@wallet.default_address)
     end
   end
 
   describe '#default_address' do
     it 'returns the first address' do
-      expect(@wallet.default_address).to eq(@wallet.list_addresses.first)
+      expect(@wallet.default_address).to eq(@wallet.addresses.first)
     end
   end
 
-  describe '#get_address' do
+  describe '#address' do
     before do
       allow(addresses_api).to receive(:create_address).and_return(address_model)
     end
 
     it 'returns the correct address' do
       default_address = @wallet.default_address
-      expect(@wallet.get_address(default_address.address_id)).to eq(default_address)
+      expect(@wallet.address(default_address.address_id)).to eq(default_address)
     end
   end
 
-  describe '#list_addresses' do
+  describe '#addresses' do
     it 'contains one address' do
-      expect(@wallet.list_addresses.length).to eq(1)
+      expect(@wallet.addresses.length).to eq(1)
     end
   end
 
@@ -266,9 +266,9 @@ describe Coinbase::Wallet do
     it 'allows for re-creation of a Wallet' do
       wallet_data = seed_wallet.export
       new_wallet = described_class.new(model, seed: wallet_data.seed, address_count: address_count)
-      expect(new_wallet.list_addresses.length).to eq(address_count)
-      new_wallet.list_addresses.each_with_index do |address, i|
-        expect(address.address_id).to eq(seed_wallet.list_addresses[i].address_id)
+      expect(new_wallet.addresses.length).to eq(address_count)
+      new_wallet.addresses.each_with_index do |address, i|
+        expect(address.address_id).to eq(seed_wallet.addresses[i].address_id)
       end
     end
   end


### PR DESCRIPTION
### What changed? Why?

This renames some methods to be more idiomatic, e.g. `address.list_balances` => `address.balances`.

This also moves the responsibility of some logic into the class that best represents the domain of that behavior.

* Wallet Import
  * `user.import_wallet` => `Coinbase::Wallet.import` (the helper still exists, but logic belongs to Wallet).
* Balance Map
  * `Coinbase.to_balance_map` => `Coinbase::BalanceMap.from_balances`
* Asset denomination handling
  * Logic existed at the wallet and address layer now belongs to `Asset`.
* Coinbase::Balance handles parsing client balances and converting them to the write asset using the asset class methods.
* `address.list_transfer_ids` => `address.transfers`.
* Change ID methods to not stutter
  * `user.user_id` => `user.id`
  * `wallet.wallet_id` => `wallet.id`
  * `address.address_id` => `address.id`


TODO:
* Move asset and amount manipulation to the backend. Supporting gwei and wei and taking an argument to indicate if we're passing `whole` or `atomic` units will allow us to not have to do any of this logic client side.
* Move wallet creation logic out of `Wallet.new` so we can leverage wallets in a state where we do not need a seed to be imported.
  * This enables us to add user.wallets or Coinbase::Wallet.list that returns a set of wallets

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->

This contains some breaking changes from v0.0.3.