### PR TITLE
[chore] Move simplecov to gemspec dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,5 @@
 
 source 'https://rubygems.org'
 
-# Testing only dependencies
-gem 'simplecov', require: false, group: :test
-
 # Include dependencies defined in the gemspec.
 gemspec

--- a/coinbase.gemspec
+++ b/coinbase.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   # Pin to a specific version of RuboCop to ensure consistent linting.
   spec.add_development_dependency 'rubocop', '1.63.1'
+  spec.add_development_dependency 'simplecov'
   # Pin to a specific version of YARD to ensure consistent documentation generation.
   spec.add_development_dependency 'yard', '0.9.36'
   spec.add_development_dependency 'yard-markdown'


### PR DESCRIPTION
This moves the simplecov gemspec as a development dependency so that tests can be ran using simplecov in a development context, as well as have our E2E tests in CI run using simplecov.

### What changed? Why?


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->