### PR TITLE
[hotfix] Fix approve transaction payload key

### DIFF
--- a/lib/coinbase/trade.rb
+++ b/lib/coinbase/trade.rb
@@ -147,7 +147,7 @@ module Coinbase
 
       payloads = { signed_payload: transaction.raw.hex }
 
-      payloads[:approve_tx_signed_payload] = approve_transaction.raw.hex unless approve_transaction.nil?
+      payloads[:approve_transaction_signed_payload] = approve_transaction.raw.hex unless approve_transaction.nil?
 
       @model = Coinbase.call_api do
         trades_api.broadcast_trade(wallet_id, address_id, id, payloads)

--- a/spec/unit/coinbase/trade_spec.rb
+++ b/spec/unit/coinbase/trade_spec.rb
@@ -369,7 +369,7 @@ describe Coinbase::Trade do
         let(:broadcast_trade_request) do
           {
             signed_payload: trade.transaction.raw.hex,
-            approve_tx_signed_payload: trade.approve_transaction.raw.hex
+            approve_transaction_signed_payload: trade.approve_transaction.raw.hex
           }
         end
 


### PR DESCRIPTION

### What changed? Why?

This fixes the approve transaction payload key to be `approve_transaction_signed_payload` instead of the abbreviation.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->