### PR TITLE
Consolidate address balance and faucet endpoints

### DIFF
--- a/lib/coinbase/address/external_address.rb
+++ b/lib/coinbase/address/external_address.rb
@@ -7,47 +7,6 @@ module Coinbase
   # External addresses can be used to fetch balances, request funds from the faucet, etc...,
   # but cannot be used to sign transactions.
   class ExternalAddress < Address
-    # Returns the balances of the Address.
-    # @return [BalanceMap] The balances of the Address, keyed by asset ID. Ether balances are denominated
-    #  in ETH.
-    def balances
-      response = Coinbase.call_api do
-        addresses_api.list_external_address_balances(Coinbase.normalize_network(network_id), id)
-      end
-
-      Coinbase::BalanceMap.from_balances(response.data)
-    end
-
-    # Returns the balance of the provided Asset.
-    # @param asset_id [Symbol] The Asset to retrieve the balance for
-    # @return [BigDecimal] The balance of the Asset
-    def balance(asset_id)
-      response = Coinbase.call_api do
-        addresses_api.get_external_address_balance(
-          Coinbase.normalize_network(network_id),
-          id,
-          Coinbase::Asset.primary_denomination(asset_id).to_s
-        )
-      end
-
-      return BigDecimal('0') if response.nil?
-
-      Coinbase::Balance.from_model_and_asset_id(response, asset_id).amount
-    end
-
-    # Requests funds for the address from the faucet and returns the faucet transaction.
-    # This is only supported on testnet networks.
-    # @return [Coinbase::FaucetTransaction] The successful faucet transaction
-    # @raise [Coinbase::FaucetLimitReachedError] If the faucet limit has been reached for the address or user.
-    # @raise [Coinbase::Client::ApiError] If an unexpected error occurs while requesting faucet funds.
-    def faucet
-      Coinbase.call_api do
-        Coinbase::FaucetTransaction.new(
-          addresses_api.request_external_faucet_funds(Coinbase.normalize_network(network_id), id)
-        )
-      end
-    end
-
     # Builds a stake operation for the supplied asset. The stake operation
     # may take a few minutes to complete in the case when infrastructure is spun up.
     # @param amount [Integer,String,BigDecimal] The amount of the asset to stake
@@ -172,10 +131,6 @@ module Coinbase
     end
 
     private
-
-    def addresses_api
-      @addresses_api ||= Coinbase::Client::ExternalAddressesApi.new(Coinbase.configuration.api_client)
-    end
 
     def validate_can_stake!(amount, asset_id, mode, options)
       stakeable_balance = stakeable_balance(asset_id, mode: mode, options: options)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,5 @@ SimpleCov.start do
 end
 
 require_relative '../lib/coinbase'
+require_relative 'support/shared_examples/address_balances'
 require_relative 'support/shared_examples/pagination'

--- a/spec/support/shared_examples/address_balances.rb
+++ b/spec/support/shared_examples/address_balances.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+shared_examples 'an address that supports balance queries' do |_operation|
+  let(:eth_asset) do
+    Coinbase::Client::Asset.new(network_id: normalized_network_id, asset_id: 'eth', decimals: 18)
+  end
+  let(:usdc_asset) do
+    Coinbase::Client::Asset.new(network_id: normalized_network_id, asset_id: 'usdc', decimals: 6)
+  end
+  let(:weth_asset) do
+    Coinbase::Client::Asset.new(network_id: normalized_network_id, asset_id: 'weth', decimals: 18)
+  end
+  let(:external_addresses_api) { double('Coinbase::Client::ExternalAddressesApi') }
+
+  before do
+    allow(Coinbase::Client::ExternalAddressesApi).to receive(:new).and_return(external_addresses_api)
+  end
+
+  describe '#balances' do
+    let(:response) do
+      Coinbase::Client::AddressBalanceList.new(
+        data: [
+          Coinbase::Client::Balance.new(amount: '1000000000000000000', asset: eth_asset),
+          Coinbase::Client::Balance.new(amount: '5000000000', asset: usdc_asset),
+          Coinbase::Client::Balance.new(amount: '3000000000000000000', asset: weth_asset)
+        ]
+      )
+    end
+
+    before do
+      allow(external_addresses_api)
+        .to receive(:list_external_address_balances)
+        .with(normalized_network_id, address_id)
+        .and_return(response)
+    end
+
+    it 'returns a hash with balances' do
+      expect(address.balances).to eq(
+        eth: BigDecimal('1'),
+        usdc: BigDecimal('5000'),
+        weth: BigDecimal('3')
+      )
+    end
+
+    it 'lists external address balances' do
+      address.balances
+
+      expect(external_addresses_api)
+        .to have_received(:list_external_address_balances)
+        .with(normalized_network_id, address_id)
+    end
+  end
+
+  describe '#balance' do
+    let(:response) do
+      Coinbase::Client::Balance.new(amount: '1000000000000000000', asset: eth_asset)
+    end
+
+    before do
+      allow(external_addresses_api)
+        .to receive(:get_external_address_balance)
+        .with(normalized_network_id, address_id, primary_denomination)
+        .and_return(response)
+    end
+
+    context 'when the asset_id is :eth' do
+      let(:asset_id) { :eth }
+      let(:primary_denomination) { 'eth' }
+
+      it 'returns the correct ETH balance' do
+        expect(address.balance(:eth)).to eq BigDecimal('1')
+      end
+    end
+
+    context 'when the asset_id is :gwei' do
+      let(:asset_id) { :gwei }
+      let(:primary_denomination) { 'eth' }
+
+      it 'returns the correct Gwei balance' do
+        expect(address.balance(:gwei)).to eq BigDecimal('1_000_000_000')
+      end
+    end
+
+    context 'when the asset_id is :wei' do
+      let(:asset_id) { :wei }
+      let(:primary_denomination) { 'eth' }
+
+      it 'returns the correct Wei balance' do
+        expect(address.balance(:wei)).to eq BigDecimal('1_000_000_000_000_000_000')
+      end
+    end
+
+    context 'when the asset id is a non-eth denomination' do
+      let(:asset_id) { :other }
+      let(:primary_denomination) { 'other' }
+      let(:decimals) { 7 }
+      let(:other_asset) do
+        Coinbase::Client::Asset.new(network_id: normalized_network_id, asset_id: 'other', decimals: decimals)
+      end
+      let(:response) do
+        Coinbase::Client::Balance.new(amount: '1000000000000000000', asset: other_asset)
+      end
+
+      it 'returns the correct balance' do
+        expect(address.balance(:other)).to eq BigDecimal('100_000_000_000')
+      end
+    end
+
+    context 'when there is no response' do
+      let(:response) { nil }
+      let(:asset_id) { :eth }
+      let(:primary_denomination) { 'eth' }
+
+      it 'returns 0' do
+        expect(address.balance(:eth)).to eq BigDecimal('0')
+      end
+    end
+  end
+end
+
+shared_examples 'an address that supports requesting faucet funds' do |_operation|
+  let(:external_addresses_api) { double('Coinbase::Client::ExternalAddressesApi') }
+
+  before do
+    allow(Coinbase::Client::ExternalAddressesApi).to receive(:new).and_return(external_addresses_api)
+  end
+
+  describe '#faucet' do
+    let(:tx_hash) { '0xdeadbeef' }
+    let(:faucet_tx) do
+      instance_double('Coinbase::Client::FaucetTransaction', transaction_hash: tx_hash)
+    end
+
+    context 'when the request is successful' do
+      subject(:faucet_response) { address.faucet }
+
+      before do
+        expect(external_addresses_api)
+          .to receive(:request_external_faucet_funds)
+          .with(normalized_network_id, address_id)
+          .and_return(faucet_tx)
+      end
+
+      it 'requests funds from the faucet and returns the faucet transaction' do
+        expect(faucet_response).to be_a(Coinbase::FaucetTransaction)
+        expect(faucet_response.transaction_hash).to eq(tx_hash)
+      end
+    end
+
+    context 'when the request is unsuccesful' do
+      before do
+        expect(external_addresses_api)
+          .to receive(:request_external_faucet_funds)
+          .with(normalized_network_id, address_id)
+          .and_raise(api_error)
+      end
+
+      context 'when the faucet limit is reached' do
+        let(:api_error) do
+          Coinbase::Client::ApiError.new(
+            code: 429,
+            response_body: {
+              'code' => 'faucet_limit_reached',
+              'message' => 'failed to claim funds - address likely has already claimed in the past 24 hours'
+            }.to_json
+          )
+        end
+
+        it 'raises a FaucetLimitReachedError' do
+          expect { address.faucet }.to raise_error(::Coinbase::FaucetLimitReachedError)
+        end
+      end
+
+      context 'when the request fails unexpectedly' do
+        let(:api_error) do
+          Coinbase::Client::ApiError.new(
+            code: 500,
+            response_body: {
+              'code' => 'internal',
+              'message' => 'unexpected error occurred while requesting faucet funds'
+            }.to_json
+          )
+        end
+
+        it 'raises an internal error' do
+          expect { address.faucet }.to raise_error(::Coinbase::InternalError)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/coinbase/address/external_address_spec.rb
+++ b/spec/unit/coinbase/address/external_address_spec.rb
@@ -4,10 +4,7 @@ describe Coinbase::ExternalAddress do
   let(:network_id) { :ethereum_mainnet }
   let(:normalized_network_id) { 'ethereum-mainnet' }
   let(:address_id) { '0x1234' }
-  let(:external_addresses_api) { instance_double(Coinbase::Client::ExternalAddressesApi) }
   let(:stake_api) { instance_double(Coinbase::Client::StakeApi) }
-  let(:id) { '0x1234' }
-  let(:address) { described_class.new(network_id, id) }
   let(:eth_asset) do
     Coinbase::Client::Asset.new(network_id: normalized_network_id, asset_id: 'eth', decimals: 18)
   end
@@ -37,7 +34,6 @@ describe Coinbase::ExternalAddress do
   end
 
   before do
-    allow(Coinbase::Client::ExternalAddressesApi).to receive(:new).and_return(external_addresses_api)
     allow(Coinbase::Client::StakeApi).to receive(:new).and_return(stake_api)
     allow(Coinbase::Asset).to receive(:fetch).and_return(
       Coinbase::Asset.from_model(eth_asset)
@@ -63,40 +59,8 @@ describe Coinbase::ExternalAddress do
     end
   end
 
-  describe '#balances' do
-    let(:response) do
-      Coinbase::Client::AddressBalanceList.new(
-        data: [
-          Coinbase::Client::Balance.new(amount: '1000000000000000000', asset: eth_asset),
-          Coinbase::Client::Balance.new(amount: '5000000000', asset: usdc_asset),
-          Coinbase::Client::Balance.new(amount: '3000000000000000000', asset: weth_asset)
-        ]
-      )
-    end
-
-    before do
-      allow(external_addresses_api)
-        .to receive(:list_external_address_balances)
-        .with(normalized_network_id, address_id)
-        .and_return(response)
-    end
-
-    it 'returns a hash with balances' do
-      expect(address.balances).to eq(
-        eth: BigDecimal('1'),
-        usdc: BigDecimal('5000'),
-        weth: BigDecimal('3')
-      )
-    end
-
-    it 'lists external address balances' do
-      address.balances
-
-      expect(external_addresses_api)
-        .to have_received(:list_external_address_balances)
-        .with(normalized_network_id, address_id)
-    end
-  end
+  it_behaves_like 'an address that supports balance queries'
+  it_behaves_like 'an address that supports requesting faucet funds'
 
   shared_examples 'it builds a staking operation' do |operation|
     let(:transaction) { instance_double('Coinbase::Client::Transaction') }
@@ -122,7 +86,7 @@ describe Coinbase::ExternalAddress do
       subject
       expect(stake_api).to have_received(:build_staking_operation).with(
         asset_id: eth_asset.asset_id,
-        address_id: id,
+        address_id: address_id,
         action: operation,
         network_id: 'ethereum-mainnet',
         options: { amount: (10**18).to_s, mode: mode }
@@ -161,137 +125,6 @@ describe Coinbase::ExternalAddress do
     it_behaves_like 'it builds a staking operation', 'claim_stake'
   end
 
-  describe '#balance' do
-    let(:response) do
-      Coinbase::Client::Balance.new(amount: '1000000000000000000', asset: eth_asset)
-    end
-
-    before do
-      allow(external_addresses_api)
-        .to receive(:get_external_address_balance)
-        .with(normalized_network_id, address_id, primary_denomination)
-        .and_return(response)
-    end
-
-    context 'when the asset_id is :eth' do
-      let(:asset_id) { :eth }
-      let(:primary_denomination) { 'eth' }
-
-      it 'returns the correct ETH balance' do
-        expect(address.balance(:eth)).to eq BigDecimal('1')
-      end
-    end
-
-    context 'when the asset_id is :gwei' do
-      let(:asset_id) { :gwei }
-      let(:primary_denomination) { 'eth' }
-
-      it 'returns the correct Gwei balance' do
-        expect(address.balance(:gwei)).to eq BigDecimal('1_000_000_000')
-      end
-    end
-
-    context 'when the asset_id is :wei' do
-      let(:asset_id) { :wei }
-      let(:primary_denomination) { 'eth' }
-
-      it 'returns the correct Wei balance' do
-        expect(address.balance(:wei)).to eq BigDecimal('1_000_000_000_000_000_000')
-      end
-    end
-
-    context 'when the asset id is a non-eth denomination' do
-      let(:asset_id) { :other }
-      let(:primary_denomination) { 'other' }
-      let(:decimals) { 7 }
-      let(:other_asset) do
-        Coinbase::Client::Asset.new(network_id: 'base-sepolia', asset_id: 'other', decimals: decimals)
-      end
-      let(:response) do
-        Coinbase::Client::Balance.new(amount: '1000000000000000000', asset: other_asset)
-      end
-
-      it 'returns the correct balance' do
-        expect(address.balance(:other)).to eq BigDecimal('100_000_000_000')
-      end
-    end
-
-    context 'when there is no response' do
-      let(:response) { nil }
-      let(:asset_id) { :eth }
-      let(:primary_denomination) { 'eth' }
-
-      it 'returns 0' do
-        expect(address.balance(:eth)).to eq BigDecimal('0')
-      end
-    end
-  end
-
-  describe '#faucet' do
-    let(:request) { double('Request', transaction: transaction) }
-    let(:tx_hash) { '0xdeadbeef' }
-    let(:faucet_tx) do
-      instance_double('Coinbase::Client::FaucetTransaction', transaction_hash: tx_hash)
-    end
-
-    context 'when the request is successful' do
-      subject(:faucet_response) { address.faucet }
-
-      before do
-        expect(external_addresses_api)
-          .to receive(:request_external_faucet_funds)
-          .with(normalized_network_id, address_id)
-          .and_return(faucet_tx)
-      end
-
-      it 'requests funds from the faucet and returns the faucet transaction' do
-        expect(faucet_response).to be_a(Coinbase::FaucetTransaction)
-        expect(faucet_response.transaction_hash).to eq(tx_hash)
-      end
-    end
-
-    context 'when the request is unsuccesful' do
-      before do
-        expect(external_addresses_api)
-          .to receive(:request_external_faucet_funds)
-          .with(normalized_network_id, address_id)
-          .and_raise(api_error)
-      end
-
-      context 'when the faucet limit is reached' do
-        let(:api_error) do
-          Coinbase::Client::ApiError.new(
-            code: 429,
-            response_body: {
-              'code' => 'faucet_limit_reached',
-              'message' => 'failed to claim funds - address likely has already claimed in the past 24 hours'
-            }.to_json
-          )
-        end
-
-        it 'raises a FaucetLimitReachedError' do
-          expect { address.faucet }.to raise_error(::Coinbase::FaucetLimitReachedError)
-        end
-      end
-
-      context 'when the request fails unexpectedly' do
-        let(:api_error) do
-          Coinbase::Client::ApiError.new(
-            code: 500,
-            response_body: {
-              'code' => 'internal',
-              'message' => 'unexpected error occurred while requesting faucet funds'
-            }.to_json
-          )
-        end
-
-        it 'raises an internal error' do
-          expect { address.faucet }.to raise_error(::Coinbase::InternalError)
-        end
-      end
-    end
-  end
-
   shared_examples 'it called staking context balances' do
     it 'creates a new staking_api_client' do
       subject
@@ -304,7 +137,7 @@ describe Coinbase::ExternalAddress do
 
       expect(stake_api).to have_received(:get_staking_context).with(
         asset_id: eth_asset.asset_id,
-        address_id: id,
+        address_id: address_id,
         network_id: 'ethereum-mainnet',
         options: {
           mode: mode
@@ -357,7 +190,7 @@ describe Coinbase::ExternalAddress do
       expect(Coinbase::StakingReward).to receive(:list).with(
         network_id,
         eth_asset.asset_id,
-        [id],
+        [address_id],
         start_time: start_time,
         end_time: start_time,
         format: :usd

--- a/spec/unit/coinbase/address/wallet_address_spec.rb
+++ b/spec/unit/coinbase/address/wallet_address_spec.rb
@@ -24,13 +24,13 @@ describe Coinbase::WalletAddress do
   let(:weth_asset) do
     Coinbase::Client::Asset.new(network_id: normalized_network_id, asset_id: 'weth', decimals: 18)
   end
-  let(:addresses_api) { double('Coinbase::Client::AddressesApi') }
+  let(:addresses_api) { double('Coinbase::Client::ExternalAddressesApi') }
   let(:assets_api) { double('Coinbase::Client::AssetsApi') }
   let(:transfers_api) { double('Coinbase::Client::TransfersApi') }
   let(:trades_api) { double('Coinbase::Client::TradesApi') }
 
   before(:each) do
-    allow(Coinbase::Client::AddressesApi).to receive(:new).and_return(addresses_api)
+    allow(Coinbase::Client::ExternalAddressesApi).to receive(:new).and_return(addresses_api)
     allow(Coinbase::Client::AssetsApi).to receive(:new).and_return(assets_api)
     allow(Coinbase::Client::TransfersApi).to receive(:new).and_return(transfers_api)
     allow(Coinbase::Client::TradesApi).to receive(:new).and_return(trades_api)
@@ -113,96 +113,9 @@ describe Coinbase::WalletAddress do
     end
   end
 
-  describe '#balances' do
-    let(:response) do
-      Coinbase::Client::AddressBalanceList.new(
-        data: [
-          Coinbase::Client::Balance.new(amount: '1000000000000000000', asset: eth_asset),
-          Coinbase::Client::Balance.new(amount: '5000000000', asset: usdc_asset),
-          Coinbase::Client::Balance.new(amount: '3000000000000000000', asset: weth_asset)
-        ]
-      )
-    end
+  it_behaves_like 'an address that supports balance queries'
 
-    it 'returns a hash with balances' do
-      expect(addresses_api)
-        .to receive(:list_address_balances)
-        .with(wallet_id, address_id)
-        .and_return(response)
-
-      expect(address.balances).to eq(
-        eth: BigDecimal('1'),
-        usdc: BigDecimal('5000'),
-        weth: BigDecimal('3')
-      )
-    end
-  end
-
-  describe '#balance' do
-    let(:response) do
-      Coinbase::Client::Balance.new(amount: '1000000000000000000', asset: eth_asset)
-    end
-
-    before do
-      allow(addresses_api)
-        .to receive(:get_address_balance)
-        .with(wallet_id, address_id, primary_denomination)
-        .and_return(response)
-    end
-
-    context 'when the asset_id is :eth' do
-      let(:asset_id) { :eth }
-      let(:primary_denomination) { 'eth' }
-
-      it 'returns the correct ETH balance' do
-        expect(address.balance(:eth)).to eq BigDecimal('1')
-      end
-    end
-
-    context 'when the asset_id is :gwei' do
-      let(:asset_id) { :gwei }
-      let(:primary_denomination) { 'eth' }
-
-      it 'returns the correct Gwei balance' do
-        expect(address.balance(:gwei)).to eq BigDecimal('1_000_000_000')
-      end
-    end
-
-    context 'when the asset_id is :wei' do
-      let(:asset_id) { :wei }
-      let(:primary_denomination) { 'eth' }
-
-      it 'returns the correct Wei balance' do
-        expect(address.balance(:wei)).to eq BigDecimal('1_000_000_000_000_000_000')
-      end
-    end
-
-    context 'when the asset id is a non-eth denomination' do
-      let(:asset_id) { :other }
-      let(:primary_denomination) { 'other' }
-      let(:decimals) { 7 }
-      let(:other_asset) do
-        Coinbase::Client::Asset.new(network_id: 'base-sepolia', asset_id: 'other', decimals: decimals)
-      end
-      let(:response) do
-        Coinbase::Client::Balance.new(amount: '1000000000000000000', asset: other_asset)
-      end
-
-      it 'returns the correct balance' do
-        expect(address.balance(:other)).to eq BigDecimal('100_000_000_000')
-      end
-    end
-
-    context 'when there is no response' do
-      let(:response) { nil }
-      let(:asset_id) { :eth }
-      let(:primary_denomination) { 'eth' }
-
-      it 'returns 0' do
-        expect(address.balance(:eth)).to eq BigDecimal('0')
-      end
-    end
-  end
+  it_behaves_like 'an address that supports requesting faucet funds'
 
   describe '#transfer' do
     let(:eth_balance_response) do
@@ -277,8 +190,8 @@ describe Coinbase::WalletAddress do
 
       before do
         allow(addresses_api)
-          .to receive(:get_address_balance)
-          .with(wallet_id, address_id, transfer_asset_id)
+          .to receive(:get_external_address_balance)
+          .with(normalized_network_id, address_id, transfer_asset_id)
           .and_return(balance_response)
 
         allow(transfers_api)
@@ -466,8 +379,8 @@ describe Coinbase::WalletAddress do
 
       before do
         expect(addresses_api)
-          .to receive(:get_address_balance)
-          .with(wallet_id, address_id, 'eth')
+          .to receive(:get_external_address_balance)
+          .with(normalized_network_id, address_id, 'eth')
           .and_return(eth_balance_response)
       end
 
@@ -506,8 +419,8 @@ describe Coinbase::WalletAddress do
         allow(Coinbase).to receive(:configuration).and_return(configuration)
 
         allow(addresses_api)
-          .to receive(:get_address_balance)
-          .with(wallet_id, address_id, transfer_asset_id)
+          .to receive(:get_external_address_balance)
+          .with(normalized_network_id, address_id, transfer_asset_id)
           .and_return(balance_response)
 
         allow(transfers_api)
@@ -519,8 +432,8 @@ describe Coinbase::WalletAddress do
 
       it 'creates a transfer without broadcast' do
         expect(addresses_api)
-          .to receive(:get_address_balance)
-          .with(wallet_id, address_id, 'eth')
+          .to receive(:get_external_address_balance)
+          .with(normalized_network_id, address_id, 'eth')
           .and_return(eth_balance_response)
         expect(transfers_api)
           .to receive(:create_transfer)
@@ -621,8 +534,8 @@ describe Coinbase::WalletAddress do
 
       before do
         allow(addresses_api)
-          .to receive(:get_address_balance)
-          .with(wallet_id, address_id, normalized_from_asset_id)
+          .to receive(:get_external_address_balance)
+          .with(normalized_network_id, address_id, normalized_from_asset_id)
           .and_return(balance_response)
 
         allow(trades_api)
@@ -743,8 +656,8 @@ describe Coinbase::WalletAddress do
 
       before do
         expect(addresses_api)
-          .to receive(:get_address_balance)
-          .with(wallet_id, address_id, 'eth')
+          .to receive(:get_external_address_balance)
+          .with(normalized_network_id, address_id, 'eth')
           .and_return(eth_balance_response)
       end
 
@@ -755,71 +668,6 @@ describe Coinbase::WalletAddress do
           ArgumentError,
           "Insufficient funds: #{excessive_amount} requested, but only #{current_balance} available"
         )
-      end
-    end
-  end
-
-  describe '#faucet' do
-    let(:request) { double('Request', transaction: transaction) }
-    let(:tx_hash) { '0xdeadbeef' }
-    let(:faucet_tx) do
-      instance_double('Coinbase::Client::FaucetTransaction', transaction_hash: tx_hash)
-    end
-
-    context 'when the request is successful' do
-      subject(:faucet_response) { address.faucet }
-
-      before do
-        expect(addresses_api)
-          .to receive(:request_faucet_funds)
-          .with(wallet_id, address_id)
-          .and_return(faucet_tx)
-      end
-
-      it 'requests funds from the faucet and returns the faucet transaction' do
-        expect(faucet_response).to be_a(Coinbase::FaucetTransaction)
-        expect(faucet_response.transaction_hash).to eq(tx_hash)
-      end
-    end
-
-    context 'when the request is unsuccesful' do
-      before do
-        expect(addresses_api)
-          .to receive(:request_faucet_funds)
-          .with(wallet_id, address_id)
-          .and_raise(api_error)
-      end
-
-      context 'when the faucet limit is reached' do
-        let(:api_error) do
-          Coinbase::Client::ApiError.new(
-            code: 429,
-            response_body: {
-              'code' => 'faucet_limit_reached',
-              'message' => 'failed to claim funds - address likely has already claimed in the past 24 hours'
-            }.to_json
-          )
-        end
-
-        it 'raises a FaucetLimitReachedError' do
-          expect { address.faucet }.to raise_error(::Coinbase::FaucetLimitReachedError)
-        end
-      end
-
-      context 'when the request fails unexpectedly' do
-        let(:api_error) do
-          Coinbase::Client::ApiError.new(
-            code: 500,
-            response_body: {
-              'code' => 'internal',
-              'message' => 'unexpected error occurred while requesting faucet funds'
-            }.to_json
-          )
-        end
-
-        it 'raises an internal error' do
-          expect { address.faucet }.to raise_error(::Coinbase::InternalError)
-        end
       end
     end
   end

--- a/spec/unit/coinbase/address_spec.rb
+++ b/spec/unit/coinbase/address_spec.rb
@@ -2,48 +2,43 @@
 
 describe Coinbase::Address do
   let(:network_id) { :ethereum_mainnet }
-  let(:id) { '0x1234' }
-  let(:model) { described_class.new(network_id, id) }
+  let(:normalized_network_id) { 'ethereum-mainnet' }
+  let(:address_id) { '0x1234' }
+
+  subject(:address) { described_class.new(network_id, address_id) }
 
   describe '#id' do
-    subject { model.id }
+    subject { address.id }
 
-    it { is_expected.to eq(id) }
+    it { is_expected.to eq(address_id) }
   end
 
   describe '#network_id' do
-    subject { model.network_id }
+    subject { address.network_id }
 
     it { is_expected.to eq(network_id) }
   end
 
+  describe '#to_s' do
+    subject { address.to_s }
+
+    it 'includes the network ID and address ID' do
+      expect(subject).to include(network_id.to_s, address_id)
+    end
+  end
+
   describe '#inspect' do
     it 'matches to_s' do
-      expect(model.inspect).to eq(model.to_s)
+      expect(address.inspect).to eq(address.to_s)
     end
   end
 
   describe '#can_sign?' do
-    subject { model.can_sign? }
+    subject { address.can_sign? }
 
     it { is_expected.to be(false) }
   end
 
-  describe '#balances' do
-    it 'raises an error' do
-      expect { model.balances }.to raise_error(NotImplementedError, 'Must be implemented by subclass')
-    end
-  end
-
-  describe '#balance' do
-    it 'raises an error' do
-      expect { model.balance(:eth) }.to raise_error(NotImplementedError, 'Must be implemented by subclass')
-    end
-  end
-
-  describe '#faucet' do
-    it 'raises an error' do
-      expect { model.faucet }.to raise_error(NotImplementedError, 'Must be implemented by subclass')
-    end
-  end
+  it_behaves_like 'an address that supports balance queries'
+  it_behaves_like 'an address that supports requesting faucet funds'
 end


### PR DESCRIPTION
### What changed? Why?
This consolidates the address balance and faucet endpoints to use the non-wallet scoped ones.

This will enable us to consolidate our APIs eventually


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->

This is a cleanup task and should not impact any behavior.