### PR TITLE
Use progress format when running locally

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', head]
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v2

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
---format documentation
+--format progress
 --color
 --require spec_helper


### PR DESCRIPTION
### What changed? Why?

Hey all! I realized when doing local development the documentation format of rspec can get kinda noisy. It hid away some warnings I was seeing. I believe we could benefit from using the progress formatter instead where successes are hidden as a `.` and warnings are easier to spot.

#### Qualified Impact
This has no impact on the gem itself, only development of it.