### PR TITLE
Support faucet transaction link

### DIFF
--- a/lib/coinbase/client/models/faucet_transaction.rb
+++ b/lib/coinbase/client/models/faucet_transaction.rb
@@ -14,14 +14,19 @@ require 'date'
 require 'time'
 
 module Coinbase::Client
+  # The faucet transaction
   class FaucetTransaction
     # The transaction hash of the transaction the faucet created.
     attr_accessor :transaction_hash
 
+    # Link to the transaction on the blockchain explorer.
+    attr_accessor :transaction_link
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
-        :'transaction_hash' => :'transaction_hash'
+        :'transaction_hash' => :'transaction_hash',
+        :'transaction_link' => :'transaction_link'
       }
     end
 
@@ -33,7 +38,8 @@ module Coinbase::Client
     # Attribute type mapping.
     def self.openapi_types
       {
-        :'transaction_hash' => :'String'
+        :'transaction_hash' => :'String',
+        :'transaction_link' => :'String'
       }
     end
 
@@ -63,6 +69,12 @@ module Coinbase::Client
       else
         self.transaction_hash = nil
       end
+
+      if attributes.key?(:'transaction_link')
+        self.transaction_link = attributes[:'transaction_link']
+      else
+        self.transaction_link = nil
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -74,6 +86,10 @@ module Coinbase::Client
         invalid_properties.push('invalid value for "transaction_hash", transaction_hash cannot be nil.')
       end
 
+      if @transaction_link.nil?
+        invalid_properties.push('invalid value for "transaction_link", transaction_link cannot be nil.')
+      end
+
       invalid_properties
     end
 
@@ -82,6 +98,7 @@ module Coinbase::Client
     def valid?
       warn '[DEPRECATED] the `valid?` method is obsolete'
       return false if @transaction_hash.nil?
+      return false if @transaction_link.nil?
       true
     end
 
@@ -90,7 +107,8 @@ module Coinbase::Client
     def ==(o)
       return true if self.equal?(o)
       self.class == o.class &&
-          transaction_hash == o.transaction_hash
+          transaction_hash == o.transaction_hash &&
+          transaction_link == o.transaction_link
     end
 
     # @see the `==` method
@@ -102,7 +120,7 @@ module Coinbase::Client
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [transaction_hash].hash
+      [transaction_hash, transaction_link].hash
     end
 
     # Builds the object from hash

--- a/lib/coinbase/faucet_transaction.rb
+++ b/lib/coinbase/faucet_transaction.rb
@@ -12,8 +12,6 @@ module Coinbase
       @model = model
     end
 
-    attr_reader :model
-
     # Returns the transaction hash.
     # @return [String] The onchain transaction hash
     def transaction_hash
@@ -23,8 +21,7 @@ module Coinbase
     # Returns the link to the transaction on the blockchain explorer.
     # @return [String] The link to the transaction on the blockchain explorer
     def transaction_link
-      # TODO: Parameterize this by Network.
-      "https://sepolia.basescan.org/tx/#{transaction_hash}"
+      model.transaction_link
     end
 
     # Returns a String representation of the FaucetTransaction.
@@ -38,5 +35,9 @@ module Coinbase
     def inspect
       to_s
     end
+
+    private
+
+    attr_reader :model
   end
 end

--- a/spec/unit/coinbase/faucet_transaction_spec.rb
+++ b/spec/unit/coinbase/faucet_transaction_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+describe Coinbase::FaucetTransaction do
+  let(:transaction_hash) { '0x6c087c1676e8269dd81e0777244584d0cbfd39b6997b3477242a008fa9349e11' }
+  let(:transaction_link) { "https://sepolia.basescan.org/tx/#{transaction_hash}" }
+  let(:model) do
+    Coinbase::Client::FaucetTransaction.new(
+      transaction_hash: transaction_hash,
+      transaction_link: transaction_link
+    )
+  end
+
+  subject(:faucet_transaction) { described_class.new(model) }
+
+  describe '#initialize' do
+    it 'initializes a new FaucetTransaction' do
+      expect(faucet_transaction).to be_a(Coinbase::FaucetTransaction)
+    end
+  end
+
+  describe '#transaction_hash' do
+    it 'returns the transaction hash' do
+      expect(faucet_transaction.transaction_hash).to eq(transaction_hash)
+    end
+  end
+
+  describe '#transaction_link' do
+    it 'returns the transaction link' do
+      expect(faucet_transaction.transaction_link).to eq(transaction_link)
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns a string representation of the FaucetTransaction' do
+      expect(faucet_transaction.to_s).to eq(
+        "Coinbase::FaucetTransaction{transaction_hash: '#{transaction_hash}', transaction_link: '#{transaction_link}'}"
+      )
+    end
+  end
+
+  describe '#inspect' do
+    it 'returns the same string representation as #to_s' do
+      expect(faucet_transaction.inspect).to eq(faucet_transaction.to_s)
+    end
+  end
+end


### PR DESCRIPTION

### What changed? Why?
This adds support for faucet transaction link's provided by the backend. This support faucets on multiple networks not just `base-sepolia`


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->