### PR TITLE
make create_wallet to wait for seed creation when using signer

### DIFF
--- a/lib/coinbase/client/models/signature_creation_event.rb
+++ b/lib/coinbase/client/models/signature_creation_event.rb
@@ -25,6 +25,9 @@ module Coinbase::Client
     # The ID of the user that the wallet belongs to
     attr_accessor :wallet_user_id
 
+    # The ID of the address the transfer belongs to
+    attr_accessor :address_id
+
     # The index of the address that the server-signer should sign with
     attr_accessor :address_index
 
@@ -64,6 +67,7 @@ module Coinbase::Client
         :'seed_id' => :'seed_id',
         :'wallet_id' => :'wallet_id',
         :'wallet_user_id' => :'wallet_user_id',
+        :'address_id' => :'address_id',
         :'address_index' => :'address_index',
         :'signing_payload' => :'signing_payload',
         :'transaction_type' => :'transaction_type',
@@ -82,6 +86,7 @@ module Coinbase::Client
         :'seed_id' => :'String',
         :'wallet_id' => :'String',
         :'wallet_user_id' => :'String',
+        :'address_id' => :'String',
         :'address_index' => :'Integer',
         :'signing_payload' => :'String',
         :'transaction_type' => :'TransactionType',
@@ -128,6 +133,12 @@ module Coinbase::Client
         self.wallet_user_id = nil
       end
 
+      if attributes.key?(:'address_id')
+        self.address_id = attributes[:'address_id']
+      else
+        self.address_id = nil
+      end
+
       if attributes.key?(:'address_index')
         self.address_index = attributes[:'address_index']
       else
@@ -170,6 +181,10 @@ module Coinbase::Client
         invalid_properties.push('invalid value for "wallet_user_id", wallet_user_id cannot be nil.')
       end
 
+      if @address_id.nil?
+        invalid_properties.push('invalid value for "address_id", address_id cannot be nil.')
+      end
+
       if @address_index.nil?
         invalid_properties.push('invalid value for "address_index", address_index cannot be nil.')
       end
@@ -196,6 +211,7 @@ module Coinbase::Client
       return false if @seed_id.nil?
       return false if @wallet_id.nil?
       return false if @wallet_user_id.nil?
+      return false if @address_id.nil?
       return false if @address_index.nil?
       return false if @signing_payload.nil?
       return false if @transaction_type.nil?
@@ -211,6 +227,7 @@ module Coinbase::Client
           seed_id == o.seed_id &&
           wallet_id == o.wallet_id &&
           wallet_user_id == o.wallet_user_id &&
+          address_id == o.address_id &&
           address_index == o.address_index &&
           signing_payload == o.signing_payload &&
           transaction_type == o.transaction_type &&
@@ -226,7 +243,7 @@ module Coinbase::Client
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [seed_id, wallet_id, wallet_user_id, address_index, signing_payload, transaction_type, transaction_id].hash
+      [seed_id, wallet_id, wallet_user_id, address_id, address_index, signing_payload, transaction_type, transaction_id].hash
     end
 
     # Builds the object from hash

--- a/lib/coinbase/client/models/signature_creation_event_result.rb
+++ b/lib/coinbase/client/models/signature_creation_event_result.rb
@@ -22,6 +22,9 @@ module Coinbase::Client
     # The ID of the user that the wallet belongs to
     attr_accessor :wallet_user_id
 
+    # The ID of the address the transfer belongs to
+    attr_accessor :address_id
+
     attr_accessor :transaction_type
 
     # The ID of the transaction that the Server-Signer has signed for
@@ -57,6 +60,7 @@ module Coinbase::Client
       {
         :'wallet_id' => :'wallet_id',
         :'wallet_user_id' => :'wallet_user_id',
+        :'address_id' => :'address_id',
         :'transaction_type' => :'transaction_type',
         :'transaction_id' => :'transaction_id',
         :'signature' => :'signature'
@@ -73,6 +77,7 @@ module Coinbase::Client
       {
         :'wallet_id' => :'String',
         :'wallet_user_id' => :'String',
+        :'address_id' => :'String',
         :'transaction_type' => :'TransactionType',
         :'transaction_id' => :'String',
         :'signature' => :'String'
@@ -112,6 +117,12 @@ module Coinbase::Client
         self.wallet_user_id = nil
       end
 
+      if attributes.key?(:'address_id')
+        self.address_id = attributes[:'address_id']
+      else
+        self.address_id = nil
+      end
+
       if attributes.key?(:'transaction_type')
         self.transaction_type = attributes[:'transaction_type']
       else
@@ -144,6 +155,10 @@ module Coinbase::Client
         invalid_properties.push('invalid value for "wallet_user_id", wallet_user_id cannot be nil.')
       end
 
+      if @address_id.nil?
+        invalid_properties.push('invalid value for "address_id", address_id cannot be nil.')
+      end
+
       if @transaction_type.nil?
         invalid_properties.push('invalid value for "transaction_type", transaction_type cannot be nil.')
       end
@@ -165,6 +180,7 @@ module Coinbase::Client
       warn '[DEPRECATED] the `valid?` method is obsolete'
       return false if @wallet_id.nil?
       return false if @wallet_user_id.nil?
+      return false if @address_id.nil?
       return false if @transaction_type.nil?
       return false if @transaction_id.nil?
       return false if @signature.nil?
@@ -178,6 +194,7 @@ module Coinbase::Client
       self.class == o.class &&
           wallet_id == o.wallet_id &&
           wallet_user_id == o.wallet_user_id &&
+          address_id == o.address_id &&
           transaction_type == o.transaction_type &&
           transaction_id == o.transaction_id &&
           signature == o.signature
@@ -192,7 +209,7 @@ module Coinbase::Client
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [wallet_id, wallet_user_id, transaction_type, transaction_id, signature].hash
+      [wallet_id, wallet_user_id, address_id, transaction_type, transaction_id, signature].hash
     end
 
     # Builds the object from hash

--- a/lib/coinbase/client/models/wallet.rb
+++ b/lib/coinbase/client/models/wallet.rb
@@ -23,12 +23,38 @@ module Coinbase::Client
 
     attr_accessor :default_address
 
+    # The status of the Server-Signer for the wallet if present.
+    attr_accessor :server_signer_status
+
+    class EnumAttributeValidator
+      attr_reader :datatype
+      attr_reader :allowable_values
+
+      def initialize(datatype, allowable_values)
+        @allowable_values = allowable_values.map do |value|
+          case datatype.to_s
+          when /Integer/i
+            value.to_i
+          when /Float/i
+            value.to_f
+          else
+            value
+          end
+        end
+      end
+
+      def valid?(value)
+        !value || allowable_values.include?(value)
+      end
+    end
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'id' => :'id',
         :'network_id' => :'network_id',
-        :'default_address' => :'default_address'
+        :'default_address' => :'default_address',
+        :'server_signer_status' => :'server_signer_status'
       }
     end
 
@@ -42,7 +68,8 @@ module Coinbase::Client
       {
         :'id' => :'String',
         :'network_id' => :'String',
-        :'default_address' => :'Address'
+        :'default_address' => :'Address',
+        :'server_signer_status' => :'String'
       }
     end
 
@@ -82,6 +109,10 @@ module Coinbase::Client
       if attributes.key?(:'default_address')
         self.default_address = attributes[:'default_address']
       end
+
+      if attributes.key?(:'server_signer_status')
+        self.server_signer_status = attributes[:'server_signer_status']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -106,7 +137,19 @@ module Coinbase::Client
       warn '[DEPRECATED] the `valid?` method is obsolete'
       return false if @id.nil?
       return false if @network_id.nil?
+      server_signer_status_validator = EnumAttributeValidator.new('String', ["pending_seed_creation", "active_seed"])
+      return false unless server_signer_status_validator.valid?(@server_signer_status)
       true
+    end
+
+    # Custom attribute writer method checking allowed values (enum).
+    # @param [Object] server_signer_status Object to be assigned
+    def server_signer_status=(server_signer_status)
+      validator = EnumAttributeValidator.new('String', ["pending_seed_creation", "active_seed"])
+      unless validator.valid?(server_signer_status)
+        fail ArgumentError, "invalid value for \"server_signer_status\", must be one of #{validator.allowable_values}."
+      end
+      @server_signer_status = server_signer_status
     end
 
     # Checks equality by comparing each attribute.
@@ -116,7 +159,8 @@ module Coinbase::Client
       self.class == o.class &&
           id == o.id &&
           network_id == o.network_id &&
-          default_address == o.default_address
+          default_address == o.default_address &&
+          server_signer_status == o.server_signer_status
     end
 
     # @see the `==` method
@@ -128,7 +172,7 @@ module Coinbase::Client
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, network_id, default_address].hash
+      [id, network_id, default_address, server_signer_status].hash
     end
 
     # Builds the object from hash

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -17,9 +17,14 @@ module Coinbase
     # The maximum number of addresses in a Wallet.
     MAX_ADDRESSES = 20
 
+    # A representation of ServerSigner status in a wallet.
     module ServerSignerStatus
+      # The Wallet is awaiting seed creation by the ServerSigner. At this point,
+      # the wallet cannot create addresses.
       PENDING_SEED_CREATION = :pending_seed_creation
 
+      # The Wallet has an associated seed created by the ServerSigner. It is ready
+      # to create addresses and sign transactions.
       ACTIVE = :active_seed
     end
 

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -47,6 +47,10 @@ module Coinbase
       end
 
       # Creates a new Wallet on the specified Network and generate a default address for it.
+      # @param interval_seconds [Integer] The interval at which to poll the CDPService if using a ServerSigner,
+      # in seconds
+      # @param timeout_seconds [Integer] The maximum amount of time to wait for the ServerSigner to
+      # create a seed for the wallet, in seconds
       # @param network_id [String] (Optional) the ID of the blockchain network. Defaults to 'base-sepolia'.
       # @param server_signer [Boolean] (Optional) whether Wallet should use project's server signer. Defaults to false.
       # @return [Coinbase::Wallet] the new Wallet
@@ -80,6 +84,11 @@ module Coinbase
 
       private
 
+      # Wait_for_signer waits until the ServerSigner has created the seed in the Wallet.
+      # Timeout::Error if the ServerSigner takes longer than the given timeout to create the seed.
+      # @param interval_seconds [Integer] The interval at which to poll the CDPService, in seconds
+      # @param timeout_seconds [Integer] The maximum amount of time to wait for the Signer to create a seed, in seconds
+      # @return [Wallet] The completed Wallet object that is ready to create addresses.
       def wait_for_signer(wallet_id, interval_seconds, timeout_seconds)
         start_time = Time.now
 
@@ -142,6 +151,8 @@ module Coinbase
       Coinbase.to_sym(@model.network_id)
     end
 
+    # Returns the ServerSigner Status of the Wallet.
+    # @return [Symbol] The ServerSigner Status
     def server_signer_status
       Coinbase.to_sym(@model.server_signer_status)
     end

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -17,10 +17,10 @@ module Coinbase
     # The maximum number of addresses in a Wallet.
     MAX_ADDRESSES = 20
 
-    # A representation of ServerSigner status in a wallet.
+    # A representation of ServerSigner status in a Wallet.
     module ServerSignerStatus
       # The Wallet is awaiting seed creation by the ServerSigner. At this point,
-      # the wallet cannot create addresses.
+      # the Wallet cannot create addresses or sign transactions.
       PENDING_SEED_CREATION = :pending_seed_creation
 
       # The Wallet has an associated seed created by the ServerSigner. It is ready
@@ -47,10 +47,10 @@ module Coinbase
       end
 
       # Creates a new Wallet on the specified Network and generate a default address for it.
-      # @param interval_seconds [Integer] The interval at which to poll the CDPService if using a ServerSigner,
-      # in seconds
+      # @param interval_seconds [Integer] The interval at which to poll the CDPService for the Wallet to
+      # have an active seed, if using a ServerSigner, in seconds
       # @param timeout_seconds [Integer] The maximum amount of time to wait for the ServerSigner to
-      # create a seed for the wallet, in seconds
+      # create a seed for the Wallet, in seconds
       # @param network_id [String] (Optional) the ID of the blockchain network. Defaults to 'base-sepolia'.
       # @param server_signer [Boolean] (Optional) whether Wallet should use project's server signer. Defaults to false.
       # @return [Coinbase::Wallet] the new Wallet
@@ -68,15 +68,15 @@ module Coinbase
 
         wallet = new(model)
 
-        # Create a default address if the Wallet is not using the server signer.
-        # When used with a server signer, the server signer must first register
-        # with the wallet before addreses can be created.
+        # Create a default address if the Wallet is not using the ServerSigner.
+        # When used with a ServerSigner, the Signer must first register
+        # with the Wallet before addresses can be created.
         unless Coinbase.use_server_signer?
           wallet.create_address
           return wallet
         end
 
-        # Wait until signer is active and create the default_address.
+        # Wait until ServerSigner is active and create the default_address.
         wait_for_signer(wallet.id, interval_seconds, timeout_seconds)
         wallet.create_address
         wallet
@@ -84,7 +84,7 @@ module Coinbase
 
       private
 
-      # Wait_for_signer waits until the ServerSigner has created the seed in the Wallet.
+      # Wait_for_signer waits until the ServerSigner has created a seed for the Wallet.
       # Timeout::Error if the ServerSigner takes longer than the given timeout to create the seed.
       # @param interval_seconds [Integer] The interval at which to poll the CDPService, in seconds
       # @param timeout_seconds [Integer] The maximum amount of time to wait for the Signer to create a seed, in seconds

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -21,7 +21,7 @@ module Coinbase
     module ServerSignerStatus
       # The Wallet is awaiting seed creation by the ServerSigner. At this point,
       # the Wallet cannot create addresses or sign transactions.
-      PENDING_SEED_CREATION = :pending_seed_creation
+      PENDING = :pending_seed_creation
 
       # The Wallet has an associated seed created by the ServerSigner. It is ready
       # to create addresses and sign transactions.
@@ -54,7 +54,7 @@ module Coinbase
       # @param network_id [String] (Optional) the ID of the blockchain network. Defaults to 'base-sepolia'.
       # @param server_signer [Boolean] (Optional) whether Wallet should use project's server signer. Defaults to false.
       # @return [Coinbase::Wallet] the new Wallet
-      def create(interval_seconds = 0.2, timeout_seconds = 20, network_id: 'base-sepolia')
+      def create(network_id: 'base-sepolia', interval_seconds: 0.2, timeout_seconds: 20)
         model = Coinbase.call_api do
           wallets_api.create_wallet(
             create_wallet_request: {

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -239,7 +239,7 @@ describe Coinbase::Wallet do
       end
 
       subject(:created_wallet) do
-        described_class.create(0.2, 0.00001)
+        described_class.create(interval_seconds: 0.2, timeout_seconds: 0.00001)
       end
 
       it 'raises a Timeout::Error' do


### PR DESCRIPTION
### What changed? Why?

Make wallet creation sync, when using ServerSigner. `create_wallet` will poll CDPService to get the updated status util the wallet is ready

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->