### PR TITLE
[chore] Increase wait time in transfer

### DIFF
--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -152,7 +152,7 @@ module Coinbase
     # @param interval_seconds [Integer] The interval at which to poll the Network, in seconds
     # @param timeout_seconds [Integer] The maximum amount of time to wait for the Transfer to complete, in seconds
     # @return [Transfer] The completed Transfer object
-    def wait!(interval_seconds = 0.2, timeout_seconds = 15)
+    def wait!(interval_seconds = 0.2, timeout_seconds = 20)
       start_time = Time.now
 
       loop do

--- a/lib/coinbase/transfer.rb
+++ b/lib/coinbase/transfer.rb
@@ -152,7 +152,7 @@ module Coinbase
     # @param interval_seconds [Integer] The interval at which to poll the Network, in seconds
     # @param timeout_seconds [Integer] The maximum amount of time to wait for the Transfer to complete, in seconds
     # @return [Transfer] The completed Transfer object
-    def wait!(interval_seconds = 0.2, timeout_seconds = 10)
+    def wait!(interval_seconds = 0.2, timeout_seconds = 15)
       start_time = Time.now
 
       loop do


### PR DESCRIPTION
### What changed? Why?

Now that server-signer could also sign transactions, wait time of 10s is low in certain scenarios. Signer polling frequency is 10s, so we want the sdk timeout to be longer than that.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->