### PR TITLE
Add graceful auth error handling

### DIFF
--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -134,4 +134,10 @@ module Coinbase
   def self.use_server_signer?
     Coinbase.configuration.use_server_signer
   end
+
+  # Returns whether the SDK is configured.
+  # @return [bool] whether the SDK is configured
+  def self.configured?
+    !Coinbase.configuration.api_key_name.nil? && !Coinbase.configuration.api_key_private_key.nil?
+  end
 end

--- a/lib/coinbase/authenticator.rb
+++ b/lib/coinbase/authenticator.rb
@@ -45,6 +45,8 @@ module Coinbase
         uris: [uri]
       }
 
+      raise Coinbase::InvalidConfiguration, 'API key not configured' unless Coinbase.configured?
+
       private_key = OpenSSL::PKey.read(Coinbase.configuration.api_key_private_key)
       JWT.encode(claims, private_key, 'ES256', header)
     end

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -143,6 +143,8 @@ module Coinbase
     #   instantiated without a seed and its corresponding private keys.
     #   with the Wallet. If not provided, the Wallet will derive the first default address.
     def initialize(model, seed: nil)
+      raise ArgumentError, 'model must be a Wallet' unless model.is_a?(Coinbase::Client::Wallet)
+
       @model = model
 
       return if Coinbase.use_server_signer?

--- a/spec/unit/coinbase/authenticator_spec.rb
+++ b/spec/unit/coinbase/authenticator_spec.rb
@@ -29,11 +29,18 @@ describe Coinbase::Authenticator do
 
   describe '#build_jwt' do
     let(:uri) { 'https://cdp.api.coinbase.com/v1/users/me' }
+    subject(:jwt) { authenticator.build_jwt(uri) }
 
     it 'builds a JWT for the given endpoint URI' do
-      jwt = authenticator.build_jwt(uri)
-
       expect(jwt).to be_a(String)
+    end
+
+    context 'when an API key is not configured' do
+      let(:api_key_private_key) { nil }
+
+      it 'raises an exception' do
+        expect { jwt }.to raise_error(Coinbase::InvalidConfiguration, /API key not configured/)
+      end
     end
   end
 end

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -321,7 +321,15 @@ describe Coinbase::Wallet do
       expect(wallet.instance_variable_get(:@model)).to eq(model)
     end
 
-    describe 'when no seed is provided' do
+    context 'when the model is not a wallet' do
+      it 'raises an error' do
+        expect do
+          described_class.new(nil)
+        end.to raise_error(ArgumentError, 'model must be a Wallet')
+      end
+    end
+
+    context 'when no seed is provided' do
       before do
         allow(MoneyTree::Master).to receive(:new).and_call_original
       end


### PR DESCRIPTION
### What changed? Why?

This improves the error handling when an API key is not initialized as it returns a very vague error:

Previous errors:
```
TypeError: no implicit conversion of nil into String
from /Users/alexstone/src/coinbase-sdk-ruby/lib/coinbase/authenticator.rb:48:in `read'
```

New error:
```
Coinbase::InvalidConfiguration: API key not configured
from /Users/alexstone/src/coinbase-sdk-ruby/lib/coinbase/authenticator.rb:48:in `build_jwt'
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->