### PR TITLE
[chore] Add test coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib/**/.DS_Store
 .idea
 .DS_Store
 seeds.json
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,8 @@
 
 source 'https://rubygems.org'
 
+# Testing only dependencies
+gem 'simplecov', require: false, group: :test
+
 # Include dependencies defined in the gemspec.
 gemspec

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ lint:
 test:
 	bundle exec rake test
 
+.PHONY: test-coverage
+test-coverage:
+	open coverage/index.html
+
 .PHONY: repl
 repl:
 	bundle exec bin/repl

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,12 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+
+SimpleCov.start do
+  enable_coverage :branch
+  primary_coverage :branch
+  add_filter '/spec/'
+  add_filter '/lib/coinbase/client/'
+end
+
 require_relative '../lib/coinbase'


### PR DESCRIPTION


### What changed? Why?
This adds basic simplecov test coverage reporting that is useful for testing unit test coverage locally.

This can be pushed to a github action step and enforced if needed separately as there weren't any official reporting actions that I saw.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
This only impacts tests