### PR TITLE
Add network constants 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add network constants for Base Mainnet, Ethereum Holesky, and Ethereum Mainnet
+
 ## [0.0.13] - 2024-07-30
 
 ### Added

--- a/lib/coinbase/constants.rb
+++ b/lib/coinbase/constants.rb
@@ -14,6 +14,33 @@ module Coinbase
     chain_id: 84_532
   )
 
+  BASE_MAINNET = Network.new(
+    network_id: :base_mainnet,
+    display_name: 'Base Mainnet',
+    protocol_family: :evm,
+    is_testnet: false,
+    native_asset_id: :eth,
+    chain_id: 8453
+  )
+
+  ETHERUM_HOLESKY = Network.new(
+    network_id: :ethereum_holesky,
+    display_name: 'Ethereum Holesky',
+    protocol_family: :evm,
+    is_testnet: true,
+    native_asset_id: :eth,
+    chain_id: 17_000
+  )
+
+  ETHEREUM_MAINNET = Network.new(
+    network_id: :ethereum_mainnet,
+    display_name: 'Ethereum Mainnet',
+    protocol_family: :evm,
+    is_testnet: false,
+    native_asset_id: :eth,
+    chain_id: 1
+  )
+
   # The number of decimal places in Gwei.
   GWEI_DECIMALS = 9
 

--- a/lib/coinbase/constants.rb
+++ b/lib/coinbase/constants.rb
@@ -23,7 +23,7 @@ module Coinbase
     chain_id: 8453
   )
 
-  ETHERUM_HOLESKY = Network.new(
+  ETHEREUM_HOLESKY = Network.new(
     network_id: :ethereum_holesky,
     display_name: 'Ethereum Holesky',
     protocol_family: :evm,


### PR DESCRIPTION
### What changed? Why?

This PR helps add constants for networks Base Mainnet, Ethereum Holesky, and Ethereum Mainnet.


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->