### PR TITLE
[chore] Enable E2E spec to run against different api urls

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -24,4 +24,4 @@ jobs:
         API_KEY_NAME: ${{ secrets.API_KEY_NAME }}
         API_KEY_PRIVATE_KEY: ${{ secrets.API_KEY_PRIVATE_KEY }}
         WALLET_DATA: ${{ secrets.WALLET_DATA }}
-      run: bundle exec rspec spec/e2e/production.rb
+      run: bundle exec rspec spec/e2e/end_to_end.rb

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -4,15 +4,20 @@ require 'dotenv'
 Dotenv.load
 
 describe Coinbase do
-  describe 'v0.0.2 SDK' do
+  describe 'v0.0.4 SDK' do
     it 'behaves as expected' do
       # GitHub secrets truncate newlines as whitespace, so we need to replace them.
       # See https://github.com/github/docs/issues/14207
       api_key_name = ENV['API_KEY_NAME'].gsub('\n', "\n")
       api_key_private_key = ENV['API_KEY_PRIVATE_KEY'].gsub('\n', "\n")
+
+      # Use default API URL if not provided
+      api_url = ENV['API_URL']
+
       Coinbase.configure do |config|
         config.api_key_name = api_key_name
         config.api_key_private_key = api_key_private_key
+        config.api_url = api_url if api_url
       end
 
       puts 'Fetching default user...'


### PR DESCRIPTION

### What changed? Why?
This enables the E2E spec to run against different api urls by taking an optional `API_URL` environment variable. When omitted it will use the default api url.

This will allow end to end testing against production and non-production environments.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
This only impacts tests and does not make changes to the actual gem