### PR TITLE
Add an e2e test that uses Server-Signer

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -24,4 +24,5 @@ jobs:
         API_KEY_NAME: ${{ secrets.API_KEY_NAME }}
         API_KEY_PRIVATE_KEY: ${{ secrets.API_KEY_PRIVATE_KEY }}
         WALLET_DATA: ${{ secrets.WALLET_DATA }}
+        SERVER_SIGNER_WALLET_DATA: $${{ secrets.SERVER_SIGNER_WALLET_DATA }}
       run: bundle exec rspec spec/e2e/end_to_end.rb

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -129,10 +129,9 @@ end
 def fetch_existing_wallet(user)
   # TODO: Change to using get method when available.
   data_string = ENV['SERVER_SIGNER_WALLET_DATA']
-  puts "Data #{data_string}"
   expect(data_string).not_to be_nil
-
-  data_hash = JSON.parse(data_string)
+  decoded_data = Base64.decode64(data_string)
+  data_hash = JSON.parse(decoded_data)
   data = Coinbase::Wallet::Data.from_hash(data_hash)
   puts "imported wallet id #{data.wallet_id}"
   expect(data).not_to be_nil

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -4,54 +4,61 @@ require 'dotenv'
 Dotenv.load
 
 describe Coinbase do
+  before do
+    # GitHub secrets truncate newlines as whitespace, so we need to replace them.
+    # See https://github.com/github/docs/issues/14207
+    api_key_name = ENV['API_KEY_NAME'].gsub('\n', "\n")
+    api_key_private_key = ENV['API_KEY_PRIVATE_KEY'].gsub('\n', "\n")
+
+    # Use default API URL if not provided
+    api_url = ENV['API_URL']
+
+    Coinbase.configure do |config|
+      config.api_key_name = api_key_name
+      config.api_key_private_key = api_key_private_key
+      config.api_url = api_url if api_url
+    end
+  end
   describe 'v0.0.7 SDK' do
     it 'behaves as expected' do
-      e2e_test
+      user = fetch_user_test
+      new_address = create_new_address_test(user)
+      imported_wallet = import_wallet_test(user)
+      fetch_addresses_balances_test(imported_wallet)
+      imported_address = imported_wallet.addresses[0]
+      transfer_test(imported_address, new_address)
     end
   end
 
-  describe 'use serve signer' do
+  describe 'use for serve signer' do
     it 'behaves as expected' do
       # Use Server-Signer only half the runs to save test time.
-      skip if rand >= 0.5
-      e2e_test(use_server_signer: true)
+      # skip if rand >= 0.5
+      Coinbase.configuration.use_server_signer = true
+      signer = Coinbase::ServerSigner.default
+      puts "Using ServerSigner with ID: #{signer.id}"
+
+      user = fetch_user_test
+      new_address = create_new_address_test(user)
+      existing_wallet = fetch_existing_wallet(user)
+      fetch_addresses_balances_test(existing_wallet)
+      existing_address = existing_wallet.addresses[0]
+      transfer_test(existing_address, new_address)
     end
   end
 end
 
-# rubocop:disable Metrics/MethodLength
-# rubocop:disable Metrics/AbcSize
-def e2e_test(use_server_signer: false)
-  # GitHub secrets truncate newlines as whitespace, so we need to replace them.
-  # See https://github.com/github/docs/issues/14207
-  api_key_name = ENV['API_KEY_NAME'].gsub('\n', "\n")
-  api_key_private_key = ENV['API_KEY_PRIVATE_KEY'].gsub('\n', "\n")
-
-  # Use default API URL if not provided
-  api_url = ENV['API_URL']
-
-  Coinbase.configure do |config|
-    config.api_key_name = api_key_name
-    config.api_key_private_key = api_key_private_key
-    config.api_url = api_url if api_url
-    config.use_server_signer = use_server_signer
-  end
-
+def fetch_user_test
   puts 'Fetching default user...'
   u = Coinbase.default_user
   expect(u).not_to be_nil
   puts "Fetched default user with ID: #{u.id}"
+  u
+end
 
-  if use_server_signer
-    signer = Coinbase::ServerSigner.default
-    puts "Using ServerSigner with ID: #{signer.id}"
-  end
-
-  data_string = ENV['WALLET_DATA']
-  expect(data_string).not_to be_nil
-
+def create_new_address_test(user)
   puts 'Creating new wallet...'
-  w1 = u.create_wallet
+  w1 = user.create_wallet
   expect(w1).not_to be_nil
   puts "Created new wallet with ID: #{w1.id}, default address: #{w1.default_address}"
 
@@ -60,9 +67,12 @@ def e2e_test(use_server_signer: false)
   expect(new_address).not_to be_nil
   puts "Created new address with ID: #{new_address.id} in wallet with ID #{w1.id}"
 
-  # To move funds from imported wallet, do not use Server-Signer.
-  Coinbase.configuration.use_server_signer = false
+  new_address
+end
 
+def import_wallet_test(user)
+  data_string = ENV['WALLET_DATA']
+  expect(data_string).not_to be_nil
   puts 'Importing wallet with balance...'
 
   data_hash = JSON.parse(data_string)
@@ -72,24 +82,28 @@ def e2e_test(use_server_signer: false)
   expect(data.wallet_id).not_to be_nil
   expect(data.seed).not_to be_nil
 
-  w2 = u.import_wallet(data)
-  expect(w2).not_to be_nil
-  puts "Imported wallet with ID: #{w2.id}, default address: #{w2.default_address}"
+  wallet = user.import_wallet(data)
+  expect(wallet).not_to be_nil
+  puts "Imported wallet with ID: #{wallet.id}, default address: #{wallet.default_address}"
 
+  wallet
+end
+
+def fetch_addresses_balances_test(wallet)
   puts 'Listing wallet addresses...'
-  addresses = w2.addresses
+  addresses = wallet.addresses
   expect(addresses.length).to be > 1
   puts "Listed addresses: #{addresses.map(&:to_s).join(', ')}"
 
   puts 'Fetching wallet balances...'
-  balances = w2.balances
+  balances = wallet.balances
   expect(balances.length).to be >= 1
   puts "Fetched balances: #{balances}"
+end
 
-  puts 'Transfering 1 Gwei from imported address to new address...'
-  imported_address = addresses[0]
-
+def transfer_test(imported_address, new_address)
   # Transfer gwei from imported address to new address.
+  puts 'Transfering 1 Gwei from imported address to new address...'
   t = imported_address.transfer(1, :gwei, new_address).wait!
   expect(t.status).to eq('complete')
   puts "Transferred 1 Gwei from #{imported_address} to #{new_address}"
@@ -98,9 +112,6 @@ def e2e_test(use_server_signer: false)
   t2 = imported_address.transfer(0.00000003, :eth, new_address).wait!
   expect(t2.status).to eq('complete')
   puts "Transferred 0.00000003 Eth from #{imported_address} to #{new_address}"
-
-  # Use Server-Signer if needed for newly created wallet.
-  Coinbase.configuration.use_server_signer = use_server_signer
 
   # Transfer gwei back from new address to imported address.
   t = new_address.transfer(1, :gwei, imported_address).wait!
@@ -116,5 +127,19 @@ def e2e_test(use_server_signer: false)
   puts "New address balances: #{second_balance}"
 end
 
-# rubocop:enable Metrics/MethodLength
-# rubocop:enable Metrics/AbcSize
+def fetch_existing_wallet(user)
+  # TODO: Change to using get method when available.
+  data_string = ENV['SERVER_SIGNER_WALLET_DATA']
+  expect(data_string).not_to be_nil
+
+  data_hash = JSON.parse(data_string)
+  data = Coinbase::Wallet::Data.from_hash(data_hash)
+  puts "imported wallet id #{data.wallet_id}"
+  expect(data).not_to be_nil
+  expect(data.wallet_id).not_to be_nil
+
+  wallet = user.import_wallet(data)
+  expect(wallet).not_to be_nil
+
+  wallet
+end

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -12,6 +12,8 @@ describe Coinbase do
 
   describe 'use serve signer' do
     it 'behaves as expected' do
+      # Use Server-Signer only half the runs to save test time.
+      skip if rand >= 0.5
       e2e_test(use_server_signer: true)
     end
   end

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -6,62 +6,110 @@ Dotenv.load
 describe Coinbase do
   describe 'v0.0.7 SDK' do
     it 'behaves as expected' do
-      # GitHub secrets truncate newlines as whitespace, so we need to replace them.
-      # See https://github.com/github/docs/issues/14207
-      api_key_name = ENV['API_KEY_NAME'].gsub('\n', "\n")
-      api_key_private_key = ENV['API_KEY_PRIVATE_KEY'].gsub('\n', "\n")
+      e2e_test
+    end
+  end
 
-      # Use default API URL if not provided
-      api_url = ENV['API_URL']
-
-      Coinbase.configure do |config|
-        config.api_key_name = api_key_name
-        config.api_key_private_key = api_key_private_key
-        config.api_url = api_url if api_url
-      end
-
-      puts 'Fetching default user...'
-      u = Coinbase.default_user
-      expect(u).not_to be_nil
-      puts "Fetched default user with ID: #{u.id}"
-
-      puts 'Creating new wallet...'
-      w1 = u.create_wallet
-      expect(w1).not_to be_nil
-      puts "Created new wallet with ID: #{w1.id}, default address: #{w1.default_address}"
-
-      puts 'Importing wallet with balance...'
-      data_string = ENV['WALLET_DATA']
-      data_hash = JSON.parse(data_string)
-      data = Coinbase::Wallet::Data.from_hash(data_hash)
-      w2 = u.import_wallet(data)
-      expect(w2).not_to be_nil
-      puts "Imported wallet with ID: #{w2.id}, default address: #{w2.default_address}"
-
-      puts 'Listing wallet addresses...'
-      addresses = w2.addresses
-      expect(addresses.length).to be > 1
-      puts "Listed addresses: #{addresses.map(&:to_s).join(', ')}"
-
-      puts 'Fetching wallet balances...'
-      balances = w2.balances
-      expect(balances.length).to be >= 1
-      puts "Fetched balances: #{balances}"
-
-      puts 'Transfering 1 Gwei from default address to second address...'
-      a1 = addresses[0]
-      a2 = addresses[1]
-      t = a1.transfer(1, :gwei, a2).wait!
-      expect(t.status).to eq('complete')
-      puts "Transferred 1 Gwei from #{a1} to #{a2}"
-
-      puts 'Fetching updated balances...'
-      first_balance = a1.balances
-      second_balance = a2.balances
-      expect(first_balance[:eth]).to be > BigDecimal('0')
-      expect(second_balance[:eth]).to be > BigDecimal('0')
-      puts "First address balances: #{first_balance}"
-      puts "Second address balances: #{second_balance}"
+  describe 'use serve signer' do
+    it 'behaves as expected' do
+      # Use Server-Signer in only half of the runs to save time.
+      # skip if rand >= 0.5
+      e2e_test(use_server_signer: true)
     end
   end
 end
+
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/AbcSize
+def e2e_test(use_server_signer: false)
+  # GitHub secrets truncate newlines as whitespace, so we need to replace them.
+  # See https://github.com/github/docs/issues/14207
+  api_key_name = ENV['API_KEY_NAME'].gsub('\n', "\n")
+  api_key_private_key = ENV['API_KEY_PRIVATE_KEY'].gsub('\n', "\n")
+
+  # Use default API URL if not provided
+  api_url = ENV['API_URL']
+
+  Coinbase.configure do |config|
+    config.api_key_name = api_key_name
+    config.api_key_private_key = api_key_private_key
+    config.api_url = api_url if api_url
+    config.use_server_signer = use_server_signer
+  end
+
+  puts 'Fetching default user...'
+  u = Coinbase.default_user
+  expect(u).not_to be_nil
+  puts "Fetched default user with ID: #{u.id}"
+
+  if use_server_signer
+    signer = Coinbase::ServerSigner.default
+    puts "Using ServerSigner with ID: #{signer.id}"
+  end
+
+  data_string = ENV['WALLET_DATA']
+  expect(data_string).not_to be_nil
+
+  puts 'Creating new wallet...'
+  w1 = u.create_wallet
+  expect(w1).not_to be_nil
+  puts "Created new wallet with ID: #{w1.id}, default address: #{w1.default_address}"
+
+  puts 'Creating new address...'
+  new_address = w1.create_address
+  expect(new_address).not_to be_nil
+  puts "Created new address with ID: #{new_address.id} in wallet with ID #{w1.id}"
+
+  # To move funds from imported wallet, do not use Server-Signer.
+  Coinbase.configuration.use_server_signer = false
+
+  puts 'Importing wallet with balance...'
+
+  data_hash = JSON.parse(data_string)
+  data = Coinbase::Wallet::Data.from_hash(data_hash)
+  w2 = u.import_wallet(data)
+  expect(w2).not_to be_nil
+  puts "Imported wallet with ID: #{w2.id}, default address: #{w2.default_address}"
+
+  puts 'Listing wallet addresses...'
+  addresses = w2.addresses
+  expect(addresses.length).to be > 1
+  puts "Listed addresses: #{addresses.map(&:to_s).join(', ')}"
+
+  puts 'Fetching wallet balances...'
+  balances = w2.balances
+  expect(balances.length).to be >= 1
+  puts "Fetched balances: #{balances}"
+
+  puts 'Transfering 1 Gwei from imported address to new address...'
+  imported_address = addresses[0]
+
+  # Transfer gwei from imported address to new address.
+  t = imported_address.transfer(1, :gwei, new_address).wait!
+  expect(t.status).to eq('complete')
+  puts "Transferred 1 Gwei from #{imported_address} to #{new_address}"
+
+  # Transfer some eth for gas fee to new address.
+  t2 = imported_address.transfer(0.00000003, :eth, new_address).wait!
+  expect(t2.status).to eq('complete')
+  puts "Transferred 0.00000003 Eth from #{imported_address} to #{new_address}"
+
+  # Use Server-Signer if needed for newly created wallet.
+  Coinbase.configuration.use_server_signer = use_server_signer
+
+  # Transfer gwei back from new address to imported address.
+  t = new_address.transfer(1, :gwei, imported_address).wait!
+  expect(t.status).to eq('complete')
+  puts "Transferred 1 Gwei from #{new_address} to #{imported_address}"
+
+  puts 'Fetching updated balances...'
+  first_balance = imported_address.balances
+  second_balance = new_address.balances
+  expect(first_balance[:eth]).to be > BigDecimal('0')
+  expect(second_balance[:eth]).to be > BigDecimal('0')
+  puts "Imported address balances: #{first_balance}"
+  puts "New address balances: #{second_balance}"
+end
+
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/AbcSize

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -33,7 +33,7 @@ describe Coinbase do
   describe 'use for serve signer' do
     it 'behaves as expected' do
       # Use Server-Signer only half the runs to save test time.
-      # skip if rand >= 0.5
+      skip if rand >= 0.5
       Coinbase.configuration.use_server_signer = true
       signer = Coinbase::ServerSigner.default
       puts "Using ServerSigner with ID: #{signer.id}"

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -67,6 +67,7 @@ def e2e_test(use_server_signer: false)
 
   data_hash = JSON.parse(data_string)
   data = Coinbase::Wallet::Data.from_hash(data_hash)
+  puts "wallet_id", data.wallet_id
   expect(data).not_to be_nil
   expect(data.wallet_id).not_to be_nil
   expect(data.seed).not_to be_nil

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -67,7 +67,7 @@ def e2e_test(use_server_signer: false)
 
   data_hash = JSON.parse(data_string)
   data = Coinbase::Wallet::Data.from_hash(data_hash)
-  puts "wallet_id", data.wallet_id
+  puts "imported wallet id #{data.wallet_id}"
   expect(data).not_to be_nil
   expect(data.wallet_id).not_to be_nil
   expect(data.seed).not_to be_nil

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -50,10 +50,9 @@ end
 
 def fetch_user_test
   puts 'Fetching default user...'
-  u = Coinbase.default_user
-  expect(u).not_to be_nil
-  puts "Fetched default user with ID: #{u.id}"
-  u
+  user = Coinbase.default_user
+  expect(user).not_to be_nil
+  user
 end
 
 def create_new_address_test(user)
@@ -130,6 +129,7 @@ end
 def fetch_existing_wallet(user)
   # TODO: Change to using get method when available.
   data_string = ENV['SERVER_SIGNER_WALLET_DATA']
+  puts "Data #{data_string}"
   expect(data_string).not_to be_nil
 
   data_hash = JSON.parse(data_string)

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -12,8 +12,6 @@ describe Coinbase do
 
   describe 'use serve signer' do
     it 'behaves as expected' do
-      # Use Server-Signer in only half of the runs to save time.
-      # skip if rand >= 0.5
       e2e_test(use_server_signer: true)
     end
   end

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -67,6 +67,10 @@ def e2e_test(use_server_signer: false)
 
   data_hash = JSON.parse(data_string)
   data = Coinbase::Wallet::Data.from_hash(data_hash)
+  expect(data).not_to be_nil
+  expect(data.wallet_id).not_to be_nil
+  expect(data.seed).not_to be_nil
+
   w2 = u.import_wallet(data)
   expect(w2).not_to be_nil
   puts "Imported wallet with ID: #{w2.id}, default address: #{w2.default_address}"


### PR DESCRIPTION
### What changed? Why?
Update E2E test to : 
1. Create a new wallet
2. Import a wallet
3. Transfer gwei from imported to new
4. Transfer gas fee from imported to new
5. Transfer gwei from new to imported


Also adding to run with server-signer

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->