### PR TITLE
Expose address id for staking reward

### DIFF
--- a/lib/coinbase/staking_reward.rb
+++ b/lib/coinbase/staking_reward.rb
@@ -47,6 +47,12 @@ module Coinbase
       @model.date
     end
 
+    # Returns the onchain address of the StakingReward.
+    # @return [Time] The onchain address
+    def address_id
+      @model.address_id
+    end
+
     # Returns a string representation of the StakingReward.
     # @return [String] a string representation of the StakingReward
     def to_s

--- a/spec/unit/coinbase/staking_reward_spec.rb
+++ b/spec/unit/coinbase/staking_reward_spec.rb
@@ -10,7 +10,9 @@ describe Coinbase::StakingReward do
   let(:stake_api) { instance_double(Coinbase::Client::StakeApi) }
   let(:format) { :usd }
   let(:has_more) { false }
-  let(:staking_reward_model) { instance_double(Coinbase::Client::StakingReward, amount: 100, date: '2024-07-17', address_id: 'some-address') }
+  let(:staking_reward_model) do
+    instance_double(Coinbase::Client::StakingReward, amount: 100, date: '2024-07-17', address_id: 'some-address')
+  end
 
   before do
     allow(Coinbase::Asset).to receive(:fetch).and_return(asset)

--- a/spec/unit/coinbase/staking_reward_spec.rb
+++ b/spec/unit/coinbase/staking_reward_spec.rb
@@ -10,7 +10,7 @@ describe Coinbase::StakingReward do
   let(:stake_api) { instance_double(Coinbase::Client::StakeApi) }
   let(:format) { :usd }
   let(:has_more) { false }
-  let(:staking_reward_model) { instance_double(Coinbase::Client::StakingReward, amount: 100) }
+  let(:staking_reward_model) { instance_double(Coinbase::Client::StakingReward, amount: 100, date: '2024-07-17', address_id: 'some-address') }
 
   before do
     allow(Coinbase::Asset).to receive(:fetch).and_return(asset)
@@ -92,6 +92,24 @@ describe Coinbase::StakingReward do
 
         expect(asset).to have_received(:from_atomic_amount).with(100)
       end
+    end
+  end
+
+  describe '#date' do
+    let(:staking_reward) { described_class.new(staking_reward_model, asset, format) }
+    subject(:date) { staking_reward.date }
+
+    it 'returns the date' do
+      expect(staking_reward.date).to eq(staking_reward_model.date)
+    end
+  end
+
+  describe '#address_id' do
+    let(:staking_reward) { described_class.new(staking_reward_model, asset, format) }
+    subject(:address_id) { staking_reward.address_id }
+
+    it 'returns the address_id' do
+      expect(staking_reward.address_id).to eq(staking_reward_model.address_id)
     end
   end
 end


### PR DESCRIPTION
### What changed? Why?

For listing rewards of multiple addresses it will be helpful to be able to access the address to which the specific reward belongs to and be able to log it.

Example:

```
> rewards = Coinbase::StakingReward.list(:ethereum_mainnet, :eth, ["0x87Bf57c3d7B211a100ee4d00dee08435130A62fA", "0x15709cB3381251C362A63fF7cc39CB2c2029ae8E"], start_time: Time.now - (10 * 24 * 60 * 60), end_time: Time.now)
=> #<Enumerator: ...>

> rewards.each do |reward| puts "#{reward.date} : #{reward.address_id} : #{reward.amount.to_f}" end
2024-07-17 : 0x15709cb3381251c362a63ff7cc39cb2c2029ae8e : 7.09
2024-07-18 : 0x15709cb3381251c362a63ff7cc39cb2c2029ae8e : 10.22
2024-07-19 : 0x15709cb3381251c362a63ff7cc39cb2c2029ae8e : 8.34
2024-07-20 : 0x15709cb3381251c362a63ff7cc39cb2c2029ae8e : 7.23
2024-07-21 : 0x15709cb3381251c362a63ff7cc39cb2c2029ae8e : 14.88
2024-07-12 : 0x87bf57c3d7b211a100ee4d00dee08435130a62fa : 0.01
2024-07-13 : 0x87bf57c3d7b211a100ee4d00dee08435130a62fa : 0.01
2024-07-14 : 0x87bf57c3d7b211a100ee4d00dee08435130a62fa : 0.01
2024-07-15 : 0x87bf57c3d7b211a100ee4d00dee08435130a62fa : 0.01
2024-07-16 : 0x87bf57c3d7b211a100ee4d00dee08435130a62fa : 0.01
2024-07-17 : 0x87bf57c3d7b211a100ee4d00dee08435130a62fa : 0.01
2024-07-18 : 0x87bf57c3d7b211a100ee4d00dee08435130a62fa : 0.01
2024-07-19 : 0x87bf57c3d7b211a100ee4d00dee08435130a62fa : 0.01
2024-07-20 : 0x87bf57c3d7b211a100ee4d00dee08435130a62fa : 0.01
2024-07-21 : 0x87bf57c3d7b211a100ee4d00dee08435130a62fa : 0.01
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->