### PR TITLE
Adds balance checks to wallet

### DIFF
--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -327,6 +327,49 @@ module Coinbase
       default_address.claim_stake(amount, asset_id, mode: mode, options: options)
     end
 
+    # Retrieves the balances used for staking for the supplied asset.
+    # Currently only the default_address is used to source the staking balances.
+    # @param asset_id [Symbol] The asset to retrieve staking balances for
+    # @param mode [Symbol] The staking mode. Defaults to :default.
+    # @param options [Hash] Additional options for the staking operation
+    # @return [Hash] The staking balances
+    # @return [BigDecimal] :stakeable_balance The amount of the asset that can be staked
+    # @return [BigDecimal] :unstakeable_balance The amount of the asset that is currently staked and cannot be unstaked
+    # @return [BigDecimal] :claimable_balance The amount of the asset that can be claimed
+    def staking_balances(asset_id, mode: :default, options: {})
+      default_address.staking_balances(asset_id, mode: mode, options: options)
+    end
+
+    # Retrieves the stakeable balance for the supplied asset.
+    # Currently only the default_address is used to source the stakeable balance.
+    # @param asset_id [Symbol] The asset to retrieve the stakeable balance for
+    # @param mode [Symbol] The staking mode. Defaults to :default.
+    # @param options [Hash] Additional options for the staking operation
+    # @return [BigDecimal] The stakeable balance
+    def stakeable_balance(asset_id, mode: :default, options: {})
+      default_address.stakeable_balance(asset_id, mode: mode, options: options)
+    end
+
+    # Retrieves the unstakeable balance for the supplied asset.
+    # Currently only the default_address is used to source the unstakeable balance.
+    # @param asset_id [Symbol] The asset to retrieve the unstakeable balance for
+    # @param mode [Symbol] The staking mode. Defaults to :default.
+    # @param options [Hash] Additional options for the staking operation
+    # @return [BigDecimal] The unstakeable balance
+    def unstakeable_balance(asset_id, mode: :default, options: {})
+      default_address.unstakeable_balance(asset_id, mode: mode, options: options)
+    end
+
+    # Retrieves the claimable balance for the supplied asset.
+    # Currently only the default_address is used to source the claimable balance.
+    # @param asset_id [Symbol] The asset to retrieve the claimable balance for
+    # @param mode [Symbol] The staking mode. Defaults to :default.
+    # @param options [Hash] Additional options for the staking operation
+    # @return [BigDecimal] The claimable balance
+    def claimable_balance(asset_id, mode: :default, options: {})
+      default_address.claimable_balance(asset_id, mode: mode, options: options)
+    end
+
     # Exports the Wallet's data to a Data object.
     # @return [Data] The Wallet data
     def export

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -838,6 +838,58 @@ describe Coinbase::Wallet do
         expect(wallet.default_address).to have_received(:claim_stake).with(5, :eth, mode: :default, options: {})
       end
     end
+
+    describe '#staking_balances' do
+      before do
+        allow(wallet.default_address).to receive(:staking_balances)
+      end
+
+      subject(:staking_balances) { wallet.staking_balances(:eth) }
+
+      it 'calls staking_balances' do
+        subject
+        expect(wallet.default_address).to have_received(:staking_balances).with(:eth, mode: :default, options: {})
+      end
+    end
+
+    describe '#stakeable_balance' do
+      before do
+        allow(wallet.default_address).to receive(:stakeable_balance)
+      end
+
+      subject(:stakeable_balance) { wallet.stakeable_balance(:eth) }
+
+      it 'calls stakeable_balance' do
+        subject
+        expect(wallet.default_address).to have_received(:stakeable_balance).with(:eth, mode: :default, options: {})
+      end
+    end
+
+    describe '#unstakeable_balance' do
+      before do
+        allow(wallet.default_address).to receive(:unstakeable_balance)
+      end
+
+      subject(:unstakeable_balance) { wallet.unstakeable_balance(:eth) }
+
+      it 'calls unstakeable_balance' do
+        subject
+        expect(wallet.default_address).to have_received(:unstakeable_balance).with(:eth, mode: :default, options: {})
+      end
+    end
+
+    describe '#claimable_balance' do
+      before do
+        allow(wallet.default_address).to receive(:claimable_balance)
+      end
+
+      subject(:claimable_balance) { wallet.claimable_balance(:eth) }
+
+      it 'calls claimable_balance' do
+        subject
+        expect(wallet.default_address).to have_received(:claimable_balance).with(:eth, mode: :default, options: {})
+      end
+    end
   end
 
   describe '#transfer' do


### PR DESCRIPTION
### What changed? Why?
This adds staking balance calls for wallets. It delegates all calls to the default_address.

#### Qualified Impact
This updates `Coinbase::Wallets` and adds: `staking_balances` `stakeable_balance` `unstakeable_balance` and `claimable_balance`