### PR TITLE
Fix balance handling for dynamic assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Remove unused `base_sepolia_rpc_url` configuration option.
+
 ## [0.0.7] - 2024-06-11
 
 ### Added

--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -55,13 +55,10 @@ module Coinbase
 
   # Configuration object for the Coinbase SDK.
   class Configuration
-    attr_reader :base_sepolia_rpc_url, :base_sepolia_client
     attr_accessor :api_url, :api_key_name, :api_key_private_key, :debug_api, :use_server_signer
 
     # Initializes the configuration object.
     def initialize
-      @base_sepolia_rpc_url = 'https://sepolia.base.org'
-      @base_sepolia_client = Jimson::Client.new(@base_sepolia_rpc_url)
       @api_url = 'https://api.cdp.coinbase.com'
       @debug_api = false
       @use_server_signer = false
@@ -80,13 +77,6 @@ module Coinbase
       data = JSON.parse(file)
       @api_key_name = data['name']
       @api_key_private_key = data['privateKey']
-    end
-
-    # Sets the Base Sepolia RPC URL.
-    # @param new_base_sepolia_rpc_url [String] the new Base Sepolia RPC URL
-    def base_sepolia_rpc_url=(new_base_sepolia_rpc_url)
-      @base_sepolia_rpc_url = new_base_sepolia_rpc_url
-      @base_sepolia_client = Jimson::Client.new(@base_sepolia_rpc_url)
     end
 
     # Returns the API client.

--- a/lib/coinbase/balance.rb
+++ b/lib/coinbase/balance.rb
@@ -7,9 +7,9 @@ module Coinbase
     # @param balance_model [Coinbase::Client::Balance] The balance fetched from the API.
     # @return [Balance] The converted Balance object.
     def self.from_model(balance_model)
-      asset_id = Coinbase.to_sym(balance_model.asset.asset_id.downcase)
+      asset = Coinbase::Asset.from_model(balance_model.asset)
 
-      from_model_and_asset_id(balance_model, asset_id)
+      new(amount: asset.from_atomic_amount(balance_model.amount), asset: asset)
     end
 
     # Converts a Coinbase::Client::Balance model and asset ID to a Coinbase::Balance
@@ -19,8 +19,11 @@ module Coinbase
     # @param asset_id [Symbol] The Asset ID of the denomination we want returned.
     # @return [Balance] The converted Balance object.
     def self.from_model_and_asset_id(balance_model, asset_id)
+      asset = Coinbase::Asset.from_model(balance_model.asset, asset_id: asset_id)
+
       new(
-        amount: Coinbase::Asset.from_atomic_amount(BigDecimal(balance_model.amount), asset_id),
+        amount: asset.from_atomic_amount(balance_model.amount),
+        asset: asset,
         asset_id: asset_id
       )
     end
@@ -29,12 +32,13 @@ module Coinbase
     # Balance.from_model_and_asset_id.
     # @param amount [BigDecimal] The amount of the Asset
     # @param asset_id [Symbol] The Asset ID
-    def initialize(amount:, asset_id:)
+    def initialize(amount:, asset:, asset_id: nil)
       @amount = amount
-      @asset_id = asset_id
+      @asset = asset
+      @asset_id = asset_id || asset.asset_id
     end
 
-    attr_reader :amount, :asset_id
+    attr_reader :amount, :asset, :asset_id
 
     # Returns a string representation of the Balance.
     # @return [String] a string representation of the Balance

--- a/lib/coinbase/constants.rb
+++ b/lib/coinbase/constants.rb
@@ -4,19 +4,12 @@ require_relative 'asset'
 require_relative 'network'
 
 module Coinbase
-  # The Assets supported on Base Sepolia by the Coinbase SDK.
-  ETH = Asset.new(network_id: :base_sepolia, asset_id: :eth, display_name: 'Ether')
-  USDC = Asset.new(network_id: :base_sepolia, asset_id: :usdc, display_name: 'USD Coin',
-                   address_id: '0x036CbD53842c5426634e7929541eC2318f3dCF7e')
-  WETH = Asset.new(network_id: :base_sepolia, asset_id: :weth, display_name: 'Wrapped Ether',
-                   address_id: '0x4200000000000000000000000000000000000006')
   # The Base Sepolia Network.
   BASE_SEPOLIA = Network.new(
     network_id: :base_sepolia,
     display_name: 'Base Sepolia',
     protocol_family: :evm,
     is_testnet: true,
-    assets: [ETH, USDC],
     native_asset_id: :eth,
     chain_id: 84_532
   )
@@ -26,6 +19,9 @@ module Coinbase
 
   # The amount of Wei per Gwei.
   WEI_PER_GWEI = 1_000_000_000
+
+  # The number of decimal places in Gwei.
+  GWEI_DECIMALS = 9
 
   # The amount of Gwei per Ether.
   GWEI_PER_ETHER = 1_000_000_000

--- a/lib/coinbase/network.rb
+++ b/lib/coinbase/network.rb
@@ -3,7 +3,7 @@
 module Coinbase
   # A blockchain network.
   class Network
-    attr_reader :chain_id
+    attr_reader :chain_id, :native_asset_id
 
     # Returns a new Network object. Do not use this method directly. Instead, use the Network constants defined in
     # the Coinbase module.
@@ -12,44 +12,14 @@ module Coinbase
     # @param protocol_family [String] The protocol family to which the Network belongs
     #   (e.g., "evm")
     # @param is_testnet [Boolean] Whether the Network is a testnet
-    # @param assets [Array<Asset>] The Assets supported by the Network
-    # @param native_asset_id [String] The ID of the Network's native Asset
     # @param chain_id [Integer] The Chain ID of the Network
-    def initialize(network_id:, display_name:, protocol_family:, is_testnet:, assets:, native_asset_id:, chain_id:)
+    def initialize(network_id:, display_name:, protocol_family:, is_testnet:, native_asset_id:, chain_id:)
       @network_id = network_id
       @display_name = display_name
       @protocol_family = protocol_family
       @is_testnet = is_testnet
+      @native_asset_id = native_asset_id
       @chain_id = chain_id
-
-      @asset_map = {}
-      assets.each do |asset|
-        @asset_map[asset.asset_id] = asset
-      end
-
-      raise ArgumentError, 'Native Asset not found' unless @asset_map.key?(native_asset_id)
-
-      @native_asset = @asset_map[native_asset_id]
     end
-
-    # Lists the Assets supported by the Network.
-    #
-    # @return [Array<Asset>] The Assets supported by the Network
-    def list_assets
-      @asset_map.values
-    end
-
-    # Gets the Asset with the given ID.
-    #
-    # @param asset_id [Symbol] The ID of the Asset
-    # @return [Asset] The Asset with the given ID
-    def get_asset(asset_id)
-      @asset_map[asset_id]
-    end
-
-    # Gets the native Asset of the Network.
-    #
-    # @return [Asset] The native Asset of the Network
-    attr_reader :native_asset
   end
 end

--- a/spec/unit/coinbase/balance_map_spec.rb
+++ b/spec/unit/coinbase/balance_map_spec.rb
@@ -1,17 +1,25 @@
 # frozen_string_literal: true
 
 describe Coinbase::BalanceMap do
+  let(:eth_asset) do
+    Coinbase::Client::Asset.new(network_id: 'base-sepolia', asset_id: 'eth', decimals: 18)
+  end
+
   describe '.from_balances' do
     let(:eth_amount) { BigDecimal('123.0') }
-    let(:eth_asset) { instance_double('Coinbase::Client::Asset', asset_id: 'ETH') }
     let(:eth_balance_model) { instance_double('Coinbase::Client::Balance', asset: eth_asset, amount: eth_amount) }
 
     let(:usdc_amount) { BigDecimal('456.0') }
-    let(:usdc_asset) { instance_double('Coinbase::Client::Asset', asset_id: 'USDC') }
+    let(:usdc_asset) do
+      Coinbase::Client::Asset.new(network_id: 'base-sepolia', asset_id: 'usdc', decimals: 6)
+    end
     let(:usdc_balance_model) { instance_double('Coinbase::Client::Balance', asset: usdc_asset, amount: usdc_amount) }
 
     let(:weth_amount) { BigDecimal('789.0') }
     let(:weth_asset) { instance_double('Coinbase::Client::Asset', asset_id: 'WETH') }
+    let(:weth_asset) do
+      Coinbase::Client::Asset.new(network_id: 'base-sepolia', asset_id: 'weth', decimals: 18)
+    end
     let(:weth_balance_model) { instance_double('Coinbase::Client::Balance', asset: weth_asset, amount: weth_amount) }
 
     let(:balances) { [eth_balance_model, usdc_balance_model, weth_balance_model] }
@@ -28,7 +36,8 @@ describe Coinbase::BalanceMap do
   describe '#add' do
     let(:amount) { BigDecimal('123.0') }
     let(:asset_id) { :eth }
-    let(:balance) { Coinbase::Balance.new(amount: amount, asset_id: asset_id) }
+    let(:asset) { Coinbase::Asset.from_model(eth_asset) }
+    let(:balance) { Coinbase::Balance.new(amount: amount, asset: asset) }
 
     subject { described_class.new }
 
@@ -39,7 +48,7 @@ describe Coinbase::BalanceMap do
     end
 
     context 'when the balance is not a Coinbase::Balance' do
-      let(:balance) { instance_double('Coinbase::Balance') }
+      let(:balance) { instance_double('Coinbase::Asset') }
 
       it 'raises an ArgumentError' do
         expect { subject.add(balance) }.to raise_error(ArgumentError)
@@ -50,7 +59,8 @@ describe Coinbase::BalanceMap do
   describe '#to_s' do
     let(:amount) { BigDecimal('123.0') }
     let(:asset_id) { :eth }
-    let(:balance) { Coinbase::Balance.new(amount: amount, asset_id: asset_id) }
+    let(:asset) { Coinbase::Asset.from_model(eth_asset) }
+    let(:balance) { Coinbase::Balance.new(amount: amount, asset: asset) }
 
     let(:expected_result) { { eth: '123' }.to_s }
 

--- a/spec/unit/coinbase/balance_spec.rb
+++ b/spec/unit/coinbase/balance_spec.rb
@@ -1,75 +1,66 @@
 # frozen_string_literal: true
 
 describe Coinbase::Balance do
-  describe '.from_model' do
-    let(:amount) { BigDecimal('123.0') }
-    let(:balance_model) { instance_double('Coinbase::Client::Balance', asset: asset, amount: amount) }
+  let(:amount) { BigDecimal('123.0') }
+  let(:balance_model) { instance_double('Coinbase::Client::Balance', asset: asset, amount: amount) }
+  let(:eth_asset) do
+    Coinbase::Client::Asset.new(network_id: 'base-sepolia', asset_id: 'eth', decimals: 18)
+  end
 
+  describe '.from_model' do
     subject(:balance) { described_class.from_model(balance_model) }
 
     context 'when the asset is :eth' do
-      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'ETH') }
+      let(:asset) { eth_asset }
 
-      it 'returns a new Balance object with the correct amount' do
-        expect(balance.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+      it 'returns a Balance object' do
+        expect(balance).to be_a(described_class)
       end
 
-      it 'returns a new Balance object with the correct asset_id' do
+      it 'sets the correct amount' do
+        expect(balance.amount).to eq(amount / BigDecimal(10).power(eth_asset.decimals))
+      end
+
+      it 'sets the correct asset_id' do
         expect(balance.asset_id).to eq(:eth)
       end
     end
 
-    context 'when the asset is :usdc' do
-      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'USDC') }
-
-      it 'returns a new Balance object with the correct amount' do
-        expect(balance.amount).to eq(amount / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC))
+    context 'when the asset is other' do
+      let(:decimals) { 9 }
+      let(:asset) do
+        Coinbase::Client::Asset.new(
+          network_id: 'base-sepolia',
+          asset_id: 'other',
+          decimals: decimals
+        )
       end
 
-      it 'returns a new Balance object with the correct asset_id' do
-        expect(balance.asset_id).to eq(:usdc)
-      end
-    end
-
-    context 'when the asset is :weth' do
-      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'WETH') }
-
-      it 'returns a new Balance object with the correct amount' do
-        expect(balance.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+      it 'returns a Balance object' do
+        expect(balance).to be_a(described_class)
       end
 
-      it 'returns a new Balance object with the correct asset_id' do
-        expect(balance.asset_id).to eq(:weth)
-      end
-    end
-
-    context 'when the asset is another asset type' do
-      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'OTHER') }
-
-      it 'returns a new Balance object with the correct amount' do
-        expect(balance.amount).to eq(amount)
+      it 'sets the correct amount' do
+        expect(balance.amount).to eq(amount / BigDecimal(10).power(decimals))
       end
 
-      it 'returns a new Balance object with the correct asset_id' do
+      it 'sets the correct asset_id' do
         expect(balance.asset_id).to eq(:other)
       end
     end
   end
 
   describe '.from_model_and_asset_id' do
-    let(:amount) { BigDecimal('123.0') }
-    let(:balance_model) { instance_double('Coinbase::Client::Balance', asset: asset, amount: amount) }
-
     subject(:balance) { described_class.from_model_and_asset_id(balance_model, asset_id) }
 
     context 'when the balance model asset is :eth' do
-      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'ETH') }
+      let(:asset) { eth_asset }
 
       context 'and the specified asset_id is :eth' do
         let(:asset_id) { :eth }
 
         it 'returns a new Balance object with the correct amount' do
-          expect(balance.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
+          expect(balance.amount).to eq(amount / BigDecimal(10).power(eth_asset.decimals))
         end
 
         it 'returns a new Balance object with the correct asset_id' do
@@ -100,68 +91,69 @@ describe Coinbase::Balance do
           expect(balance.asset_id).to eq(asset_id)
         end
       end
-    end
 
-    context 'when the asset is :usdc' do
-      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'USDC') }
-      let(:asset_id) { :usdc }
+      context 'and the specified asset_id is another asset type' do
+        let(:asset_id) { :other }
 
-      it 'returns a new Balance object with the correct amount' do
-        expect(balance.amount).to eq(amount / BigDecimal(Coinbase::ATOMIC_UNITS_PER_USDC))
-      end
-
-      it 'returns a new Balance object with the correct asset_id' do
-        expect(balance.asset_id).to eq(asset_id)
+        it 'raise an error' do
+          expect { balance }.to raise_error(ArgumentError)
+        end
       end
     end
 
-    context 'when the asset is :weth' do
-      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'WETH') }
-      let(:asset_id) { :weth }
-
-      it 'returns a new Balance object with the correct amount' do
-        expect(balance.amount).to eq(amount / BigDecimal(Coinbase::WEI_PER_ETHER))
-      end
-
-      it 'returns a new Balance object with the correct asset_id' do
-        expect(balance.asset_id).to eq(asset_id)
-      end
-    end
-
-    context 'when the asset is another asset type' do
-      let(:asset) { instance_double('Coinbase::Client::Asset', asset_id: 'OTHER') }
+    context 'when the asset is not eth' do
+      let(:decimals) { 9 }
       let(:asset_id) { :other }
+      let(:asset) do
+        Coinbase::Client::Asset.new(
+          network_id: 'base-sepolia',
+          asset_id: 'other',
+          decimals: decimals
+        )
+      end
 
       it 'returns a new Balance object with the correct amount' do
-        expect(balance.amount).to eq(amount)
+        expect(balance.amount).to eq(amount / BigDecimal(10).power(decimals))
       end
 
       it 'returns a new Balance object with the correct asset_id' do
         expect(balance.asset_id).to eq(asset_id)
+      end
+
+      context 'when the asset ID does not match the asset' do
+        let(:asset_id) { :different }
+
+        it 'raises an error' do
+          expect { balance }.to raise_error(ArgumentError)
+        end
       end
     end
   end
 
   describe '#initialize' do
     let(:amount) { BigDecimal('123.0') }
-    let(:asset_id) { :eth }
+    let(:asset) { Coinbase::Asset.from_model(eth_asset) }
 
-    subject(:balance) { described_class.new(amount: amount, asset_id: asset_id) }
+    subject(:balance) { described_class.new(amount: amount, asset: asset) }
 
     it 'sets the amount' do
       expect(balance.amount).to eq(amount)
     end
 
-    it 'sets the asset_id' do
-      expect(balance.asset_id).to eq(asset_id)
+    it 'sets the asset' do
+      expect(balance.asset).to eq(asset)
+    end
+
+    it "sets the asset_id to the asset's ID" do
+      expect(balance.asset_id).to eq(:eth)
     end
   end
 
   describe '#inspect' do
     let(:amount) { BigDecimal('123.0') }
-    let(:asset_id) { :eth }
+    let(:asset) { Coinbase::Asset.from_model(eth_asset) }
 
-    subject(:balance) { described_class.new(amount: amount, asset_id: asset_id) }
+    subject(:balance) { described_class.new(amount: amount, asset: asset) }
 
     it 'includes balance details' do
       expect(balance.inspect).to include('123', 'eth')

--- a/spec/unit/coinbase/network_spec.rb
+++ b/spec/unit/coinbase/network_spec.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
 describe Coinbase::Network do
-  let(:eth) { Coinbase::Asset.new(network_id: :base_sepolia, asset_id: :eth, display_name: 'Ether') }
-  let(:usdc) { Coinbase::Asset.new(network_id: :base_sepolia, asset_id: :usdc, display_name: 'USD Coin') }
   let(:network) do
     described_class.new(
       network_id: :ethereum,
       display_name: 'Ethereum',
       protocol_family: 'evm',
       is_testnet: false,
-      assets: [eth, usdc],
       native_asset_id: :eth,
       chain_id: 1
     )
@@ -17,43 +14,19 @@ describe Coinbase::Network do
 
   describe '#initialize' do
     it 'initializes a network' do
+      expect(network).to be_a(described_class)
+    end
+  end
+
+  describe '#chain_id' do
+    it 'returns the chain ID of the network' do
       expect(network.chain_id).to eq(1)
     end
-
-    it 'raises an error if the native asset is not found' do
-      expect do
-        described_class.new(
-          network_id: :ethereum,
-          display_name: 'Ethereum',
-          protocol_family: 'evm',
-          is_testnet: false,
-          assets: [eth, usdc],
-          native_asset_id: :btc,
-          chain_id: 1
-        )
-      end.to raise_error(ArgumentError, 'Native Asset not found')
-    end
   end
 
-  describe '#list_assets' do
-    it 'lists the assets supported by the network' do
-      expect(network.list_assets).to include(eth, usdc)
-    end
-  end
-
-  describe '#get_asset' do
-    it 'gets an asset by ID' do
-      expect(network.get_asset(:eth)).to eq(eth)
-    end
-
-    it 'returns nil if the asset is not found' do
-      expect(network.get_asset(:btc)).to be_nil
-    end
-  end
-
-  describe '#native_asset' do
-    it 'returns the native asset of the network' do
-      expect(network.native_asset).to eq(eth)
+  describe '#native_asset_id' do
+    it 'returns the native asset ID of the network' do
+      expect(network.native_asset_id).to eq(:eth)
     end
   end
 end

--- a/spec/unit/coinbase/trade_spec.rb
+++ b/spec/unit/coinbase/trade_spec.rb
@@ -76,7 +76,7 @@ describe Coinbase::Trade do
       it 'raises an error' do
         expect do
           described_class.new(Coinbase::Client::Balance.new)
-        end.to raise_error
+        end.to raise_error(StandardError)
       end
     end
   end

--- a/spec/unit/coinbase/transaction_spec.rb
+++ b/spec/unit/coinbase/transaction_spec.rb
@@ -59,7 +59,7 @@ describe Coinbase::Transaction do
       it 'raises an error' do
         expect do
           described_class.new(Coinbase::Client::Balance.new)
-        end.to raise_error
+        end.to raise_error(RuntimeError)
       end
     end
   end
@@ -219,7 +219,7 @@ describe Coinbase::Transaction do
 
     context 'when it is signed again' do
       it 'raises an error' do
-        expect { transaction.sign(from_key) }.to raise_error
+        expect { transaction.sign(from_key) }.to raise_error(Eth::Signature::SignatureError)
       end
     end
   end

--- a/spec/unit/coinbase/transaction_spec.rb
+++ b/spec/unit/coinbase/transaction_spec.rb
@@ -166,7 +166,7 @@ describe Coinbase::Transaction do
   end
 
   describe '#raw' do
-    it 'returns the rraw transaction' do
+    it 'returns the raw transaction' do
       expect(transaction.raw).to be_a(Eth::Tx::Eip1559)
     end
 

--- a/spec/unit/coinbase/transfer_spec.rb
+++ b/spec/unit/coinbase/transfer_spec.rb
@@ -73,7 +73,7 @@ describe Coinbase::Transfer do
       it 'raises an error' do
         expect do
           described_class.new(Coinbase::Client::Balance.new)
-        end.to raise_error
+        end.to raise_error(RuntimeError)
       end
     end
   end

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -422,7 +422,7 @@ describe Coinbase::Wallet do
       end
     end
 
-    context 'when an address already exists', focus: true do
+    context 'when an address already exists' do
       let(:created_address_model) { address_model2 }
 
       let(:wallet) do

--- a/spec/unit/coinbase_spec.rb
+++ b/spec/unit/coinbase_spec.rb
@@ -106,11 +106,5 @@ describe Coinbase do
         expect(Coinbase.configuration.api_url).to eq 'https://api.cdp.coinbase.com'
       end
     end
-
-    describe '#base_sepolia_rpc_url' do
-      it 'returns the default base sepolia rpc url' do
-        expect(Coinbase.configuration.base_sepolia_rpc_url).to eq 'https://sepolia.base.org'
-      end
-    end
   end
 end


### PR DESCRIPTION
### What changed? Why?
This fixes balance handling for dynamic assets by using the returned asset object as the source of truth for decimals.

Note that for transfers and trades, where we need to convert from whole amount to atomic amount, we will need to add a `GetAsset` API in order to properly convert these values.

#### Qualified Impact
This could cause errors when fetching balances