### PR TITLE
[CCSTAK-586] Add Staking API support into the SDK for Partial ETH Staking

### DIFF
--- a/lib/coinbase/stake.rb
+++ b/lib/coinbase/stake.rb
@@ -10,8 +10,6 @@ module Coinbase
         'ethereum-holesky'
       ].freeze
 
-      SELF_SERVICE_INTEGRATOR_CONTRACT_ADDRESS_HOLESKY = '0xA55416de5DE61A0AC1aa8970a280E04388B1dE4b'
-
       # Builds a stake operation for a protocol on a given network.
       # @param protocol [Symbol] The protocol name.
       # @param network [Symbol] The network name.
@@ -33,7 +31,6 @@ module Coinbase
             'ethereum_kiln_staking_parameters' => {
               'stake_parameters' => {
                 'staker_address' => (params[:address]).to_s,
-                'integrator_contract_address' => SELF_SERVICE_INTEGRATOR_CONTRACT_ADDRESS_HOLESKY,
                 'amount' => {
                   'value' => (params[:amount]).to_s,
                   'currency' => 'ETH'
@@ -52,7 +49,7 @@ module Coinbase
       # @param params  [Hash] The parameters needed to create an unstake operation.
       # @param opts [Hash] Optional parameters related to an unstake operation.
       # @return [String] An unsigned transaction used to unstake.
-      def build_unstake_operation(protocol, network, params, opts = {})
+      def build_unstake_operation(protocol, network, params, opts = { mode: :partial })
         return if not_valid_protocol_network?(protocol, network)
 
         body = {}
@@ -67,7 +64,6 @@ module Coinbase
             'ethereum_kiln_staking_parameters' => {
               'unstake_parameters' => {
                 'staker_address' => (params[:address]).to_s,
-                'integrator_contract_address' => SELF_SERVICE_INTEGRATOR_CONTRACT_ADDRESS_HOLESKY,
                 'amount' => {
                   'value' => (params[:amount]).to_s,
                   'currency' => 'ETH'
@@ -86,7 +82,7 @@ module Coinbase
       # @param params  [Hash] The parameters needed to create a claim_stake operation.
       # @param opts [Hash] Optional parameters related to a claim_stake operation.
       # @return [String] An unsigned transaction used to claim_stake.
-      def build_claim_stake_operation(protocol, network, params, opts = {})
+      def build_claim_stake_operation(protocol, network, params, opts = { mode: :partial })
         return if not_valid_protocol_network?(protocol, network)
 
         body = {}
@@ -100,8 +96,7 @@ module Coinbase
             'action' => action("#{protocol}_kiln".to_sym, network, :claim_stake),
             'ethereum_kiln_staking_parameters' => {
               'claim_stake_parameters' => {
-                'staker_address' => (params[:address]).to_s,
-                'integrator_contract_address' => SELF_SERVICE_INTEGRATOR_CONTRACT_ADDRESS_HOLESKY
+                'staker_address' => (params[:address]).to_s
               }
             }
           }

--- a/lib/coinbase/stake.rb
+++ b/lib/coinbase/stake.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require 'faraday'
+
+module Coinbase
+  # A representation of a Stake operation used for a end-user custody flow.
+  class Stake
+    class << self
+      VALID_PROTOCOL_NETWORK = [
+        'ethereum-holesky'
+      ].freeze
+
+      SELF_SERVICE_INTEGRATOR_CONTRACT_ADDRESS_HOLESKY = '0xA55416de5DE61A0AC1aa8970a280E04388B1dE4b'
+
+      # Builds a stake operation for a protocol on a given network.
+      # @param protocol [Symbol] The protocol name.
+      # @param network [Symbol] The network name.
+      # @param params  [Hash] The parameters needed to create a stake operation.
+      # @param opts [Hash] Optional parameters related to a stake operation.
+      # @return [String] An unsigned transaction used to stake.
+      def build_stake_operation(protocol, network, params, opts = { mode: :partial })
+        return if not_valid_protocol_network?(protocol, network)
+
+        body = {}
+
+        case protocol_network(protocol, network)
+        when 'ethereum-holesky'
+          return if missing_required_params?(params, %i[address amount])
+          return if not_partial?(opts)
+
+          body = {
+            'action' => action("#{protocol}_kiln".to_sym, network, :stake),
+            'ethereum_kiln_staking_parameters' => {
+              'stake_parameters' => {
+                'staker_address' => (params[:address]).to_s,
+                'integrator_contract_address' => SELF_SERVICE_INTEGRATOR_CONTRACT_ADDRESS_HOLESKY,
+                'amount' => {
+                  'value' => (params[:amount]).to_s,
+                  'currency' => 'ETH'
+                }
+              }
+            }
+          }
+        end
+
+        call_client(body)
+      end
+
+      # Builds an unstake operation for a protocol on a given network.
+      # @param protocol [Symbol] The protocol name.
+      # @param network [Symbol] The network name.
+      # @param params  [Hash] The parameters needed to create an unstake operation.
+      # @param opts [Hash] Optional parameters related to an unstake operation.
+      # @return [String] An unsigned transaction used to unstake.
+      def build_unstake_operation(protocol, network, params, opts = {})
+        return if not_valid_protocol_network?(protocol, network)
+
+        body = {}
+
+        case protocol_network(protocol, network)
+        when 'ethereum-holesky'
+          return if missing_required_params?(params, %i[address amount])
+          return if not_partial?(opts)
+
+          body = {
+            'action' => action("#{protocol}_kiln".to_sym, network, :unstake),
+            'ethereum_kiln_staking_parameters' => {
+              'unstake_parameters' => {
+                'staker_address' => (params[:address]).to_s,
+                'integrator_contract_address' => SELF_SERVICE_INTEGRATOR_CONTRACT_ADDRESS_HOLESKY,
+                'amount' => {
+                  'value' => (params[:amount]).to_s,
+                  'currency' => 'ETH'
+                }
+              }
+            }
+          }
+        end
+
+        call_client(body)
+      end
+
+      # Builds a claim_stake operation for a protocol on a given network.
+      # @param protocol [Symbol] The protocol name.
+      # @param network [Symbol] The network name.
+      # @param params  [Hash] The parameters needed to create a claim_stake operation.
+      # @param opts [Hash] Optional parameters related to a claim_stake operation.
+      # @return [String] An unsigned transaction used to claim_stake.
+      def build_claim_stake_operation(protocol, network, params, opts = {})
+        return if not_valid_protocol_network?(protocol, network)
+
+        body = {}
+
+        case protocol_network(protocol, network)
+        when 'ethereum-holesky'
+          return if missing_required_params?(params, [:address])
+          return if not_partial?(opts)
+
+          body = {
+            'action' => action("#{protocol}_kiln".to_sym, network, :claim_stake),
+            'ethereum_kiln_staking_parameters' => {
+              'claim_stake_parameters' => {
+                'staker_address' => (params[:address]).to_s,
+                'integrator_contract_address' => SELF_SERVICE_INTEGRATOR_CONTRACT_ADDRESS_HOLESKY
+              }
+            }
+          }
+        end
+
+        call_client(body)
+      end
+
+      # Checks if the protocol/network combo is supported.
+      #  @param protocol [Symbol] The protocol name.
+      #  @param network [Symbol] The network name.
+      #  @return [Boolean] If the protocol-network combo is supported.
+      def not_valid_protocol_network?(protocol, network)
+        if VALID_PROTOCOL_NETWORK.none?(protocol_network(
+                                          protocol, network
+                                        ))
+          raise ArgumentError,
+                "Unsupported #{protocol_network(protocol, network)}"
+        end
+      end
+
+      # Checks to see if the input parameters have all required fields.
+      # @param params [Hash] User provided parameters for a staking operation.
+      # @param required_params [Hash] The required parameters needed to create a staking operation.
+      # @return [Boolean] If the input parameters have all the required parameters populated.
+      def missing_required_params?(params, required_params)
+        raise ArgumentError, "missing required params #{required_params}" unless required_params.all? do |key|
+          params.key?(key)
+        end
+      end
+
+      # Creates an action resource name for the body of a staking operation.
+      # @param protocol [Symbol] The protocol name.
+      # @param network [Symbol] The network name.
+      # @param action [Symbol] The action which translates to a specific staking operation.
+      # @return [String] The action resource name.
+      def action(protocol, network, action)
+        "protocols/#{protocol}/networks/#{network}/actions/#{action}"
+      end
+
+      # Creates a protocol-network pair.
+      # @param protocol [Symbol] The protocol name.
+      # @param network [Symbol] The network name.
+      # @return [String] The protocol-network combo.
+      def protocol_network(protocol, network)
+        "#{protocol}-#{network}"
+      end
+
+      # Checks if the mode is set to partial.
+      # @param opts [Hash] The options passed in by the user.
+      # @return [Boolean] If the mode is partial.
+      def not_partial?(opts)
+        raise ArgumentError, "required mode to be 'partial'" if opts[:mode] != :partial
+      end
+
+      # Sets up the options and calls the Staking API service backend.
+      # @param body [Hash] Holds the different options passed into the API call.
+      # @return [String] The unsigned transaction from the response body.
+      def call_client(body)
+        opts = {
+          header_params: {
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json'
+          },
+          query_params: {},
+          return_type: 'Object'
+        }
+
+        call_opts = opts.merge(body: body)
+
+        response = Coinbase.call_api do
+          staking_api.call_api(:POST, '/v1/workflows', call_opts)
+        end
+
+        response[0].dig(:steps, 0, :txStepOutput, :unsignedTx)
+      end
+
+      # Creates the Staking API client used to create staking operations.
+      # @return [ApiClient] The Staking API client.
+      def staking_api
+        @staking_api ||= Coinbase::Client::ApiClient.new(Middleware.config).tap do |client|
+          client.config.base_path = '/staking/orchestration'
+        end
+      end
+    end
+  end
+end

--- a/lib/coinbase/stake.rb
+++ b/lib/coinbase/stake.rb
@@ -4,10 +4,6 @@ module Coinbase
   # A representation of a Stake operation used for a end-user custody flow.
   class Stake
     class << self
-      VALID_PROTOCOL_NETWORK = [
-        'ethereum-holesky'
-      ].freeze
-
       # Builds a stake operation for a protocol on a given network.
       # @param protocol [Symbol] The protocol name.
       # @param network [Symbol] The network name.
@@ -15,8 +11,6 @@ module Coinbase
       # @param opts [Hash] Optional parameters related to a stake operation.
       # @return [String] An unsigned transaction used to stake.
       def build_stake_operation(protocol, network, params, opts = { mode: :partial })
-        return if not_valid_protocol_network?(protocol, network)
-
         body = {}
 
         case protocol_network(protocol, network)
@@ -48,8 +42,6 @@ module Coinbase
       # @param opts [Hash] Optional parameters related to an unstake operation.
       # @return [String] An unsigned transaction used to unstake.
       def build_unstake_operation(protocol, network, params, opts = { mode: :partial })
-        return if not_valid_protocol_network?(protocol, network)
-
         body = {}
 
         case protocol_network(protocol, network)
@@ -81,8 +73,6 @@ module Coinbase
       # @param opts [Hash] Optional parameters related to a claim_stake operation.
       # @return [String] An unsigned transaction used to claim_stake.
       def build_claim_stake_operation(protocol, network, params, opts = { mode: :partial })
-        return if not_valid_protocol_network?(protocol, network)
-
         body = {}
 
         case protocol_network(protocol, network)
@@ -101,19 +91,6 @@ module Coinbase
         end
 
         call_client(body)
-      end
-
-      # Checks if the protocol/network combo is supported.
-      #  @param protocol [Symbol] The protocol name.
-      #  @param network [Symbol] The network name.
-      #  @return [Boolean] If the protocol-network combo is supported.
-      def not_valid_protocol_network?(protocol, network)
-        if VALID_PROTOCOL_NETWORK.none?(protocol_network(
-                                          protocol, network
-                                        ))
-          raise ArgumentError,
-                "Unsupported #{protocol_network(protocol, network)}"
-        end
       end
 
       # Checks to see if the input parameters have all required fields.

--- a/lib/coinbase/stake.rb
+++ b/lib/coinbase/stake.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday'
-
 module Coinbase
   # A representation of a Stake operation used for a end-user custody flow.
   class Stake


### PR DESCRIPTION
### What changed? Why?
Adding support for Partial ETH Staking via Staking API in SDK.

### Usage

#### Stake
```
unsigned_tx = Coinbase::Stake.build_stake_operation(:ethereum, :holesky, {:address => '0x87bf57c3d7b211a100ee4d00dee08435130a62fa', :amount => 11})
```

#### Unstake
```
unsigned_tx = Coinbase::Stake.build_unstake_operation(:ethereum, :holesky, {:address => '0x87bf57c3d7b211a100ee4d00dee08435130a62fa', :amount => 11})
```

#### ClaimStake
```
unsigned_tx = Coinbase::Stake.build_claim_stake_operation(:ethereum, :holesky, {:address => '0x87bf57c3d7b211a100ee4d00dee08435130a62fa'})
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->