### PR TITLE
 support transfer with signer 

### DIFF
--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -78,7 +78,7 @@ module Coinbase
     #  default address. If a String, interprets it as the address ID.
     # @return [String] The hash of the Transfer transaction.
     def transfer(amount, asset_id, destination)
-      raise 'Cannot transfer from address without private key loaded' if @key.nil?
+      raise 'Cannot transfer from address without private key loaded' if !Coinbase.use_server_signer? && @key.nil?
 
       raise ArgumentError, "Unsupported asset: #{asset_id}" unless Coinbase::Asset.supported?(asset_id)
 
@@ -107,6 +107,9 @@ module Coinbase
       transfer_model = Coinbase.call_api do
         transfers_api.create_transfer(wallet_id, id, create_transfer_request)
       end
+
+      # Return here if ServerSigner is expected to sign the transfer.
+      return Coinbase::Transfer.new(transfer_model) if Coinbase.use_server_signer?
 
       transfer = Coinbase::Transfer.new(transfer_model)
 

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -154,7 +154,7 @@ module Coinbase
       loop do
         reload
 
-        return @model if status == Status::COMPLETE.to_s || status == Status::FAILED.to_s
+        return self if status == Status::COMPLETE.to_s || status == Status::FAILED.to_s
 
         raise Timeout::Error, 'Transfer timed out' if Time.now - start_time > timeout_seconds
 

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -137,6 +137,8 @@ module Coinbase
       @model.status
     end
 
+    # Reload reloads the Transfer model with the latest version from the server side.
+    # @return [Transfer] The most recent version of Transfer from the server.
     def reload
       @model = Coinbase.call_api do
         transfers_api.get_transfer(wallet_id, from_address_id, id)

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -156,7 +156,7 @@ module Coinbase
       loop do
         reload
 
-        return self if status == Status::COMPLETE.to_s || status == Status::FAILED.to_s
+        return self if terminal_state?
 
         raise Timeout::Error, 'Transfer timed out' if Time.now - start_time > timeout_seconds
 
@@ -183,6 +183,10 @@ module Coinbase
 
     def transfers_api
       @transfers_api ||= Coinbase::Client::TransfersApi.new(Coinbase.configuration.api_client)
+    end
+
+    def terminal_state?
+      status == Status::COMPLETE.to_s || status == Status::FAILED.to_s
     end
   end
 end

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -166,7 +166,11 @@ module Coinbase
       start_time = Time.now
 
       loop do
-        return self if status == Status::COMPLETE || status == Status::FAILED
+        model = Coinbase.call_api do
+          transfers_api.get_transfer(wallet_id, from_address_id, id)
+        end
+
+        return self if model.status.to_s == Status::COMPLETE.to_s || model.status == Status::FAILED.to_s
 
         raise Timeout::Error, 'Transfer timed out' if Time.now - start_time > timeout_seconds
 
@@ -189,6 +193,10 @@ module Coinbase
     # @return [String] a String representation of the Transfer
     def inspect
       to_s
+    end
+
+    def transfers_api
+      @transfers_api ||= Coinbase::Client::TransfersApi.new(Coinbase.configuration.api_client)
     end
   end
 end

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -86,6 +86,7 @@ module Coinbase
 
       # Wait_for_signer waits until the ServerSigner has created a seed for the Wallet.
       # Timeout::Error if the ServerSigner takes longer than the given timeout to create the seed.
+      # @param wallet_id [string] The ID of the Wallet that is awaiting seed creation.
       # @param interval_seconds [Integer] The interval at which to poll the CDPService, in seconds
       # @param timeout_seconds [Integer] The maximum amount of time to wait for the Signer to create a seed, in seconds
       # @return [Wallet] The completed Wallet object that is ready to create addresses.
@@ -129,7 +130,7 @@ module Coinbase
     #   with the Wallet. If not provided, the Wallet will derive the first default address.
     # @param client [Jimson::Client] (Optional) The JSON RPC client to use for interacting with the Network
     def initialize(model, seed: nil, address_models: [])
-      validate_seed_and_address_models(seed, address_models)
+      # validate_seed_and_address_models(seed, address_models)
 
       @model = model
       @master = master_node(seed)

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -130,7 +130,7 @@ module Coinbase
     #   with the Wallet. If not provided, the Wallet will derive the first default address.
     # @param client [Jimson::Client] (Optional) The JSON RPC client to use for interacting with the Network
     def initialize(model, seed: nil, address_models: [])
-      # validate_seed_and_address_models(seed, address_models)
+      validate_seed_and_address_models(seed, address_models)
 
       @model = model
       @master = master_node(seed)

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -52,7 +52,7 @@ describe Coinbase do
       a1 = addresses[0]
       a2 = addresses[1]
       t = a1.transfer(1, :gwei, a2).wait!
-      expect(t.status).to eq(:complete)
+      expect(t.status).to eq('complete')
       puts "Transferred 1 Gwei from #{a1} to #{a2}"
 
       puts 'Fetching updated balances...'

--- a/spec/unit/coinbase/transfer_spec.rb
+++ b/spec/unit/coinbase/transfer_spec.rb
@@ -334,7 +334,7 @@ describe Coinbase::Transfer do
       end
 
       it 'returns the completed Transfer' do
-        expect(transfer.wait!(0.001, 0.1)).to eq(complete_broadcast_model)
+        expect(transfer.wait!(0.001, 0.1)).to eq(transfer)
         expect(transfer.status).to eq(Coinbase::Transfer::Status::COMPLETE.to_s)
       end
     end
@@ -352,7 +352,7 @@ describe Coinbase::Transfer do
       end
 
       it 'returns the failed Transfer' do
-        expect(transfer.wait!).to eq(failed_broadcast_model)
+        expect(transfer.wait!).to eq(transfer)
         expect(transfer.status).to eq(Coinbase::Transfer::Status::FAILED.to_s)
       end
     end


### PR DESCRIPTION
### What changed? Why?
Support transfer with ServerSigner.
1. Change logic in status to return what is in the model
2. Add a reload method that updates the model with what is in backend
3. Update wait! to use reload instead of relying on status

```
[6] pry(main)> t = w.transfer(0.0001, :eth, w2).wait!
=> Coinbase::Transfer{transfer_id: 'f199e5f6-b18f-4aca-b4b5-4075c0feabb1', network_id: 'base_sepolia', from_address_id: '0x88DBBf024Ef56137bc688FAed7AffD20474d80B8', destination_address_id: '0x7b422c56A66e0A8c789Ac0e29313b127e9CDd0e0', asset_id: 'eth', amount: '0.1e-3', transaction_hash: '0x1fa2d646ded18f69550207f8e3979ec031361883e5e95c55d7911464da4d694f', transaction_link: 'https://sepolia.basescan.org/tx/0x1fa2d646ded18f69550207f8e3979ec031361883e5e95c55d7911464da4d694f', status: 'complete'}
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->