### PR TITLE
[chore] Refactor wallet creation

### DIFF
--- a/lib/coinbase/user.rb
+++ b/lib/coinbase/user.rb
@@ -20,21 +20,10 @@ module Coinbase
     end
 
     # Creates a new Wallet belonging to the User.
+    # @param network_id [String] (Optional) the ID of the blockchain network. Defaults to 'base-sepolia'.
     # @return [Coinbase::Wallet] the new Wallet
-    def create_wallet
-      create_wallet_request = {
-        wallet: {
-          # TODO: Don't hardcode this.
-          network_id: 'base-sepolia'
-        }
-      }
-      opts = { create_wallet_request: create_wallet_request }
-
-      model = Coinbase.call_api do
-        wallets_api.create_wallet(opts)
-      end
-
-      Wallet.new(model)
+    def create_wallet(**create_wallet_options)
+      Wallet.create(create_wallet_options)
     end
 
     # Imports a Wallet belonging to the User.

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -6,22 +6,35 @@ describe Coinbase::Wallet do
   let(:network_id) { 'base-sepolia' }
   let(:model) { Coinbase::Client::Wallet.new({ 'id': wallet_id, 'network_id': network_id }) }
   let(:address_model1) do
-    Coinbase::Client::Address.new({
-                                    'address_id': '0xfbd9D61057eC1debCeEE12C62812Fb3E1d025201',
-                                    'wallet_id': wallet_id,
-                                    'public_key': '0x1234567890',
-                                    'network_id': network_id
-                                  })
+    Coinbase::Client::Address.new(
+      {
+        'address_id': '0x919538116b4F25f1CE01429fd9Ed7964556bf565',
+        'wallet_id': wallet_id,
+        'public_key': '0292df2f2c31a5c4b0d4946e922cc3bd25ad7196ffeb049905b0952b9ac48ef25f',
+        'network_id': network_id
+      }
+    )
+  end
+  let(:address_model2) do
+    Coinbase::Client::Address.new(
+      {
+        'address_id': '0xf23692a9DE556Ee1711b172Bf744C5f33B13DC89',
+        'wallet_id': wallet_id,
+        'public_key': '034ecbfc86f7447c8bfd1a5f71b13600d767ccb58d290c7b146632090f3a05c66c',
+        'network_id': network_id
+      }
+    )
   end
   let(:model_with_default_address) do
     Coinbase::Client::Wallet.new(
       {
         'id': wallet_id,
-        'network_id': 'base-sepolia',
+        'network_id': network_id,
         'default_address': address_model1
       }
     )
   end
+  let(:seed) { '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' }
   let(:wallets_api) { double('Coinbase::Client::WalletsApi') }
   let(:addresses_api) { double('Coinbase::Client::AddressesApi') }
   let(:transfers_api) { double('Coinbase::Client::TransfersApi') }
@@ -31,24 +44,24 @@ describe Coinbase::Wallet do
   before do
     allow(Coinbase::Client::AddressesApi).to receive(:new).and_return(addresses_api)
     allow(Coinbase::Client::WalletsApi).to receive(:new).and_return(wallets_api)
-    allow(addresses_api).to receive(:create_address).and_return(address_model1)
-    allow(addresses_api).to receive(:get_address).and_return(address_model1)
-    allow(wallets_api).to receive(:get_wallet).with(wallet_id).and_return(model_with_default_address)
   end
 
-  describe '#import' do
+  describe '.import' do
     let(:client) { double('Jimson::Client') }
     let(:wallet_id) { SecureRandom.uuid }
-    let(:wallet_model) { Coinbase::Client::Wallet.new({ 'id': wallet_id, 'network_id': 'base-sepolia' }) }
-    let(:create_wallet_request) { { wallet: { network_id: network_id } } }
-    let(:opts) { { create_wallet_request: create_wallet_request } }
+    let(:wallet_model) { Coinbase::Client::Wallet.new({ 'id': wallet_id, 'network_id': network_id }) }
     let(:address_list_model) do
-      Coinbase::Client::AddressList.new({ 'data' => [address_model1], 'total_count' => 1 })
+      Coinbase::Client::AddressList.new(
+        {
+          'data' => [address_model1, address_model2],
+          'total_count' => 2
+        }
+      )
     end
     let(:exported_data) do
       Coinbase::Wallet::Data.new(
         wallet_id: wallet_id,
-        seed: '86fc9fba421dcc6ad42747f14132c3cd975bd9fb1454df84ce5ea554f2542fbe'
+        seed: seed
       )
     end
     subject(:imported_wallet) { Coinbase::Wallet.import(exported_data) }
@@ -72,61 +85,124 @@ describe Coinbase::Wallet do
     it 'contains the same seed when re-exported' do
       expect(imported_wallet.export.seed).to eq(exported_data.seed)
     end
+
+    context 'when there are no addresses' do
+      let(:address_list_model) { Coinbase::Client::AddressList.new({ 'data' => [], 'total_count' => 0 }) }
+
+      it 'loads the wallet addresses' do
+        expect(imported_wallet.addresses.length).to eq(0)
+      end
+    end
+  end
+
+  describe '.create' do
+    let(:wallet_id) { SecureRandom.uuid }
+    let(:create_wallet_request) do
+      { wallet: { network_id: network_id } }
+    end
+    let(:request) { { create_wallet_request: create_wallet_request } }
+    let(:wallet_model) { Coinbase::Client::Wallet.new({ 'id': wallet_id, 'network_id': network_id }) }
+    let(:default_address_model) do
+      Coinbase::Client::Address.new(
+        {
+          'address_id': '0xdeadbeef',
+          'wallet_id': wallet_id,
+          'public_key': '0x1234567890',
+          'network_id': network_id
+        }
+      )
+    end
+
+    subject(:created_wallet) { described_class.create }
+
+    before do
+      allow(wallets_api).to receive(:create_wallet).with(request).and_return(wallet_model)
+
+      allow(addresses_api)
+        .to receive(:create_address)
+        .with(
+          wallet_id,
+          satisfy do |opts|
+            public_key_present = opts[:create_address_request][:public_key].is_a?(String)
+            attestation_present = opts[:create_address_request][:attestation].is_a?(String)
+            public_key_present && attestation_present
+          end
+        ).and_return(address_model1)
+
+      allow(wallets_api)
+        .to receive(:get_wallet)
+        .with(wallet_id)
+        .and_return(model_with_default_address)
+    end
+
+    it 'creates a new wallet' do
+      expect(created_wallet).to be_a(Coinbase::Wallet)
+    end
+
+    it 'creates a default address' do
+      expect(created_wallet.default_address).to be_a(Coinbase::Address)
+      expect(created_wallet.addresses.length).to eq(1)
+    end
+
+    context 'when setting the network ID explicitly' do
+      let(:network_id) { 'base-mainnet' }
+
+      subject(:created_wallet) do
+        described_class.create(network_id: network_id)
+      end
+
+      it 'creates a new wallet' do
+        expect(created_wallet).to be_a(Coinbase::Wallet)
+      end
+
+      it 'sets the specified network ID' do
+        expect(created_wallet.network_id).to eq(:base_mainnet)
+      end
+    end
   end
 
   describe '#initialize' do
     context 'when no seed or address models are provided' do
+      subject(:wallet) { described_class.new(model) }
+
       it 'initializes a new Wallet' do
-        expect(addresses_api)
-          .to receive(:create_address)
-          .with(wallet_id, satisfy do |opts|
-            public_key_present = opts[:create_address_request][:public_key].is_a?(String)
-            attestation_present = opts[:create_address_request][:attestation].is_a?(String)
-            public_key_present && attestation_present
-          end)
         expect(wallet).to be_a(Coinbase::Wallet)
+      end
+
+      it 'sets the model' do
+        expect(wallet.model).to eq(model)
+      end
+
+      it 'sets the master seed' do
+        expect(wallet.instance_variable_get(:@master)).to be_a(MoneyTree::Master)
+      end
+
+      it 'sets the private key index' do
+        expect(wallet.instance_variable_get(:@private_key_index)).to eq(0)
       end
     end
 
     context 'when a seed is provided' do
-      let(:seed) { '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' }
       let(:seed_wallet) { described_class.new(model, seed: seed) }
 
       it 'initializes a new Wallet with the provided seed' do
-        expect(addresses_api)
-          .to receive(:create_address)
-          .with(wallet_id, satisfy do |opts|
-            public_key_present = opts[:create_address_request][:public_key].is_a?(String)
-            attestation_present = opts[:create_address_request][:attestation].is_a?(String)
-            public_key_present && attestation_present
-          end)
-          .and_return(address_model1)
         expect(seed_wallet).to be_a(Coinbase::Wallet)
       end
 
-      it 'raises an error for an invalid seed' do
-        expect do
-          described_class.new(model, seed: 'invalid')
-        end.to raise_error(ArgumentError, 'Seed must be 32 bytes')
+      context 'when the seed is invalid' do
+        let(:seed) { 'invalid' }
+
+        it 'raises an error for an invalid seed' do
+          expect { seed_wallet }.to raise_error(ArgumentError, 'Seed must be 32 bytes')
+        end
       end
     end
 
     context 'when only the address models are provided' do
-      let(:address_model2) do
-        Coinbase::Client::Address.new({
-                                        'address_id': '0x945F8F802Ec6d7fc69E417B93609A51E100a25FE',
-                                        'wallet_id': wallet_id,
-                                        'public_key': '0xabcd',
-                                        'network_id': network_id
-                                      })
-      end
-      let(:address_wallet) do
-      end
-
-      it 'initializes a new Wallet with the provided address models' do
+      it 'raises an error' do
         expect do
           described_class.new(model, address_models: [address_model1, address_model2])
-        end.to raise_error(ArgumentError)
+        end.to raise_error(ArgumentError, 'Seed must be present if address_models are provided')
       end
     end
 
@@ -139,7 +215,7 @@ describe Coinbase::Wallet do
     end
 
     context 'when the seed is empty and no address models are provided' do
-      it 'throws an error' do
+      it 'raises an error' do
         expect do
           described_class.new(model, seed: '')
         end.to raise_error(ArgumentError, 'Seed must be empty if address_models are not provided')
@@ -165,7 +241,7 @@ describe Coinbase::Wallet do
     end
 
     it 'sets the seed' do
-      seedless_wallet.seed = '86fc9fba421dcc6ad42747f14132c3cd975bd9fb1454df84ce5ea554f2542fbe'
+      seedless_wallet.seed = seed
       expect(seedless_wallet.can_sign?).to be true
       expect(seedless_wallet.default_address.can_sign?).to be true
     end
@@ -178,7 +254,7 @@ describe Coinbase::Wallet do
 
     it 'raises an error if the wallet is already hydrated' do
       expect do
-        wallet.seed = '86fc9fba421dcc6ad42747f14132c3cd975bd9fb1454df84ce5ea554f2542fbe'
+        wallet.seed = seed
       end.to raise_error('Seed is already set')
     end
 
@@ -190,23 +266,67 @@ describe Coinbase::Wallet do
   end
 
   describe '#create_address' do
-    it 'creates a new address' do
-      expect(wallet.addresses.length).to eq(1)
+    let(:expected_public_key) { created_address_model.public_key }
 
-      expect(addresses_api)
+    let(:wallet) do
+      described_class.new(model, seed: seed)
+    end
+
+    subject(:created_address) { wallet.create_address }
+
+    before do
+      allow(addresses_api)
         .to receive(:create_address)
-        .with(wallet_id, satisfy do |opts|
-          public_key_present = opts[:create_address_request][:public_key].is_a?(String)
-          attestation_present = opts[:create_address_request][:attestation].is_a?(String)
-          public_key_present && attestation_present
-        end)
-        .and_return(address_model1)
-        .exactly(1).times
+        .with(
+          wallet_id,
+          satisfy do |req|
+            public_key = req[:create_address_request][:public_key]
+            attestation = req[:create_address_request][:attestation]
 
-      address = wallet.create_address
-      expect(address).to be_a(Coinbase::Address)
-      expect(wallet.addresses.length).to eq(2)
-      expect(address).not_to eq(wallet.default_address)
+            public_key == expected_public_key && attestation.is_a?(String)
+          end
+        ).and_return(created_address_model)
+    end
+
+    context 'when no addresses exist' do
+      let(:created_address_model) { address_model1 }
+
+      before do
+        allow(wallets_api)
+          .to receive(:get_wallet)
+          .with(wallet_id)
+          .and_return(model_with_default_address)
+      end
+
+      it 'creates a new address' do
+        expect(created_address).to be_a(Coinbase::Address)
+      end
+
+      it 'reloads the wallet with the new default address' do
+        expect(created_address).to eq(wallet.default_address)
+      end
+    end
+
+    context 'when an address already exists', focus: true do
+      let(:created_address_model) { address_model2 }
+
+      let(:wallet) do
+        described_class.new(model_with_default_address, seed: seed, address_models: [address_model1])
+      end
+
+      before { created_address }
+
+      it 'creates a new address' do
+        expect(created_address).to be_a(Coinbase::Address)
+      end
+
+      it 'updates the address count' do
+        expect(wallet.addresses.length).to eq(2)
+      end
+
+      it 'is not sets as the default address' do
+        expect(created_address).not_to eq(wallet.default_address)
+      end
     end
   end
 
@@ -217,19 +337,29 @@ describe Coinbase::Wallet do
   end
 
   describe '#address' do
-    before do
-      allow(addresses_api).to receive(:create_address).and_return(address_model1)
+    let(:address_models) { [address_model1, address_model2] }
+    let(:wallet) do
+      described_class.new(model, seed: '', address_models: address_models)
     end
+    subject(:address) { wallet.address(address_model2.address_id) }
 
     it 'returns the correct address' do
-      default_address = wallet.default_address
-      expect(wallet.address(default_address.id)).to eq(default_address)
+      expect(address).to be_a(Coinbase::Address)
+      expect(address.id).to eq(address_model2.address_id)
     end
   end
 
   describe '#addresses' do
-    it 'contains one address' do
-      expect(wallet.addresses.length).to eq(1)
+    let(:address_models) { [address_model1, address_model2] }
+    subject(:wallet) do
+      described_class.new(model, seed: '', address_models: address_models)
+    end
+
+    it 'returns an address for each address model' do
+      expect(wallet.addresses.length).to eq(2)
+      expect(wallet.addresses.each_with_index.all? do |address, i|
+        address.id == address_models[i].address_id
+      end).to be true
     end
   end
 
@@ -304,13 +434,33 @@ describe Coinbase::Wallet do
     let(:transfer) { double('Coinbase::Transfer') }
     let(:amount) { 5 }
     let(:asset_id) { :eth }
+    let(:other_wallet) do
+      described_class.new(
+        Coinbase::Client::Wallet.new(
+          {
+            'id': wallet_id,
+            'network_id': 'base-sepolia',
+            'default_address': address_model2
+          }
+        ),
+        seed: '',
+        address_models: [address_model2]
+      )
+    end
+
+    subject(:wallet) do
+      described_class.new(model_with_default_address, seed: '', address_models: [address_model1])
+    end
 
     context 'when the destination is a Wallet' do
-      let(:destination) { described_class.new(model) }
+      let(:destination) { other_wallet }
       let(:to_address_id) { destination.default_address.id }
 
       before do
-        expect(wallet.default_address).to receive(:transfer).with(amount, asset_id, to_address_id).and_return(transfer)
+        allow(wallet.default_address)
+          .to receive(:transfer)
+          .with(amount, asset_id, to_address_id)
+          .and_return(transfer)
       end
 
       it 'creates a transfer to the default address ID' do
@@ -319,11 +469,14 @@ describe Coinbase::Wallet do
     end
 
     context 'when the desination is an Address' do
-      let(:destination) { wallet.create_address }
+      let(:destination) { other_wallet.default_address }
       let(:to_address_id) { destination.id }
 
       before do
-        expect(wallet.default_address).to receive(:transfer).with(amount, asset_id, to_address_id).and_return(transfer)
+        allow(wallet.default_address)
+          .to receive(:transfer)
+          .with(amount, asset_id, to_address_id)
+          .and_return(transfer)
       end
 
       it 'creates a transfer to the address ID' do
@@ -335,7 +488,10 @@ describe Coinbase::Wallet do
       let(:destination) { '0x1234567890' }
 
       before do
-        expect(wallet.default_address).to receive(:transfer).with(amount, asset_id, destination).and_return(transfer)
+        allow(wallet.default_address)
+          .to receive(:transfer)
+          .with(amount, asset_id, destination)
+          .and_return(transfer)
       end
 
       it 'creates a transfer to the address ID' do
@@ -345,23 +501,6 @@ describe Coinbase::Wallet do
   end
 
   describe '#export' do
-    let(:seed) { '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' }
-    let(:address_model1) do
-      Coinbase::Client::Address.new({
-                                      'address_id': '0xf23692a9DE556Ee1711b172Bf744C5f33B13DC89',
-                                      'wallet_id': wallet_id,
-                                      'public_key': '0xabcd',
-                                      'network_id': network_id
-                                    })
-    end
-    let(:address_model2) do
-      Coinbase::Client::Address.new({
-                                      'address_id': '0x919538116b4F25f1CE01429fd9Ed7964556bf565',
-                                      'wallet_id': wallet_id,
-                                      'public_key': '0xefgh',
-                                      'network_id': network_id
-                                    })
-    end
     let(:seed_wallet) do
       described_class.new(model, seed: seed, address_models: [address_model1, address_model2])
     end
@@ -386,21 +525,25 @@ describe Coinbase::Wallet do
 
   describe '#faucet' do
     let(:faucet_transaction_model) do
-      Coinbase::Client::FaucetTransaction.new({
-                                                'transaction_hash': '0x123456789'
-                                              })
+      Coinbase::Client::FaucetTransaction.new({ 'transaction_hash': '0x123456789' })
     end
+    let(:wallet) do
+      described_class.new(model_with_default_address, seed: '', address_models: [address_model1])
+    end
+    subject(:faucet_transaction) { wallet.faucet }
 
     before do
-      expect(addresses_api)
+      allow(addresses_api)
         .to receive(:request_faucet_funds)
         .with(wallet_id, address_model1.address_id)
         .and_return(faucet_transaction_model)
     end
 
     it 'returns the faucet transaction' do
-      faucet_transaction = wallet.faucet
       expect(faucet_transaction).to be_a(Coinbase::FaucetTransaction)
+    end
+
+    it 'contains the transaction hash' do
       expect(faucet_transaction.transaction_hash).to eq(faucet_transaction_model.transaction_hash)
     end
   end
@@ -410,19 +553,32 @@ describe Coinbase::Wallet do
       expect(wallet.can_sign?).to be true
     end
 
-    it 'returns false if the wallet is not hydrated' do
-      wallet = described_class.new(model, seed: '', address_models: [address_model1])
-      expect(wallet.can_sign?).to be false
+    context 'when the wallet is not hydrated' do
+      subject(:wallet) { described_class.new(model, seed: '', address_models: [address_model1]) }
+
+      it 'returns false' do
+        expect(wallet.can_sign?).to be false
+      end
     end
   end
 
   describe '#inspect' do
     it 'includes wallet details' do
-      expect(wallet.inspect).to include(wallet_id, Coinbase.to_sym(network_id).to_s, address_model1.address_id)
+      expect(wallet.inspect).to include(wallet_id, Coinbase.to_sym(network_id).to_s)
     end
 
     it 'returns the same value as to_s' do
       expect(wallet.inspect).to eq(wallet.to_s)
+    end
+
+    context 'when the model has a default address' do
+      subject(:wallet) do
+        described_class.new(model_with_default_address, seed: '', address_models: [address_model1])
+      end
+
+      it 'includes the default address' do
+        expect(wallet.inspect).to include(address_model1.address_id)
+      end
     end
   end
 end


### PR DESCRIPTION

### What changed? Why?
This moves wallet creation into a wallet class method and splits out default address creation from the initializer. This makes it so that the initializer is just intitializing and fetching resources and not actually mutating things.

When we create the wallet initially we will create the default address, but we don't need that code path for every single initialize call.

This also adds dynamic network support as the backend is keeping the source of truth for supported networks.

This also updates the tests so that we're loading / importing wallets for most scenarios.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->

This touches the `user.create_wallet` flow, so wallet creation could break.