### PR TITLE
[chore] Explicitly disable server signer for trading

### DIFF
--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -102,8 +102,7 @@ module Coinbase
 
       trade = create_trade(amount, from_asset_id, to_asset_id)
 
-      # If a server signer is managing keys, it will sign and broadcast the underlying trade transaction out of band.
-      return trade if Coinbase.use_server_signer?
+      # NOTE: Trading does not yet support server signers at this point.
 
       payloads = { signed_payload: trade.transaction.sign(@key) }
 

--- a/spec/unit/coinbase/address_spec.rb
+++ b/spec/unit/coinbase/address_spec.rb
@@ -610,22 +610,6 @@ describe Coinbase::Address do
           end
         end
       end
-
-      context 'when using server signer' do
-        let(:use_server_signer) { true }
-
-        before do
-          trade
-        end
-
-        it 'creates a Trade' do
-          expect(trade).to eq(created_trade)
-        end
-
-        it 'does not sign the transaction' do
-          expect(transaction).not_to have_received(:sign)
-        end
-      end
     end
 
     describe 'when the address cannot sign' do


### PR DESCRIPTION

### What changed? Why?
When we support server signing for trading and mainnet we can add this handling explicitly.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->