### PR TITLE
Cleanup error handling

### DIFF
--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -122,7 +122,7 @@ module Coinbase
   def self.call_api
     yield
   rescue Coinbase::Client::ApiError => e
-    raise Coinbase::APIError.from_error(e)
+    raise Coinbase::APIError.from_error(e), cause: nil
   rescue StandardError => e
     raise e
   end

--- a/spec/unit/coinbase/errors_spec.rb
+++ b/spec/unit/coinbase/errors_spec.rb
@@ -2,6 +2,40 @@
 
 describe Coinbase::APIError do
   describe '#from_error' do
+    subject(:api_error) { described_class.from_error(err) }
+
+    context 'when the error has a recognized API error code' do
+      let(:http_code) { 400 }
+      let(:api_code) { 'unsupported_asset' }
+      let(:api_message) { 'Asset "test" is not supported on "base-sepolia"' }
+      let(:err) do
+        Coinbase::Client::ApiError.new(
+          code: http_code,
+          response_body: { code: api_code, message: api_message }.to_json
+        )
+      end
+
+      it 'returns an instance of the appropriate error class' do
+        expect(api_error).to be_a(Coinbase::UnsupportedAssetError)
+      end
+
+      it 'sets the http_code attribute' do
+        expect(api_error.http_code).to eq(http_code)
+      end
+
+      it 'sets the api code' do
+        expect(api_error.api_code).to eq(api_code)
+      end
+
+      it 'sets the api message' do
+        expect(api_error.api_message).to eq(api_message)
+      end
+
+      it 'sets the error message to the api message' do
+        expect(api_error.message).to eq(api_message)
+      end
+    end
+
     context 'when the error is a generic error' do
       let(:err) { StandardError.new('message') }
 
@@ -10,25 +44,87 @@ describe Coinbase::APIError do
       end
     end
 
-    context 'when the error is an instance of Coinbase::Client::ApiError' do
-      let(:err) { Coinbase::Client::ApiError.new('message') }
+    context 'when the error is an ApiError without a response body' do
+      let(:http_code) { 501 }
+      let(:err) { Coinbase::Client::ApiError.new(code: http_code) }
 
       it 'returns an instance of Coinbase::APIError' do
-        e = Coinbase::APIError.from_error(err)
-        expect(e).to be_a(Coinbase::APIError)
+        expect(api_error).to be_a(Coinbase::APIError)
+      end
+
+      it 'sets the http_code attribute' do
+        expect(api_error.http_code).to eq(http_code)
+      end
+
+      it 'does not set the api code' do
+        expect(api_error.api_code).to be_nil
+      end
+
+      it 'does not set the api message' do
+        expect(api_error.api_message).to be_nil
+      end
+
+      it 'sets the error message to the default error message' do
+        expect(api_error.message).to eq(err.message)
       end
     end
 
-    context 'when the error has a recognized API error code' do
+    context 'when the error response body is not valid JSON' do
+      let(:http_code) { 501 }
+      let(:err) do
+        Coinbase::Client::ApiError.new(code: http_code, response_body: 'invalid json')
+      end
+
+      it 'returns an instance of Coinbase::APIError' do
+        expect(api_error).to be_a(Coinbase::APIError)
+      end
+
+      it 'sets the http_code attribute' do
+        expect(api_error.http_code).to eq(http_code)
+      end
+
+      it 'does not set the api code' do
+        expect(api_error.api_code).to be_nil
+      end
+
+      it 'does not set the api message' do
+        expect(api_error.api_message).to be_nil
+      end
+
+      it 'sets the error message to the default error message' do
+        expect(api_error.message).to eq(err.message)
+      end
+    end
+
+    context 'when the error does not have a recognized API error code' do
+      let(:http_code) { 501 }
+      let(:api_code) { 'unknown' }
+      let(:api_message) { 'test' }
       let(:err) do
         Coinbase::Client::ApiError.new(
-          code: 501,
-          response_body: '{ "code": "unimplemented", "message": "method is not implemented"}'
+          code: http_code,
+          response_body: { code: api_code, message: api_message }.to_json
         )
       end
-      it 'returns an instance of the appropriate error class' do
-        e = Coinbase::APIError.from_error(err)
-        expect(e).to be_a(Coinbase::UnimplementedError)
+
+      it 'returns an instance of Coinbase::APIError' do
+        expect(api_error).to be_a(Coinbase::APIError)
+      end
+
+      it 'sets the http_code attribute' do
+        expect(api_error.http_code).to eq(http_code)
+      end
+
+      it 'sets the api code' do
+        expect(api_error.api_code).to eq(api_code)
+      end
+
+      it 'does not set the api message' do
+        expect(api_error.api_message).to eq(api_message)
+      end
+
+      it 'sets the error message to the default error message' do
+        expect(api_error.message).to eq(err.message)
       end
     end
   end


### PR DESCRIPTION
### What changed? Why?

This makes it so that categorized errors now render with a lot less unnecessary information to the developer.

Before:
```
=> Coinbase::UnsupportedAssetError: asset "test" not supported on network "base-sepolia"
from /Users/alexstone/src/coinbase-sdk-ruby/lib/coinbase.rb:125:in `rescue in call_api'
Caused by Coinbase::Client::ApiError: Error message: the server returns an error
HTTP status code: 400
Response headers: {"date"=>"Mon, 17 Jun 2024 18:41:02 GMT", "content-type"=>"application/json", "content-length"=>"98", "connection"=>"keep-alive", "set-cookie"=>"cb_dm=8218c3c6-3d26-47f0-9df8-dafcf5b22f7a; Path=/; Domain=cbhq.net; Expires=Sat, 17 Jun 2034 18:41:02 GMT; HttpOnly; Secure", "trace-id"=>"3655272292412506473", "x-envoy-upstream-service-time"=>"21", "server"=>"cerberus"}
Response body: {"code":"unsupported_asset","message":"asset \"test\" not supported on network \"base-sepolia\""}
```

After
```
=> Coinbase::UnsupportedAssetError: asset "test" not supported on network "base-sepolia"
```

This will make it so that when we can leverage the server-side errors instead of trying to do it all client-side, e.g. check support assets from the SDK.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
This makes it so that our explicitly handle API error messages render in a much nicer manner.