### PR TITLE
Enable ethereum networks for address path prefix

### DIFF
--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -421,9 +421,9 @@ module Coinbase
     end
 
     def address_path_prefix
-      # TODO: Add support for other networks.
+      # TODO: Push this logic to the backend.
       @address_path_prefix ||= case network_id.to_s.split('_').first
-                               when 'base'
+                               when 'base', 'ethereum'
                                  "m/44'/60'/0'/0"
                                else
                                  raise ArgumentError, "Unsupported network ID: #{network_id}"


### PR DESCRIPTION
### What changed? Why?
This handles both ethereum and base networks for address path prefix. This will be pushed to the backend so we don't need to know what protocol each network is on the client-side.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->