### PR TITLE
Fix external addresses API reference

### DIFF
--- a/lib/coinbase/address/external_address.rb
+++ b/lib/coinbase/address/external_address.rb
@@ -49,7 +49,7 @@ module Coinbase
     private
 
     def addresses_api
-      @addresses_api ||= Coinbase::Client::AddressesApi.new(Coinbase.configuration.api_client)
+      @addresses_api ||= Coinbase::Client::ExternalAddressesApi.new(Coinbase.configuration.api_client)
     end
   end
 end


### PR DESCRIPTION

### What changed? Why?
This fixes the external addresses API reference which got split out of the addresses API in the generated client.


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->