### PR TITLE
Migrate transfers to use new transaction class

### DIFF
--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -88,9 +88,7 @@ module Coinbase
       # If a server signer is managing keys, it will sign and broadcast the underlying transfer transaction out of band.
       return transfer if Coinbase.use_server_signer?
 
-      signed_payload = sign_transfer(transfer)
-
-      broadcast_transfer(transfer, signed_payload)
+      broadcast_transfer(transfer, transfer.transaction.sign(@key))
     end
 
     # Returns whether the Address has a private key backing it to sign transactions.
@@ -197,13 +195,6 @@ module Coinbase
       end
 
       Coinbase::Transfer.new(transfer_model)
-    end
-
-    def sign_transfer(transfer)
-      transaction = transfer.transaction
-      transaction.sign(@key)
-
-      transaction.hex
     end
 
     def broadcast_transfer(transfer, signed_payload)

--- a/lib/coinbase/asset.rb
+++ b/lib/coinbase/asset.rb
@@ -61,26 +61,40 @@ module Coinbase
       asset_id
     end
 
+    def self.from_model(asset_model)
+      raise unless asset_model.is_a?(Coinbase::Client::Asset)
+
+      new(
+        network_id: Coinbase.to_sym(asset_model.network_id),
+        asset_id: Coinbase.to_sym(asset_model.asset_id),
+        address_id: asset_model.contract_address,
+        decimals: asset_model.decimals
+      )
+    end
+
     # Returns a new Asset object. Do not use this method. Instead, use the Asset constants defined in
     # the Coinbase module.
     # @param network_id [Symbol] The ID of the Network to which the Asset belongs
     # @param asset_id [Symbol] The Asset ID
-    # @param display_name [String] The Asset's display name
+    # @param display_name [String] (Optional) The Asset's display name
     # @param address_id [String] (Optional) The Asset's address ID, if one exists
-    def initialize(network_id:, asset_id:, display_name:, address_id: nil)
+    # @param decimals [Integer] (Optional) The number of decimal places the Asset uses
+    def initialize(network_id:, asset_id:, display_name: nil, address_id: nil, decimals: nil)
       @network_id = network_id
       @asset_id = asset_id
       @display_name = display_name
       @address_id = address_id
+      @decimals = decimals
     end
 
-    attr_reader :network_id, :asset_id, :display_name, :address_id
+    attr_reader :network_id, :asset_id, :display_name, :address_id, :decimals
 
     # Returns a string representation of the Asset.
     # @return [String] a string representation of the Asset
     def to_s
       "Coinbase::Asset{network_id: '#{network_id}', asset_id: '#{asset_id}', display_name: '#{display_name}'" +
-        (address_id.nil? ? '}' : ", address_id: '#{address_id}'}")
+        (address_id.nil? ? '}' : ", address_id: '#{address_id}'}") +
+        (decimals.nil? ? '}' : ", decimals: '#{decimals}'}")
     end
 
     # Same as to_s.

--- a/lib/coinbase/client/models/transfer.rb
+++ b/lib/coinbase/client/models/transfer.rb
@@ -34,8 +34,12 @@ module Coinbase::Client
     # The ID of the asset being transferred
     attr_accessor :asset_id
 
+    attr_accessor :asset
+
     # The ID of the transfer
     attr_accessor :transfer_id
+
+    attr_accessor :transaction
 
     # The unsigned payload of the transfer. This is the payload that needs to be signed by the sender.
     attr_accessor :unsigned_payload
@@ -80,7 +84,9 @@ module Coinbase::Client
         :'destination' => :'destination',
         :'amount' => :'amount',
         :'asset_id' => :'asset_id',
+        :'asset' => :'asset',
         :'transfer_id' => :'transfer_id',
+        :'transaction' => :'transaction',
         :'unsigned_payload' => :'unsigned_payload',
         :'signed_payload' => :'signed_payload',
         :'transaction_hash' => :'transaction_hash',
@@ -102,7 +108,9 @@ module Coinbase::Client
         :'destination' => :'String',
         :'amount' => :'String',
         :'asset_id' => :'String',
+        :'asset' => :'Asset',
         :'transfer_id' => :'String',
+        :'transaction' => :'Transaction',
         :'unsigned_payload' => :'String',
         :'signed_payload' => :'String',
         :'transaction_hash' => :'String',
@@ -167,10 +175,22 @@ module Coinbase::Client
         self.asset_id = nil
       end
 
+      if attributes.key?(:'asset')
+        self.asset = attributes[:'asset']
+      else
+        self.asset = nil
+      end
+
       if attributes.key?(:'transfer_id')
         self.transfer_id = attributes[:'transfer_id']
       else
         self.transfer_id = nil
+      end
+
+      if attributes.key?(:'transaction')
+        self.transaction = attributes[:'transaction']
+      else
+        self.transaction = nil
       end
 
       if attributes.key?(:'unsigned_payload')
@@ -223,8 +243,16 @@ module Coinbase::Client
         invalid_properties.push('invalid value for "asset_id", asset_id cannot be nil.')
       end
 
+      if @asset.nil?
+        invalid_properties.push('invalid value for "asset", asset cannot be nil.')
+      end
+
       if @transfer_id.nil?
         invalid_properties.push('invalid value for "transfer_id", transfer_id cannot be nil.')
+      end
+
+      if @transaction.nil?
+        invalid_properties.push('invalid value for "transaction", transaction cannot be nil.')
       end
 
       if @unsigned_payload.nil?
@@ -248,7 +276,9 @@ module Coinbase::Client
       return false if @destination.nil?
       return false if @amount.nil?
       return false if @asset_id.nil?
+      return false if @asset.nil?
       return false if @transfer_id.nil?
+      return false if @transaction.nil?
       return false if @unsigned_payload.nil?
       return false if @status.nil?
       status_validator = EnumAttributeValidator.new('String', ["pending", "broadcast", "complete", "failed"])
@@ -277,7 +307,9 @@ module Coinbase::Client
           destination == o.destination &&
           amount == o.amount &&
           asset_id == o.asset_id &&
+          asset == o.asset &&
           transfer_id == o.transfer_id &&
+          transaction == o.transaction &&
           unsigned_payload == o.unsigned_payload &&
           signed_payload == o.signed_payload &&
           transaction_hash == o.transaction_hash &&
@@ -293,7 +325,7 @@ module Coinbase::Client
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [network_id, wallet_id, address_id, destination, amount, asset_id, transfer_id, unsigned_payload, signed_payload, transaction_hash, status].hash
+      [network_id, wallet_id, address_id, destination, amount, asset_id, asset, transfer_id, transaction, unsigned_payload, signed_payload, transaction_hash, status].hash
     end
 
     # Builds the object from hash

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -4,7 +4,7 @@ require 'dotenv'
 Dotenv.load
 
 describe Coinbase do
-  describe 'v0.0.4 SDK' do
+  describe 'v0.0.7 SDK' do
     it 'behaves as expected' do
       # GitHub secrets truncate newlines as whitespace, so we need to replace them.
       # See https://github.com/github/docs/issues/14207

--- a/spec/unit/coinbase/address_spec.rb
+++ b/spec/unit/coinbase/address_spec.rb
@@ -147,15 +147,38 @@ describe Coinbase::Address do
     let(:to_key) { Eth::Key.new }
     let(:to_address_id) { to_key.address.to_s }
     let(:transaction_hash) { '0xdeadbeef' }
-    let(:raw_signed_transaction) { '0123456789abcdef' }
+    let(:unsigned_payload) { 'unsigned_payload' }
     let(:signed_payload) { '0x12345' }
     let(:broadcast_transfer_request) do
-      { signed_payload: raw_signed_transaction }
+      { signed_payload: signed_payload }
     end
-    let(:transaction) { double('Transaction', sign: transaction_hash, hex: raw_signed_transaction) }
+    let(:transaction) { double(Coinbase::Transaction, sign: signed_payload) }
+    let(:transaction_model) do
+      Coinbase::Client::Transaction.new(
+        status: 'pending',
+        unsigned_payload: unsigned_payload
+      )
+    end
     let(:created_transfer) { double('Transfer', transaction: transaction, id: transfer_id) }
-    let(:transfer_model) { instance_double('Coinbase::Client::Transfer', status: 'pending') }
-    let(:broadcasted_transfer_model) { instance_double('Coinbase::Client::Transfer', status: 'broadcast') }
+    let(:transfer_model) do
+      instance_double(
+        Coinbase::Client::Transfer,
+        transaction: transaction_model
+      )
+    end
+    let(:broadcasted_transaction_model) do
+      Coinbase::Client::Transaction.new(
+        status: 'broadcast',
+        unsigned_payload: unsigned_payload,
+        signed_payload: signed_payload
+      )
+    end
+    let(:broadcasted_transfer_model) do
+      instance_double(
+        Coinbase::Client::Transfer,
+        transaction: broadcasted_transaction_model
+      )
+    end
     let(:broadcasted_transfer) { double('Transfer', transaction: transaction, id: transfer_id) }
     let(:transfer_asset_id) { 'eth' }
     let(:balance_response) { eth_balance_response }

--- a/spec/unit/coinbase/asset_spec.rb
+++ b/spec/unit/coinbase/asset_spec.rb
@@ -107,6 +107,57 @@ describe Coinbase::Asset do
     end
   end
 
+  describe '.from_model' do
+    let(:asset_model) do
+      Coinbase::Client::Asset.new(network_id: 'base-sepolia', asset_id: 'eth', decimals: 18)
+    end
+    subject(:asset) { described_class.from_model(asset_model) }
+
+    it 'returns an Asset' do
+      expect(asset).to be_a(described_class)
+    end
+
+    it 'sets the network_id' do
+      expect(asset.network_id).to eq(:base_sepolia)
+    end
+
+    it 'sets the asset_id' do
+      expect(asset.asset_id).to eq(:eth)
+    end
+
+    it 'sets the decimals' do
+      expect(asset.decimals).to eq(18)
+    end
+
+    it 'does not set the address_id' do
+      expect(asset.address_id).to be_nil
+    end
+
+    context 'when the asset is not a Coinbase::Client::Asset' do
+      it 'raises an error' do
+        expect do
+          described_class.from_model(Coinbase::Client::Balance.new)
+        end.to raise_error(StandardError)
+      end
+    end
+
+    context 'when the asset has a contract address' do
+      let(:contract_address) { '0x036CbD53842c5426634e7929541eC2318f3dCF7e' }
+      let(:asset_model) do
+        Coinbase::Client::Asset.new(
+          network_id: 'base-sepolia',
+          asset_id: 'usdc',
+          decimals: 6,
+          contract_address: contract_address
+        )
+      end
+
+      it 'sets the address_id' do
+        expect(asset.address_id).to eq(contract_address)
+      end
+    end
+  end
+
   describe '#initialize' do
     let(:network_id) { :base_sepolia }
     let(:asset_id) { :eth }
@@ -136,6 +187,38 @@ describe Coinbase::Asset do
 
     it 'sets the address_id' do
       expect(asset.address_id).to eq(address_id)
+    end
+
+    it 'does not set decimals' do
+      expect(asset.decimals).to be_nil
+    end
+
+    context 'when decimals is specified' do
+      let(:decimals) { 18 }
+
+      subject(:asset) do
+        described_class.new(
+          network_id: network_id,
+          asset_id: asset_id,
+          display_name: display_name,
+          address_id: address_id,
+          decimals: decimals
+        )
+      end
+
+      it 'sets the decimals' do
+        expect(asset.decimals).to eq(decimals)
+      end
+    end
+
+    context 'when display name is not specified' do
+      subject(:asset) do
+        described_class.new(network_id: network_id, asset_id: asset_id, address_id: address_id)
+      end
+
+      it 'does not set display_name' do
+        expect(asset.display_name).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
### What changed? Why?
This migrates the transfers to use the newly added transaction class.

This will unify all of our different interactions transfer/trade/stake to interact with the same transaction object and make flows such as signing, etc... normalized.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->