### PR TITLE
[chore] Run unit tests against various ruby versions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,6 +5,9 @@ on: [pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', head]
 
     steps:
     - uses: actions/checkout@v2
@@ -12,12 +15,8 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
-
-    - name: Install dependencies
-      run: |
-        gem install bundler -v 2.4.22
-        bundle install --jobs 4 --retry 3
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
 
     - name: Run unit tests
       run: bundle exec rake test

--- a/coinbase.gemspec
+++ b/coinbase.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 
+  spec.add_runtime_dependency 'bigdecimal'
   spec.add_runtime_dependency 'eth'
   spec.add_runtime_dependency 'faraday'
   spec.add_runtime_dependency 'faraday-multipart'

--- a/lib/coinbase/user.rb
+++ b/lib/coinbase/user.rb
@@ -22,8 +22,12 @@ module Coinbase
     # Creates a new Wallet belonging to the User.
     # @param network_id [String] (Optional) the ID of the blockchain network. Defaults to 'base-sepolia'.
     # @return [Coinbase::Wallet] the new Wallet
-    def create_wallet(**create_wallet_options)
-      Wallet.create(create_wallet_options)
+    def create_wallet(create_wallet_options = {})
+      # For ruby 2.7 compatibility we cannot pass in keyword args when the create wallet
+      # options is empty
+      return Wallet.create if create_wallet_options.empty?
+
+      Wallet.create(**create_wallet_options)
     end
 
     # Imports a Wallet belonging to the User.

--- a/spec/unit/coinbase/user_spec.rb
+++ b/spec/unit/coinbase/user_spec.rb
@@ -20,7 +20,7 @@ describe Coinbase::User do
 
     context 'when called with no arguments' do
       before do
-        allow(Coinbase::Wallet).to receive(:create).with({}).and_return(wallet)
+        allow(Coinbase::Wallet).to receive(:create).with(no_args).and_return(wallet)
       end
 
       it 'creates a new wallet' do


### PR DESCRIPTION
### What changed? Why?
This runs our unit tests against the ruby versions going back to the latest one we support (`2.7`).

This explicitly adds `bigdecimal` as a runtime dependency as it is no longer bundled with ruby as of 3.4


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->