### PR TITLE
Attempt to fix factory bot CI error

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'simplecov'
 require 'pry'
+require 'active_support/inflector' # Required for factory_bot
 require 'factory_bot'
 
 SimpleCov.start do


### PR DESCRIPTION
### What changed? Why?
This attempts to fix the following CI error by loading the active
support inflector module explicitly.

```
An error occurred while loading spec_helper.
Failure/Error: require 'factory_bot'

NameError:
  uninitialized constant #<Class:ActiveSupport::Delegation>::Inflector
No examples found.
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->