### PR TITLE
[chore] Add NetworkFeatureUnsupportedError class

### DIFF
--- a/lib/coinbase/errors.rb
+++ b/lib/coinbase/errors.rb
@@ -76,6 +76,8 @@ module Coinbase
         InvalidSignedPayloadError.new(err)
       when 'invalid_transfer_status'
         InvalidTransferStatusError.new(err)
+      when 'network_feature_unsupported'
+        NetworkFeatureUnsupportedError.new(err)
       else
         APIError.new(err)
       end
@@ -117,4 +119,5 @@ module Coinbase
   class FaucetLimitReachedError < APIError; end
   class InvalidSignedPayloadError < APIError; end
   class InvalidTransferStatusError < APIError; end
+  class NetworkFeatureUnsupportedError < APIError; end
 end


### PR DESCRIPTION

### What changed? Why?
This adds a network feature unsupported error class for explicit handling within the SDK.


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->