### PR TITLE
Support listing and fetching wallets

### DIFF
--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -52,7 +52,10 @@ module Coinbase
         end
       end
 
-      # Fetches a Wallet by its ID, without setting a seed.
+      # Fetches a Wallet by its ID.
+      # The returned wallet can be immediately used for signing operations if backed by a server signer.
+      # If the wallet is not backed by a server signer, the wallet's seed will need to be set before
+      # it can be used for signing operations.
       # @param wallet_id [String] The ID of the Wallet to fetch
       # @return [Coinbase::Wallet] The fetched Wallet
       def fetch(wallet_id)

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -1,112 +1,86 @@
 # frozen_string_literal: true
 
 describe Coinbase::Wallet do
-  let(:client) { double('Jimson::Client') }
   let(:wallet_id) { SecureRandom.uuid }
   let(:network_id) { 'base-sepolia' }
-  let(:model) { Coinbase::Client::Wallet.new({ 'id': wallet_id, 'network_id': network_id }) }
+  let(:model) { Coinbase::Client::Wallet.new(id: wallet_id, network_id: network_id) }
   let(:address_model1) do
     Coinbase::Client::Address.new(
-      'address_id': '0x919538116b4F25f1CE01429fd9Ed7964556bf565',
-      'wallet_id': wallet_id,
-      'public_key': '0292df2f2c31a5c4b0d4946e922cc3bd25ad7196ffeb049905b0952b9ac48ef25f',
-      'network_id': network_id
+      address_id: '0x919538116b4F25f1CE01429fd9Ed7964556bf565',
+      wallet_id: wallet_id,
+      public_key: '0292df2f2c31a5c4b0d4946e922cc3bd25ad7196ffeb049905b0952b9ac48ef25f',
+      network_id: network_id
     )
   end
   let(:address_model2) do
     Coinbase::Client::Address.new(
-      'address_id': '0xf23692a9DE556Ee1711b172Bf744C5f33B13DC89',
-      'wallet_id': wallet_id,
-      'public_key': '034ecbfc86f7447c8bfd1a5f71b13600d767ccb58d290c7b146632090f3a05c66c',
-      'network_id': network_id
+      address_id: '0xf23692a9DE556Ee1711b172Bf744C5f33B13DC89',
+      wallet_id: wallet_id,
+      public_key: '034ecbfc86f7447c8bfd1a5f71b13600d767ccb58d290c7b146632090f3a05c66c',
+      network_id: network_id
     )
   end
   let(:model_with_default_address) do
     Coinbase::Client::Wallet.new(
-      'id': wallet_id,
-      'network_id': network_id,
-      'default_address': address_model1
+      id: wallet_id,
+      network_id: network_id,
+      default_address: address_model1
     )
   end
 
   let(:model_with_seed_pending) do
     Coinbase::Client::Wallet.new(
-      'id': wallet_id,
-      'network_id': network_id,
-      'server_signer_status': 'pending_seed_creation'
+      id: wallet_id,
+      network_id: network_id,
+      server_signer_status: 'pending_seed_creation'
     )
   end
   let(:model_with_seed_active) do
     Coinbase::Client::Wallet.new(
-      'id': wallet_id,
-      'network_id': network_id,
-      'default_address': address_model1,
-      'server_signer_status': 'active_seed'
+      id: wallet_id,
+      network_id: network_id,
+      default_address: address_model1,
+      server_signer_status: 'active_seed'
     )
   end
   let(:seed) { '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' }
   let(:wallets_api) { double('Coinbase::Client::WalletsApi') }
   let(:addresses_api) { double('Coinbase::Client::AddressesApi') }
   let(:transfers_api) { double('Coinbase::Client::TransfersApi') }
+  let(:use_server_signer) { false }
+  let(:configuration) do
+    instance_double(Coinbase::Configuration, use_server_signer: use_server_signer, api_client: nil)
+  end
 
   subject(:wallet) { described_class.new(model) }
 
   before do
     allow(Coinbase::Client::AddressesApi).to receive(:new).and_return(addresses_api)
     allow(Coinbase::Client::WalletsApi).to receive(:new).and_return(wallets_api)
+
+    allow(Coinbase).to receive(:configuration).and_return(configuration)
   end
 
   describe '.import' do
-    let(:client) { double('Jimson::Client') }
     let(:wallet_id) { SecureRandom.uuid }
-    let(:wallet_model) { Coinbase::Client::Wallet.new({ 'id': wallet_id, 'network_id': network_id }) }
-    let(:address_list_model) do
-      Coinbase::Client::AddressList.new(
-        {
-          'data' => [address_model1, address_model2],
-          'total_count' => 2
-        }
-      )
-    end
-    let(:exported_data) do
-      Coinbase::Wallet::Data.new(
-        wallet_id: wallet_id,
-        seed: seed
-      )
-    end
-    let(:configuration) { double('Coinbase::Configuration', use_server_signer: use_server_signer, api_client: nil) }
+    let(:wallet_model) { Coinbase::Client::Wallet.new(id: wallet_id, network_id: network_id) }
+    let(:exported_data) { Coinbase::Wallet::Data.new(wallet_id: wallet_id, seed: seed) }
+
     subject(:imported_wallet) { Coinbase::Wallet.import(exported_data) }
 
     before do
-      expect(wallets_api).to receive(:get_wallet).with(wallet_id).and_return(model_with_default_address)
-      expect(addresses_api)
-        .to receive(:list_addresses)
-        .with(wallet_id, { limit: 20 })
-        .and_return(address_list_model)
-      allow(Coinbase).to receive(:configuration).and_return(configuration)
+      allow(wallets_api).to receive(:get_wallet).with(wallet_id).and_return(model_with_default_address)
     end
 
     context 'when not using server signer' do
       let(:use_server_signer) { false }
+
       it 'imports an exported wallet' do
         expect(imported_wallet.id).to eq(wallet_id)
       end
 
-      it 'loads the wallet addresses' do
-        expect(imported_wallet.addresses.length).to eq(address_list_model.total_count)
-      end
-
       it 'contains the same seed when re-exported' do
         expect(imported_wallet.export.seed).to eq(exported_data.seed)
-      end
-    end
-
-    context 'when there are no addresses' do
-      let(:use_server_signer) { false }
-      let(:address_list_model) { Coinbase::Client::AddressList.new({ 'data' => [], 'total_count' => 0 }) }
-
-      it 'loads the wallet addresses' do
-        expect(imported_wallet.addresses.length).to eq(0)
       end
     end
 
@@ -117,14 +91,18 @@ describe Coinbase::Wallet do
         expect(imported_wallet.id).to eq(wallet_id)
       end
 
-      it 'loads the wallet addresses' do
-        expect(imported_wallet.addresses.length).to eq(address_list_model.total_count)
-      end
-
       it 'cannot export the wallet' do
         expect do
           imported_wallet.export
         end.to raise_error 'Cannot export data for Server-Signer backed Wallet'
+      end
+    end
+
+    context 'when the data is invalid' do
+      subject(:imported_wallet) { Coinbase::Wallet.import({ invalid: 'data' }) }
+
+      it 'raises an error for invalid data' do
+        expect { imported_wallet }.to raise_error(ArgumentError)
       end
     end
   end
@@ -138,21 +116,24 @@ describe Coinbase::Wallet do
     let(:wallet_model) { Coinbase::Client::Wallet.new({ 'id': wallet_id, 'network_id': network_id }) }
     let(:default_address_model) do
       Coinbase::Client::Address.new(
-        {
-          'address_id': '0xdeadbeef',
-          'wallet_id': wallet_id,
-          'public_key': '0x1234567890',
-          'network_id': network_id
-        }
+        address_id: '0xdeadbeef',
+        wallet_id: wallet_id,
+        public_key: '0x1234567890',
+        network_id: network_id
       )
     end
-    let(:configuration) { double('Coinbase::Configuration', use_server_signer: use_server_signer, api_client: nil) }
 
     subject(:created_wallet) { described_class.create }
 
     before do
-      allow(Coinbase).to receive(:configuration).and_return(configuration)
       allow(wallets_api).to receive(:create_wallet).with(request).and_return(wallet_model)
+
+      # During address creation we check if there are any addresses in the wallet, before
+      # creating an address.
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: [], total_count: 0))
     end
 
     context 'when not using a server signer' do
@@ -290,63 +271,63 @@ describe Coinbase::Wallet do
   end
 
   describe '#initialize' do
-    context 'when no seed or address models are provided' do
-      subject(:wallet) { described_class.new(model) }
+    subject(:wallet) { described_class.new(model) }
+
+    it 'initializes a new Wallet' do
+      expect(wallet).to be_a(Coinbase::Wallet)
+    end
+
+    it 'sets the model instance variable' do
+      expect(wallet.instance_variable_get(:@model)).to eq(model)
+    end
+
+    describe 'when no seed is provided' do
+      before do
+        allow(MoneyTree::Master).to receive(:new).and_call_original
+      end
 
       it 'initializes a new Wallet' do
         expect(wallet).to be_a(Coinbase::Wallet)
       end
 
-      it 'sets the model' do
-        expect(wallet.model).to eq(model)
+      it 'initializes a new master seed' do
+        expect(MoneyTree::Master).to receive(:new).with(no_args)
+
+        wallet
       end
 
       it 'sets the master seed' do
         expect(wallet.instance_variable_get(:@master)).to be_a(MoneyTree::Master)
       end
-
-      it 'sets the private key index' do
-        expect(wallet.instance_variable_get(:@private_key_index)).to eq(0)
-      end
     end
 
     context 'when a seed is provided' do
-      let(:seed_wallet) { described_class.new(model, seed: seed) }
+      subject(:wallet) { described_class.new(model, seed: seed) }
 
-      it 'initializes a new Wallet with the provided seed' do
-        expect(seed_wallet).to be_a(Coinbase::Wallet)
+      before do
+        allow(MoneyTree::Master).to receive(:new).and_call_original
+      end
+
+      it 'initializes a new Wallet' do
+        expect(wallet).to be_a(Coinbase::Wallet)
+      end
+
+      it 'initializes a master seed with the specified value' do
+        expect(MoneyTree::Master).to receive(:new).with(seed_hex: seed)
+
+        wallet
+      end
+
+      it 'sets the master seed' do
+        expect(wallet.instance_variable_get(:@master).seed_hex).to eq(seed)
       end
 
       context 'when the seed is invalid' do
         let(:seed) { 'invalid' }
 
         it 'raises an error for an invalid seed' do
-          expect { seed_wallet }.to raise_error(ArgumentError, 'Seed must be 32 bytes')
+          expect { wallet }.to raise_error(ArgumentError, 'Seed must be 32 bytes')
         end
-      end
-    end
-
-    context 'when only the address models are provided' do
-      it 'raises an error' do
-        expect do
-          described_class.new(model, address_models: [address_model1, address_model2])
-        end.to raise_error(ArgumentError, 'Seed must be present if address_models are provided')
-      end
-    end
-
-    context 'when the seed is empty but the address models are provided' do
-      it 'creates an unhydrated wallet' do
-        wallet = described_class.new(model, seed: '', address_models: [address_model1])
-        expect(wallet).to be_a(Coinbase::Wallet)
-        expect(wallet.addresses.length).to eq(1)
-      end
-    end
-
-    context 'when the seed is empty and no address models are provided' do
-      it 'raises an error' do
-        expect do
-          described_class.new(model, seed: '')
-        end.to raise_error(ArgumentError, 'Seed must be empty if address_models are not provided')
       end
     end
   end
@@ -365,13 +346,84 @@ describe Coinbase::Wallet do
 
   describe '#seed=' do
     let(:seedless_wallet) do
-      described_class.new(model_with_default_address, seed: '', address_models: [address_model1])
+      described_class.new(model_with_default_address, seed: '')
     end
 
-    it 'sets the seed' do
-      seedless_wallet.seed = seed
-      expect(seedless_wallet.can_sign?).to be true
-      expect(seedless_wallet.default_address.can_sign?).to be true
+    context 'when the addresses are not already loaded' do
+      before do
+        allow(addresses_api).to receive(:list_addresses)
+
+        seedless_wallet.seed = seed
+      end
+
+      it 'marks the wallet as signable' do
+        expect(seedless_wallet.can_sign?).to be(true)
+      end
+
+      it 'does not load the addresses' do
+        expect(addresses_api).not_to have_received(:list_addresses)
+      end
+
+      it 'sets the seed' do
+        expect(seedless_wallet.instance_variable_get(:@master)).to be_a(MoneyTree::Master)
+      end
+
+      context 'and the addresses are subsequently loaded' do
+        before do
+          allow(addresses_api)
+            .to receive(:list_addresses)
+            .with(wallet_id, { limit: 20 })
+            .and_return(
+              Coinbase::Client::AddressList.new(
+                data: [address_model1, address_model2],
+                total_count: 2
+              )
+            )
+        end
+
+        it 'marks the default address as signable' do
+          expect(seedless_wallet.default_address.can_sign?).to be(true)
+        end
+
+        it 'marks all addresses as signable' do
+          seedless_wallet.addresses.each do |address|
+            expect(address.can_sign?).to be(true)
+          end
+        end
+      end
+    end
+
+    context 'when the addresses are already loaded' do
+      before do
+        allow(addresses_api)
+          .to receive(:list_addresses)
+          .with(wallet_id, { limit: 20 })
+          .and_return(
+            Coinbase::Client::AddressList.new(
+              data: [address_model1, address_model2],
+              total_count: 1
+            )
+          )
+
+        # Load the addresses
+        seedless_wallet.addresses
+      end
+
+      context 'when the seed matches already derived addresses' do
+        before { seedless_wallet.seed = seed }
+
+        it 'sets the key on every address' do
+          seedless_wallet.addresses.each do |address|
+            expect(address.can_sign?).to be(true)
+          end
+        end
+      end
+
+      it 'raises an error if the seed does not match already derived addresses' do
+        expect do
+          seedless_wallet.seed = '86fc9fba421dcc6ad42747f14132c3cd975bd9fb1454df84ce5ea554f2542fbf'
+        end.to raise_error(/Seed does not match wallet/)
+      end
     end
 
     it 'raises an error for an invalid seed' do
@@ -380,31 +432,38 @@ describe Coinbase::Wallet do
       end.to raise_error(ArgumentError, 'Seed must be 32 bytes')
     end
 
+    it 'raises an error for an empty seed' do
+      expect do
+        seedless_wallet.seed = ''
+      end.to raise_error(ArgumentError, 'Seed must not be empty')
+    end
+
+    it 'raises an error for a nil seed' do
+      expect do
+        seedless_wallet.seed = nil
+      end.to raise_error(ArgumentError, 'Seed must not be empty')
+    end
+
     it 'raises an error if the wallet is already hydrated' do
       expect do
         wallet.seed = seed
       end.to raise_error('Seed is already set')
     end
-
-    it 'raises an error if it is the wrong seed' do
-      expect do
-        seedless_wallet.seed = '86fc9fba421dcc6ad42747f14132c3cd975bd9fb1454df84ce5ea554f2542fbf'
-      end.to raise_error(/Seed does not match wallet/)
-    end
   end
 
   describe '#create_address' do
     let(:expected_public_key) { created_address_model.public_key }
-
-    let(:wallet) do
-      described_class.new(model, seed: seed)
-    end
-
-    let(:configuration) { double('Coinbase::Configuration', use_server_signer: use_server_signer, api_client: nil) }
+    let(:wallet) { described_class.new(model, seed: seed) }
+    let(:existing_addresses) { [] }
 
     subject(:created_address) { wallet.create_address }
 
     before do
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: existing_addresses, total_count: existing_addresses.length))
+
       allow(addresses_api)
         .to receive(:create_address)
         .with(
@@ -418,7 +477,7 @@ describe Coinbase::Wallet do
         ).and_return(created_address_model)
     end
 
-    context 'when no addresses exist' do
+    context 'when the wallet does not have a default address initially' do
       let(:created_address_model) { address_model1 }
 
       before do
@@ -433,18 +492,20 @@ describe Coinbase::Wallet do
       end
 
       it 'reloads the wallet with the new default address' do
+        expect(wallet.default_address).to be_nil
+
         expect(created_address).to eq(wallet.default_address)
       end
     end
 
     context 'when an address already exists' do
+      let(:existing_addresses) { [address_model1] }
       let(:created_address_model) { address_model2 }
+      let(:wallet) { described_class.new(model_with_default_address, seed: seed) }
 
-      let(:wallet) do
-        described_class.new(model_with_default_address, seed: seed, address_models: [address_model1])
+      before do
+        created_address
       end
-
-      before { created_address }
 
       it 'creates a new address' do
         expect(created_address).to be_a(Coinbase::Address)
@@ -454,13 +515,12 @@ describe Coinbase::Wallet do
         expect(wallet.addresses.length).to eq(2)
       end
 
-      it 'is not sets as the default address' do
+      it 'is not set as the default address' do
         expect(created_address).not_to eq(wallet.default_address)
       end
     end
 
     context 'when using a server signer' do
-      let(:configuration) { double('Coinbase::Configuration', use_server_signer: true, api_client: nil) }
       let(:created_address_model) { address_model1 }
 
       subject(:created_address) { wallet.create_address }
@@ -469,6 +529,7 @@ describe Coinbase::Wallet do
         allow(addresses_api)
           .to receive(:create_address)
           .with(wallet_id).and_return(created_address_model)
+
         allow(wallets_api)
           .to receive(:get_wallet)
           .with(wallet_id)
@@ -482,17 +543,52 @@ describe Coinbase::Wallet do
   end
 
   describe '#default_address' do
-    it 'returns the first address' do
-      expect(wallet.default_address).to eq(wallet.addresses.first)
+    let(:address_models) { [address_model1, address_model2] }
+    let(:wallet) { described_class.new(model, seed: '') }
+
+    before do
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: address_models, total_count: 2))
+    end
+
+    context 'when the wallet has a default address' do
+      let(:expected_address) { Coinbase::WalletAddress.new(address_model1, nil) }
+      subject(:wallet) { described_class.new(model_with_default_address, seed: '') }
+
+      it 'returns the default address' do
+        expect(wallet.default_address.id).to eq(address_model1.address_id)
+      end
+
+      it 'sets the wallet ID' do
+        expect(wallet.default_address.wallet_id).to eq(wallet_id)
+      end
+
+      it 'returns a WalletAddress' do
+        expect(wallet.default_address).to be_a(Coinbase::WalletAddress)
+      end
+    end
+
+    context 'when the wallet does not have a default address' do
+      it 'returns nil' do
+        expect(wallet.default_address).to be_nil
+      end
     end
   end
 
   describe '#address' do
     let(:address_models) { [address_model1, address_model2] }
-    let(:wallet) do
-      described_class.new(model, seed: '', address_models: address_models)
-    end
+    let(:wallet) { described_class.new(model, seed: '') }
+
     subject(:address) { wallet.address(address_model2.address_id) }
+
+    before do
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: address_models, total_count: 2))
+    end
 
     it 'returns the correct address' do
       expect(address).to be_a(Coinbase::Address)
@@ -502,15 +598,56 @@ describe Coinbase::Wallet do
 
   describe '#addresses' do
     let(:address_models) { [address_model1, address_model2] }
-    subject(:wallet) do
-      described_class.new(model, seed: '', address_models: address_models)
+    let(:total_count) { address_models.length }
+    subject(:wallet) { described_class.new(model, seed: '') }
+
+    before do
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: address_models, total_count: 2))
     end
 
-    it 'returns an address for each address model' do
-      expect(wallet.addresses.length).to eq(2)
-      expect(wallet.addresses.each_with_index.all? do |address, i|
-        address.id == address_models[i].address_id
-      end).to be true
+    context 'when there are no addresses' do
+      let(:address_models) { [] }
+
+      it 'returns an empty array' do
+        expect(wallet.addresses).to be_empty
+      end
+    end
+
+    context 'when the wallet is hydrated with a seed' do
+      subject(:wallet) { described_class.new(model, seed: seed) }
+
+      it 'returns all of the wallet addresses' do
+        expect(wallet.addresses.length).to eq(total_count)
+      end
+
+      it 'returns the addresses from the server response' do
+        wallet.addresses.each_with_index do |address, i|
+          expect(address.id).to eq(address_models[i].address_id)
+        end
+      end
+
+      it 'returns addresses that can sign' do
+        expect(wallet.addresses.all?(&:can_sign?)).to be(true)
+      end
+    end
+
+    context 'when the wallet is not hydrated with a seed' do
+      it 'returns all of the wallet addresses' do
+        expect(wallet.addresses.length).to eq(total_count)
+      end
+
+      it 'returns the addresses from the server response' do
+        wallet.addresses.each_with_index do |address, i|
+          expect(address.id).to eq(address_models[i].address_id)
+        end
+      end
+
+      it 'returns addresses that cannot sign' do
+        expect(wallet.addresses.all?(&:can_sign?)).to be(false)
+      end
     end
   end
 
@@ -551,31 +688,27 @@ describe Coinbase::Wallet do
   end
 
   describe '#balance' do
-    let(:eth_asset) do
-      Coinbase::Client::Asset.new(network_id: 'base-sepolia', asset_id: 'eth', decimals: 18)
-    end
+    let(:eth_asset) { Coinbase::Client::Asset.new(network_id: 'base-sepolia', asset_id: 'eth', decimals: 18) }
     let(:amount) { 5_000_000_000_000_000_000 }
-    let(:response) do
-      Coinbase::Client::Balance.new(amount: '5000000000000000000', asset: eth_asset)
-    end
+    let(:response) { Coinbase::Client::Balance.new(amount: amount.to_s, asset: eth_asset) }
 
     before do
       expect(wallets_api).to receive(:get_wallet_balance).with(wallet_id, 'eth').and_return(response)
     end
 
     it 'returns the correct ETH balance' do
-      expect(wallet.balance(:eth)).to eq(Coinbase::Asset.from_model(eth_asset,
-                                                                    asset_id: :eth).from_atomic_amount(amount))
+      expect(wallet.balance(:eth))
+        .to eq(Coinbase::Asset.from_model(eth_asset, asset_id: :eth).from_atomic_amount(amount))
     end
 
     it 'returns the correct Gwei balance' do
-      expect(wallet.balance(:gwei)).to eq(Coinbase::Asset.from_model(eth_asset,
-                                                                     asset_id: :gwei).from_atomic_amount(amount))
+      expect(wallet.balance(:gwei))
+        .to eq(Coinbase::Asset.from_model(eth_asset, asset_id: :gwei).from_atomic_amount(amount))
     end
 
     it 'returns the correct Wei balance' do
-      expect(wallet.balance(:wei)).to eq(Coinbase::Asset.from_model(eth_asset,
-                                                                    asset_id: :wei).from_atomic_amount(amount))
+      expect(wallet.balance(:wei))
+        .to eq(Coinbase::Asset.from_model(eth_asset, asset_id: :wei).from_atomic_amount(amount))
     end
   end
 
@@ -583,22 +716,26 @@ describe Coinbase::Wallet do
     let(:transfer) { double('Coinbase::Transfer') }
     let(:amount) { 5 }
     let(:asset_id) { :eth }
-    let(:other_wallet) do
-      described_class.new(
-        Coinbase::Client::Wallet.new(
-          {
-            'id': wallet_id,
-            'network_id': 'base-sepolia',
-            'default_address': address_model2
-          }
-        ),
-        seed: '',
-        address_models: [address_model2]
-      )
+    let(:other_wallet_id) { SecureRandom.uuid }
+    let(:other_wallet_model) do
+      Coinbase::Client::Wallet.new(id: other_wallet_id, network_id: 'base-sepolia', default_address: address_model2)
+    end
+    let(:other_wallet) { described_class.new(other_wallet_model, seed: '') }
+
+    before do
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(other_wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: [address_model2], total_count: 1))
+
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: [address_model1], total_count: 1))
     end
 
     subject(:wallet) do
-      described_class.new(model_with_default_address, seed: '', address_models: [address_model1])
+      described_class.new(model_with_default_address, seed: '')
     end
 
     context 'when the destination is a Wallet' do
@@ -654,10 +791,15 @@ describe Coinbase::Wallet do
     let(:to_asset_id) { :weth }
 
     subject(:wallet) do
-      described_class.new(model_with_default_address, seed: '', address_models: [address_model1])
+      described_class.new(model_with_default_address, seed: '')
     end
 
     before do
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: [address_model1], total_count: 1))
+
       allow(wallet.default_address)
         .to receive(:trade)
         .with(amount, from_asset_id, to_asset_id)
@@ -670,40 +812,28 @@ describe Coinbase::Wallet do
   end
 
   describe '#export' do
-    let(:configuration) { double('Coinbase::Configuration', use_server_signer: use_server_signer, api_client: nil) }
-    before do
-      allow(Coinbase).to receive(:configuration).and_return(configuration)
-    end
-
     context 'when not using a server signer' do
       let(:use_server_signer) { false }
-      let(:seed_wallet) do
-        described_class.new(model, seed: seed, address_models: [address_model1, address_model2])
-      end
+      let(:seed_wallet) { described_class.new(model, seed: seed) }
+
+      subject(:exported_data) { seed_wallet.export }
 
       it 'exports the wallet data' do
-        wallet_data = seed_wallet.export
-        expect(wallet_data).to be_a(Coinbase::Wallet::Data)
-        expect(wallet_data.wallet_id).to eq(seed_wallet.id)
-        expect(wallet_data.seed).to eq(seed)
+        expect(exported_data).to be_a(Coinbase::Wallet::Data)
       end
 
-      it 'allows for re-creation of a Wallet' do
-        wallet_data = seed_wallet.export
-        new_wallet = described_class
-                     .new(model, seed: wallet_data.seed, address_models: [address_model1, address_model2])
-        expect(new_wallet.addresses.length).to eq(2)
-        new_wallet.addresses.each_with_index do |address, i|
-          expect(address.id).to eq(seed_wallet.addresses[i].id)
-        end
+      it 'exports wallet data with the wallet ID' do
+        expect(exported_data.wallet_id).to eq(seed_wallet.id)
+      end
+
+      it 'exports wallet data with the seed' do
+        expect(exported_data.seed).to eq(seed)
       end
     end
 
     context 'when using a server signer' do
       let(:use_server_signer) { true }
-      let(:wallet_without_seed) do
-        described_class.new(model, seed: nil, address_models: [address_model1, address_model2])
-      end
+      let(:wallet_without_seed) { described_class.new(model, seed: nil) }
 
       it 'does not export seed data' do
         expect do
@@ -717,12 +847,16 @@ describe Coinbase::Wallet do
     let(:faucet_transaction_model) do
       Coinbase::Client::FaucetTransaction.new({ 'transaction_hash': '0x123456789' })
     end
-    let(:wallet) do
-      described_class.new(model_with_default_address, seed: '', address_models: [address_model1])
-    end
+    let(:wallet) { described_class.new(model_with_default_address, seed: '') }
+
     subject(:faucet_transaction) { wallet.faucet }
 
     before do
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: [address_model1], total_count: 1))
+
       allow(addresses_api)
         .to receive(:request_faucet_funds)
         .with(wallet_id, address_model1.address_id)
@@ -744,7 +878,7 @@ describe Coinbase::Wallet do
     end
 
     context 'when the wallet is not hydrated' do
-      subject(:wallet) { described_class.new(model, seed: '', address_models: [address_model1]) }
+      subject(:wallet) { described_class.new(model, seed: '') }
 
       it 'returns false' do
         expect(wallet.can_sign?).to be false
@@ -753,88 +887,126 @@ describe Coinbase::Wallet do
   end
 
   describe '#save_seed!' do
-    let(:file_path) { "#{SecureRandom.uuid}.json" }
-    let(:initial_seed_data) { JSON.pretty_generate({}) }
-    let(:seed_wallet) do
-      described_class.new(model_with_default_address, seed: seed, address_models: [address_model1])
+    let(:initial_seed_data) { {} }
+    let(:wallet) do
+      described_class.new(model_with_default_address, seed: seed)
     end
 
-    before do
-      @api_key_private_key = Coinbase.configuration.api_key_private_key
-      Coinbase.configuration.api_key_private_key = OpenSSL::PKey::EC.generate('prime256v1').to_pem
-      File.open(file_path, 'w') do |file|
-        file.write(initial_seed_data)
+    let(:file) do
+      Tempfile.new.tap do |f|
+        f.write(JSON.pretty_generate(initial_seed_data))
+        f.rewind
+      end
+    end
+    let(:file_path) { file.path }
+
+    let(:configuration) do
+      instance_double(
+        Coinbase::Configuration,
+        use_server_signer: use_server_signer,
+        api_client: nil,
+        api_key_private_key: OpenSSL::PKey::EC.generate('prime256v1').to_pem
+      )
+    end
+
+    let(:saved_seed_data) { JSON.parse(File.read(file_path)) }
+
+    after { file.unlink }
+
+    context 'when encryption is false' do
+      before do
+        wallet.save_seed!(file_path, encrypt: false)
+      end
+
+      it 'saves the wallet data to the seed file' do
+        expect(saved_seed_data[wallet.id])
+          .to eq({ 'seed' => seed, 'encrypted' => false, 'iv' => '', 'auth_tag' => '' })
       end
     end
 
-    after do
-      File.delete(file_path)
-      Coinbase.configuration.api_key_private_key = @api_key_private_key
-    end
+    context 'when encryption is true' do
+      subject(:wallet_saved_data) { saved_seed_data[wallet.id] }
 
-    it 'saves the seed when encrypt is false' do
-      seed_wallet.save_seed!(file_path, encrypt: false)
-
-      # Verify that the file has new wallet.
-      stored_seed_data = File.read(file_path)
-      wallets = JSON.parse(stored_seed_data)
-      data = wallets[seed_wallet.id]
-      expect(data).not_to be_empty
-      expect(data['encrypted']).to eq(false)
-      expect(data['iv']).to eq('')
-      expect(data['auth_tag']).to eq('')
-      expect(data['seed']).to eq(seed)
-    end
-
-    it 'saves the seed when encryption is true' do
-      seed_wallet.save_seed!(file_path, encrypt: true)
-
-      # Verify that the file has new wallet.
-      stored_seed_data = File.read(file_path)
-      wallets = JSON.parse(stored_seed_data)
-      data = wallets[seed_wallet.id]
-      expect(data).not_to be_empty
-      expect(data['encrypted']).to eq(true)
-      expect(data['iv']).not_to be_empty
-      expect(data['auth_tag']).not_to be_empty
-      expect(data['seed']).not_to eq(seed)
-    end
-
-    it 'throws an error when the wallet is seedless' do
-      seedless_wallet = described_class.new(model_with_default_address, seed: '', address_models: [address_model1])
-      expect do
-        seedless_wallet.save_seed!(file_path)
-      end.to raise_error 'Wallet does not have seed loaded'
-    end
-
-    it 'throws an error when the file is malformed' do
-      File.open(file_path, 'w') do |file|
-        file.write(JSON.pretty_generate({
-          malformed: 'test'
-        }.to_json))
+      before do
+        wallet.save_seed!(file_path, encrypt: true)
       end
-      expect do
-        seed_wallet.save_seed!(file_path)
-      end.to raise_error(ArgumentError)
+
+      it 'saves an encrypted seed' do
+        expect(wallet_saved_data['seed']).not_to eq(seed)
+      end
+
+      it 'sets encrypted to true' do
+        expect(wallet_saved_data['encrypted']).to eq(true)
+      end
+
+      it 'sets the IV' do
+        expect(wallet_saved_data['iv']).not_to be_empty
+      end
+
+      it 'sets the auth tag' do
+        expect(wallet_saved_data['auth_tag']).not_to be_empty
+      end
+    end
+
+    context 'when the file does not exist' do
+      let(:file_path) { '/tmp/missing.json' }
+
+      before do
+        wallet.save_seed!(file_path)
+      end
+
+      it 'saves the wallet data to the new file' do
+        expect(saved_seed_data[wallet.id])
+          .to eq({ 'seed' => seed, 'encrypted' => false, 'iv' => '', 'auth_tag' => '' })
+      end
+    end
+
+    context 'when the file contains other wallet data' do
+      let(:initial_seed_data) do
+        {
+          SecureRandom.uuid => {}
+        }
+      end
+    end
+
+    context 'when the wallet is seedless' do
+      let(:seedless_wallet) { described_class.new(model_with_default_address, seed: '') }
+
+      it 'throws an error' do
+        expect do
+          seedless_wallet.save_seed!(file_path)
+        end.to raise_error 'Wallet does not have seed loaded'
+      end
+    end
+
+    context 'when the file is malformed' do
+      let(:file) do
+        Tempfile.new.tap do |f|
+          f.write('[1, 2, 3]')
+          f.rewind
+        end
+      end
+
+      it 'throws an error' do
+        expect do
+          wallet.save_seed!(file_path)
+        end.to raise_error(ArgumentError)
+      end
     end
   end
 
   describe '#load_seed' do
-    let(:file_path) { "#{SecureRandom.uuid}.json" }
-    let(:initial_seed_data) { JSON.pretty_generate({}) }
     let(:address_list_model) do
       Coinbase::Client::AddressList.new(
-        {
-          'data' => [address_model1],
-          'total_count' => 1
-        }
+        data: [address_model1],
+        total_count: 1
       )
     end
     let(:seed_wallet) do
-      described_class.new(model_with_default_address, seed: seed, address_models: [address_model1])
+      described_class.new(model_with_default_address, seed: seed)
     end
     let(:seedless_wallet) do
-      described_class.new(model_with_default_address, seed: '', address_models: [address_model1])
+      described_class.new(model_with_default_address, seed: '')
     end
     let(:initial_seed_data) do
       {
@@ -858,18 +1030,32 @@ describe Coinbase::Wallet do
       }
     end
 
-    before do
-      @api_key_private_key = Coinbase.configuration.api_key_private_key
-      Coinbase.configuration.api_key_private_key = OpenSSL::PKey::EC.generate('prime256v1').to_pem
-      File.open(file_path, 'w') do |file|
-        file.write(JSON.pretty_generate(initial_seed_data))
+    let(:configuration) do
+      instance_double(
+        Coinbase::Configuration,
+        use_server_signer: use_server_signer,
+        api_client: nil,
+        api_key_private_key: OpenSSL::PKey::EC.generate('prime256v1').to_pem
+      )
+    end
+
+    let(:file) do
+      Tempfile.new.tap do |f|
+        f.write(JSON.pretty_generate(initial_seed_data))
+        f.rewind
       end
     end
 
-    after do
-      File.delete(file_path) if File.exist?(file_path)
-      Coinbase.configuration.api_key_private_key = @api_key_private_key
+    let(:file_path) { file.path }
+
+    before do
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: [address_model1], total_count: 1))
     end
+
+    after { file.unlink }
 
     it 'loads the seed from the file' do
       seedless_wallet.load_seed(file_path)
@@ -885,7 +1071,7 @@ describe Coinbase::Wallet do
     it 'loads the encrypted seed from file with multiple seeds' do
       seed_wallet.save_seed!(file_path, encrypt: true)
 
-      other_model = Coinbase::Client::Wallet.new({ 'id': SecureRandom.uuid, 'network_id': network_id })
+      other_model = Coinbase::Client::Wallet.new(id: SecureRandom.uuid, network_id: network_id)
       other_wallet = described_class.new(other_model)
       other_wallet.save_seed!(file_path, encrypt: true)
 
@@ -899,30 +1085,34 @@ describe Coinbase::Wallet do
       end.to raise_error('Wallet already has seed loaded')
     end
 
-    it 'throws an error when file contains different wallet data' do
-      File.open(file_path, 'w') do |file|
-        file.write(JSON.pretty_generate(other_seed_data))
-      end
+    context 'when the file contains different wallet data' do
+      let(:initial_seed_data) { other_seed_data }
 
-      expect do
-        seedless_wallet.load_seed(file_path)
-      end.to raise_error(ArgumentError, /does not contain seed data for wallet/)
+      it 'throws an error when file contains different wallet data' do
+        expect do
+          seedless_wallet.load_seed(file_path)
+        end.to raise_error(ArgumentError, /does not contain seed data for wallet/)
+      end
     end
 
-    it 'throws an error when the file is absent' do
-      File.delete(file_path)
-      expect do
-        seedless_wallet.load_seed(file_path)
-      end.to raise_error(ArgumentError, /does not contain seed data/)
+    context 'when the file is empty' do
+      let(:file_path) { '/tmp/empty.json' }
+
+      it 'throws an error when the file is absent' do
+        expect do
+          seedless_wallet.load_seed(file_path)
+        end.to raise_error(ArgumentError, /does not contain seed data/)
+      end
     end
 
-    it 'throws an error when the backup file is corrupted' do
-      File.open(file_path, 'w') do |file|
-        file.write(JSON.pretty_generate(malformed_seed_data))
+    context 'when the backup file is corrupted' do
+      let(:initial_seed_data) { malformed_seed_data }
+
+      it 'throws an error when the backup file is corrupted' do
+        expect do
+          seedless_wallet.load_seed(file_path)
+        end.to raise_error(ArgumentError, 'Seed data is malformed')
       end
-      expect do
-        seedless_wallet.load_seed(file_path)
-      end.to raise_error(ArgumentError, 'Seed data is malformed')
     end
   end
 
@@ -937,7 +1127,7 @@ describe Coinbase::Wallet do
 
     context 'when the model has a default address' do
       subject(:wallet) do
-        described_class.new(model_with_default_address, seed: '', address_models: [address_model1])
+        described_class.new(model_with_default_address, seed: '')
       end
 
       it 'includes the default address' do


### PR DESCRIPTION
### What changed? Why?

This adds support for easily listing and fetching wallets without the overhead of the N+1 of fetching all of the addresses for all of the wallets we've fetched.

#### Listing wallets
```ruby
Coinbase::Wallet.list
```

```ruby
Coinbase.default_user.wallets
```

#### Fetching a wallet

Fetching a wallet returns a wallet object that is not in a signing state. If using the server signer then this wallet can be used for signing purposes however! If not using the server signer this wallet and be loaded with a seed and then used for signing.

```ruby
Coinbase::Wallet.fetch(wallet_id)
```

```ruby
Coinbase.default_user.get_wallet(wallet_id)
```


#### Qualified Impact
This changes the `user.wallets` behavior from something that returns an array of 2 elements, the first being an array of wallets and the second being a page token, into a proper enumerable response that the user can use to lazily fetch all wallets if needed.