### PR TITLE
Support configuring client scheme via API URL

### DIFF
--- a/lib/coinbase/middleware.rb
+++ b/lib/coinbase/middleware.rb
@@ -12,8 +12,11 @@ module Coinbase
     # Returns the default middleware configuration for the Coinbase SDK.
     def self.config
       Coinbase::Client::Configuration.default.tap do |config|
+        uri = URI(Coinbase.configuration.api_url)
+
         config.debugging = Coinbase.configuration.debug_api
-        config.host = Coinbase.configuration.api_url
+        config.host = uri.host + (uri.port ? ":#{uri.port}" : '')
+        config.scheme = uri.scheme if uri.scheme
         config.request(:authenticator)
       end
     end


### PR DESCRIPTION
### What changed? Why?
This supports configuring the underlying OpenAPI REST HTTP client scheme (i.e. `http` or `https`) via the already configured API URL.

This will enable us to configure the SDK to run against the backend locally in E2E regression tests.

Note: The OpenAPI client library only strips the `https` scheme from the `host`, but by default the host should omit the scheme.

In order to support this we explicitly set the `host` and optionally include the `port` only if specified.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->

If developers are configuring API URL's without a protocol then the scheme could