### PR TITLE
[chore] fix flaky e2e test

### DIFF
--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -109,7 +109,8 @@ def transfer_test(imported_address, new_address)
   puts "Transferred 1 Gwei from #{imported_address} to #{new_address}"
 
   # Fund the new address with faucet.
-  puts(new_address.faucet)
+  faucet_tx = new_address.faucet
+  puts "Requested faucet funds: #{faucet_tx}"
 
   # Transfer eth back from new address to imported address.
   t = new_address.transfer(0.008, :eth, imported_address).wait!

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -108,15 +108,13 @@ def transfer_test(imported_address, new_address)
   expect(t.status).to eq('complete')
   puts "Transferred 1 Gwei from #{imported_address} to #{new_address}"
 
-  # Transfer some eth for gas fee to new address.
-  t2 = imported_address.transfer(0.0001, :eth, new_address).wait!
-  expect(t2.status).to eq('complete')
-  puts "Transferred 0.00001 Eth from #{imported_address} to #{new_address}"
+  # Fund the new address with faucet.
+  new_address.faucet
 
-  # Transfer gwei back from new address to imported address.
-  t = new_address.transfer(1, :gwei, imported_address).wait!
+  # Transfer eth back from new address to imported address.
+  t = new_address.transfer(0.008, :eth, imported_address).wait!
   expect(t.status).to eq('complete')
-  puts "Transferred 1 Gwei from #{new_address} to #{imported_address}"
+  puts "Transferred 0.008 eth from #{new_address} to #{imported_address}"
 
   puts 'Fetching updated balances...'
   first_balance = imported_address.balances

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -103,7 +103,7 @@ end
 
 def transfer_test(imported_address, new_address)
   # Transfer gwei from imported address to new address.
-  puts 'Transfering 1 Gwei from imported address to new address...'
+  puts 'Transferring 1 Gwei from imported address to new address...'
   t = imported_address.transfer(1, :gwei, new_address).wait!
   expect(t.status).to eq('complete')
   puts "Transferred 1 Gwei from #{imported_address} to #{new_address}"

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -109,7 +109,7 @@ def transfer_test(imported_address, new_address)
   puts "Transferred 1 Gwei from #{imported_address} to #{new_address}"
 
   # Fund the new address with faucet.
-  new_address.faucet
+  puts(new_address.faucet)
 
   # Transfer eth back from new address to imported address.
   t = new_address.transfer(0.008, :eth, imported_address).wait!

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -109,7 +109,7 @@ def transfer_test(imported_address, new_address)
   puts "Transferred 1 Gwei from #{imported_address} to #{new_address}"
 
   # Transfer some eth for gas fee to new address.
-  t2 = imported_address.transfer(0.00001, :eth, new_address).wait!
+  t2 = imported_address.transfer(0.0001, :eth, new_address).wait!
   expect(t2.status).to eq('complete')
   puts "Transferred 0.00001 Eth from #{imported_address} to #{new_address}"
 


### PR DESCRIPTION
### What changed? Why?
Change e2e test to 
1. Move 1 gwei from imported address to new address
2. Fund new address with faucet
3. Move eth from new address to imported address

The old flow is
1. Move 1 gwei from imported to new
2. Move eth from imported to new
3. Move gwei from new to imported

This caused flaky errors because new address often didnt have enough gas

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->