### PR TITLE
Add dynamic network constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add historical_balances function for wallet: listing historical balances for default address of the wallet.
 - Expose all networks as constants, e.g. `Coinbase::Network::ETHEREUM_MAINNET`
 
+### Breaking Changes
+- All method signatures that took a `network_id` now take a `network` that can be either a network constant (e.g. `Coinbase::Network::BASE_MAINNET`) or a network ID (e.g.  `:base_mainnet`)
+
 ### Added
 
 - Add to_address_id method to Transaction class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 - Add historical_balances function for wallet: listing historical balances for default address of the wallet.
+- Expose all networks as constants, e.g. `Coinbase::Network::ETHEREUM_MAINNET`
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ address.transfers.to_a
 See [Trades](https://docs.cdp.coinbase.com/wallets/docs/trades) for more information.
 
 ```ruby
-wallet = Coinbase::Wallet.create(network_id: :base_mainnet)
+wallet = Coinbase::Wallet.create(network: Coinbase::Network::BASE_MAINNET)
 
 puts "Wallet successfully created: #{wallet}"
 puts "Send `base-mainnet` ETH to wallets default address: #{wallet.default_address.id}"

--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -73,6 +73,17 @@ module Coinbase
       @debug_api = false
       @use_server_signer = false
       @max_network_tries = 3
+      @default_network = Coinbase::Network::BASE_SEPOLIA
+    end
+
+    attr_reader :default_network
+
+    def default_network=(network)
+      unless network.is_a?(Coinbase::Network)
+        raise InvalidConfiguration, 'Default network must use a network constant, e.g. Coinbase::Network::BASE_MAINNET'
+      end
+
+      @default_network = network
     end
 
     # Sets configuration values based on the provided CDP API Key JSON file.
@@ -104,10 +115,13 @@ module Coinbase
     value.to_s.gsub('-', '_').to_sym
   end
 
-  # Converts a network symbol to a string, replacing underscores with hyphens.
-  # @param network_sym [Symbol] the network symbol to convert
-  # @return [String] the converted string
-  def self.normalize_network(network_sym)
+  # Converts a Network object or network symbol with the string representation of the network ID,
+  # replacing underscores with hyphens.
+  # @param network_sym [Coinbase::Network, Symbol] The network or network symbol to convert
+  # @return [String] The string representation of the network ID
+  def self.normalize_network(network)
+    network_sym = network.is_a?(Coinbase::Network) ? network.id : network
+
     network_sym.to_s.gsub('_', '-')
   end
 
@@ -136,9 +150,29 @@ module Coinbase
     Coinbase.configuration.use_server_signer
   end
 
+  # Returns the default network.
+  # @return [Coinbase::Network] the default network
+  def self.default_network
+    Coinbase.configuration.default_network
+  end
+
   # Returns whether the SDK is configured.
   # @return [bool] whether the SDK is configured
   def self.configured?
     !Coinbase.configuration.api_key_name.nil? && !Coinbase.configuration.api_key_private_key.nil?
   end
 end
+
+# Initialize the Network constants.
+Coinbase::Network.const_set(
+  'ALL',
+  Coinbase::Client::NetworkIdentifier.all_vars.each_with_object([]) do |id, list|
+    next if id == Coinbase::Client::NetworkIdentifier::UNKNOWN_DEFAULT_OPEN_API
+
+    network = Coinbase::Network.new(id)
+
+    Coinbase::Network.const_set(id.upcase.gsub('-', '_'), network)
+
+    list << network
+  end
+)

--- a/lib/coinbase.rb
+++ b/lib/coinbase.rb
@@ -176,3 +176,10 @@ Coinbase::Network.const_set(
     list << network
   end
 )
+
+Coinbase::Network.const_set(
+  'NETWORK_MAP',
+  Coinbase::Network::ALL.each_with_object({}) do |network, map|
+    map[network.id] = network
+  end
+)

--- a/lib/coinbase/address/wallet_address.rb
+++ b/lib/coinbase/address/wallet_address.rb
@@ -52,7 +52,7 @@ module Coinbase
         amount: amount,
         asset_id: asset_id,
         destination: destination,
-        network_id: network_id,
+        network: network,
         wallet_id: wallet_id,
         gasless: gasless
       )
@@ -80,7 +80,7 @@ module Coinbase
         amount: amount,
         from_asset_id: from_asset_id,
         to_asset_id: to_asset_id,
-        network_id: network_id,
+        network: network,
         wallet_id: wallet_id
       )
 
@@ -164,7 +164,7 @@ module Coinbase
     # Returns a String representation of the WalletAddress.
     # @return [String] a String representation of the WalletAddress
     def to_s
-      "Coinbase::Address{id: '#{id}', network_id: '#{network_id}', wallet_id: '#{wallet_id}'}"
+      "Coinbase::Address{id: '#{id}', network_id: '#{network.id}', wallet_id: '#{wallet_id}'}"
     end
 
     private
@@ -185,7 +185,7 @@ module Coinbase
     end
 
     def complete_staking_operation(amount, asset_id, action, mode: :default, options: {})
-      op = StakingOperation.create(amount, network_id, asset_id, id, wallet_id, action, mode, options)
+      op = StakingOperation.create(amount, network, asset_id, id, wallet_id, action, mode, options)
       op.transactions.each do |transaction|
         transaction.sign(@key)
       end

--- a/lib/coinbase/asset.rb
+++ b/lib/coinbase/asset.rb
@@ -35,7 +35,7 @@ module Coinbase
         end
 
         new(
-          network_id: Coinbase.to_sym(asset_model.network_id),
+          network: Coinbase.to_sym(asset_model.network_id),
           asset_id: asset_id || Coinbase.to_sym(asset_model.asset_id),
           address_id: asset_model.contract_address,
           decimals: decimals
@@ -43,12 +43,15 @@ module Coinbase
       end
 
       # Fetches the Asset with the provided Asset ID.
+      # @param network [Coinbase::Network, Symbol] The Network or Network ID
       # @param asset_id [Symbol] The Asset ID
       # @return [Coinbase::Asset] The Asset
-      def fetch(network_id, asset_id)
+      def fetch(network, asset_id)
+        network = Coinbase::Network.from_id(network)
+
         asset_model = Coinbase.call_api do
           assets_api.get_asset(
-            Coinbase.normalize_network(network_id),
+            network.normalized_id,
             primary_denomination(asset_id).to_s
           )
         end
@@ -65,18 +68,18 @@ module Coinbase
 
     # Returns a new Asset object. Do not use this method. Instead, use the Asset constants defined in
     # the Coinbase module.
-    # @param network_id [Symbol] The ID of the Network to which the Asset belongs
+    # @param network [Symbol] The Network or Network ID to which the Asset belongs
     # @param asset_id [Symbol] The Asset ID
     # @param address_id [String] (Optional) The Asset's address ID, if one exists
     # @param decimals [Integer] (Optional) The number of decimal places the Asset uses
-    def initialize(network_id:, asset_id:, decimals:, address_id: nil)
-      @network_id = network_id
+    def initialize(network:, asset_id:, decimals:, address_id: nil)
+      @network = Coinbase::Network.from_id(network)
       @asset_id = asset_id
       @address_id = address_id
       @decimals = decimals
     end
 
-    attr_reader :network_id, :asset_id, :address_id, :decimals
+    attr_reader :network, :asset_id, :address_id, :decimals
 
     # Converts the amount of the Asset from atomic to whole units.
     # @param atomic_amount [Integer, Float, BigDecimal] The atomic amount to convert to whole units.
@@ -103,7 +106,7 @@ module Coinbase
     # Returns a string representation of the Asset.
     # @return [String] a string representation of the Asset
     def to_s
-      "Coinbase::Asset{network_id: '#{network_id}', asset_id: '#{asset_id}', decimals: '#{decimals}'" \
+      "Coinbase::Asset{network_id: '#{network.id}', asset_id: '#{asset_id}', decimals: '#{decimals}'" \
         "#{address_id.nil? ? '' : ", address_id: '#{address_id}'"}}"
     end
 

--- a/lib/coinbase/client/models/network.rb
+++ b/lib/coinbase/client/models/network.rb
@@ -33,6 +33,9 @@ module Coinbase::Client
 
     attr_accessor :feature_set
 
+    # The BIP44 path prefix for the network
+    attr_accessor :address_path_prefix
+
     class EnumAttributeValidator
       attr_reader :datatype
       attr_reader :allowable_values
@@ -64,7 +67,8 @@ module Coinbase::Client
         :'protocol_family' => :'protocol_family',
         :'is_testnet' => :'is_testnet',
         :'native_asset' => :'native_asset',
-        :'feature_set' => :'feature_set'
+        :'feature_set' => :'feature_set',
+        :'address_path_prefix' => :'address_path_prefix'
       }
     end
 
@@ -82,7 +86,8 @@ module Coinbase::Client
         :'protocol_family' => :'String',
         :'is_testnet' => :'Boolean',
         :'native_asset' => :'Asset',
-        :'feature_set' => :'FeatureSet'
+        :'feature_set' => :'FeatureSet',
+        :'address_path_prefix' => :'String'
       }
     end
 
@@ -147,6 +152,10 @@ module Coinbase::Client
         self.feature_set = attributes[:'feature_set']
       else
         self.feature_set = nil
+      end
+
+      if attributes.key?(:'address_path_prefix')
+        self.address_path_prefix = attributes[:'address_path_prefix']
       end
     end
 
@@ -223,7 +232,8 @@ module Coinbase::Client
           protocol_family == o.protocol_family &&
           is_testnet == o.is_testnet &&
           native_asset == o.native_asset &&
-          feature_set == o.feature_set
+          feature_set == o.feature_set &&
+          address_path_prefix == o.address_path_prefix
     end
 
     # @see the `==` method
@@ -235,7 +245,7 @@ module Coinbase::Client
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, display_name, chain_id, protocol_family, is_testnet, native_asset, feature_set].hash
+      [id, display_name, chain_id, protocol_family, is_testnet, native_asset, feature_set, address_path_prefix].hash
     end
 
     # Builds the object from hash

--- a/lib/coinbase/constants.rb
+++ b/lib/coinbase/constants.rb
@@ -4,16 +4,6 @@ require_relative 'asset'
 require_relative 'network'
 
 module Coinbase
-  # The Base Sepolia Network.
-  BASE_SEPOLIA = Network.new(
-    network_id: :base_sepolia,
-    display_name: 'Base Sepolia',
-    protocol_family: :evm,
-    is_testnet: true,
-    native_asset_id: :eth,
-    chain_id: 84_532
-  )
-
   # The number of decimal places in Gwei.
   GWEI_DECIMALS = 9
 

--- a/lib/coinbase/destination.rb
+++ b/lib/coinbase/destination.rb
@@ -20,32 +20,34 @@ module Coinbase
     #   If the destination is a String, it uses it as the Address ID.
     # @param network_id [Symbol] The ID of the Network to which the Destination belongs
     # @return [Destination] The Destination object
-    def initialize(model, network_id: nil)
+    def initialize(model, network:)
+      network = Coinbase::Network.from_id(network)
+
       case model
       when Coinbase::Destination
-        raise ArgumentError, 'destination network must match destination' unless model.network_id == network_id
+        raise ArgumentError, 'destination network must match destination' unless model.network == network
 
         @address_id = model.address_id
-        @network_id = model.network_id
+        @network = model.network
       when Coinbase::Wallet
-        raise ArgumentError, 'destination network must match wallet' unless model.network_id == network_id
+        raise ArgumentError, 'destination network must match wallet' unless model.network == network
         raise ArgumentError, 'destination wallet must have default address' if model.default_address.nil?
 
         @address_id = model.default_address.id
-        @network_id = model.network_id
+        @network = model.network
       when Coinbase::Address
-        raise ArgumentError, 'destination network must match address' unless model.network_id == network_id
+        raise ArgumentError, 'destination network must match address' unless model.network == network
 
         @address_id = model.id
-        @network_id = model.network_id
+        @network = model.network
       when String
         @address_id = model
-        @network_id = network_id
+        @network = network
       else
         raise ArgumentError, "unsupported destination type: #{model.class}"
       end
     end
 
-    attr_reader :address_id, :network_id
+    attr_reader :address_id, :network
   end
 end

--- a/lib/coinbase/errors.rb
+++ b/lib/coinbase/errors.rb
@@ -57,6 +57,13 @@ module Coinbase
   end
 
   # An error raised when an operation is attempted with insufficient funds.
+  class NetworkUnsupportedError < StandardError
+    def initialize(network_id)
+      super("Network #{network_id} is not supported")
+    end
+  end
+
+  # An error raised when an operation is attempted with insufficient funds.
   class InsufficientFundsError < StandardError
     def initialize(expected, exact, msg = 'Insufficient funds')
       super("#{msg}: have #{exact}, need #{expected}.")

--- a/lib/coinbase/network.rb
+++ b/lib/coinbase/network.rb
@@ -3,6 +3,19 @@
 module Coinbase
   # A blockchain network.
   class Network
+    # Returns the Network object for the given ID, if supported.
+    # @param network_id [Symbol, String] The ID of the network
+    # @return [Network] The network object
+    def self.from_id(network_id)
+      return network_id if network_id.is_a?(Network)
+
+      network = NETWORK_MAP.fetch(Coinbase.to_sym(network_id), nil)
+
+      return network unless network.nil?
+
+      raise NetworkUnsupportedError, network_id
+    end
+
     # Constructs a new Network object. Do not use this method directly. Instead, use the Network constants defined in
     # the Coinbase module.
     # @param id [Symbol, String] The Network ID
@@ -11,7 +24,20 @@ module Coinbase
       @id = ::Coinbase.to_sym(id)
     end
 
+    # Returns the equality of the Network object with another Network object by ID.
+    # @param other [Coinbase::Network] The network object to compare
+    # @return [Boolean] Whether the Network objects are equal
+    def ==(other)
+      return false unless other.is_a?(Network)
+
+      id == other.id
+    end
+
     attr_reader :id
+
+    def normalized_id
+      id.to_s.gsub('_', '-')
+    end
 
     # The Chain ID of the Network.
     # @return [Integer] The Chain ID of the Network
@@ -43,6 +69,14 @@ module Coinbase
     #  network.protocol_family #=> "evm"
     def protocol_family
       model.protocol_family
+    end
+
+    # The address path prefix of the Network.
+    # @return [String] The address path prefix of the Network
+    # @example
+    #   network.address_path_prefix #=> "m/44'/60'/0'/0"
+    def address_path_prefix
+      model.address_path_prefix
     end
 
     # Gets the Asset with the given ID.

--- a/lib/coinbase/network.rb
+++ b/lib/coinbase/network.rb
@@ -3,39 +3,88 @@
 module Coinbase
   # A blockchain network.
   class Network
-    attr_reader :chain_id
-
-    # Returns a new Network object. Do not use this method directly. Instead, use the Network constants defined in
+    # Constructs a new Network object. Do not use this method directly. Instead, use the Network constants defined in
     # the Coinbase module.
-    # @param network_id [Symbol] The Network ID
-    # @param display_name [String] The Network's display name
-    # @param protocol_family [String] The protocol family to which the Network belongs
-    #   (e.g., "evm")
-    # @param is_testnet [Boolean] Whether the Network is a testnet
-    # @param native_asset_id [String] The ID of the Network's native Asset
-    # @param chain_id [Integer] The Chain ID of the Network
-    def initialize(network_id:, display_name:, protocol_family:, is_testnet:, native_asset_id:, chain_id:)
-      @network_id = network_id
-      @display_name = display_name
-      @protocol_family = protocol_family
-      @is_testnet = is_testnet
-      @native_asset_id = native_asset_id
-      @chain_id = chain_id
+    # @param id [Symbol, String] The Network ID
+    # @return [Network] The new Network object
+    def initialize(id)
+      @id = ::Coinbase.to_sym(id)
+    end
+
+    attr_reader :id
+
+    # The Chain ID of the Network.
+    # @return [Integer] The Chain ID of the Network
+    # @example
+    #   network.chain_id #=> 84_532
+    def chain_id
+      model.chain_id
+    end
+
+    # Whether the Network is a testnet.
+    # @return [Boolean] Whether the Network is a testnet
+    # @example
+    #   network.testnet? #=> true
+    def testnet?
+      model.is_testnet
+    end
+
+    # The display name of the Network.
+    # @return [String] The display name of the Network
+    # @example
+    #  network.display_name #=> "Base Sepolia"
+    def display_name
+      model.display_name
+    end
+
+    # The protocol family to which the Network belongs. Example: `evm`.
+    # @return [String] The protocol family to which the Network belongs.
+    # @example
+    #  network.protocol_family #=> "evm"
+    def protocol_family
+      model.protocol_family
     end
 
     # Gets the Asset with the given ID.
-    #
     # @param asset_id [Symbol] The ID of the Asset
     # @return [Asset] The Asset with the given ID
     def get_asset(asset_id)
-      Asset.fetch(@network_id, asset_id)
+      Asset.fetch(@id, asset_id)
     end
 
     # Gets the native Asset of the Network.
-    #
     # @return [Asset] The native Asset of the Network
     def native_asset
-      @native_asset ||= get_asset(@native_asset_id)
+      @native_asset ||= Coinbase::Asset.from_model(model.native_asset)
+    end
+
+    def to_s
+      details = { id: id }
+
+      # Only include optional details if the model is already fetched.
+      unless @model.nil?
+        Coinbase::Client::Network.attribute_map.each_key do |attr|
+          details[attr] = @model.send(attr)
+        end
+      end
+
+      Coinbase.pretty_print_object(self.class, **details)
+    end
+
+    def inspect
+      to_s
+    end
+
+    private
+
+    def networks_api
+      @networks_api ||= Coinbase::Client::NetworksApi.new(Coinbase.configuration.api_client)
+    end
+
+    def model
+      @model ||= Coinbase.call_api do
+        networks_api.get_network(Coinbase.normalize_network(id))
+      end
     end
   end
 end

--- a/lib/coinbase/trade.rb
+++ b/lib/coinbase/trade.rb
@@ -15,12 +15,13 @@ module Coinbase
       # @param from_asset_id [Symbol] The Asset ID of the Asset to trade from
       # @param to_asset_id [Symbol] The Asset ID of the Asset to trade to
       # @param amount [BigDecimal] The amount of the Asset to send
-      # @param network_id [Symbol] The Network ID of the Asset
+      # @param network [Coinbase::Network, Symbol] The Network or Network ID of the Asset
       # @param wallet_id [String] The Wallet ID of the sending Wallet
       # @return [Send] The new pending Send object
-      def create(address_id:, from_asset_id:, to_asset_id:, amount:, network_id:, wallet_id:)
-        from_asset = Asset.fetch(network_id, from_asset_id)
-        to_asset = Asset.fetch(network_id, to_asset_id)
+      def create(address_id:, from_asset_id:, to_asset_id:, amount:, network:, wallet_id:)
+        network = Coinbase::Network.from_id(network)
+        from_asset = network.get_asset(from_asset_id)
+        to_asset = network.get_asset(to_asset_id)
 
         model = Coinbase.call_api do
           trades_api.create_trade(
@@ -75,10 +76,10 @@ module Coinbase
       @model.trade_id
     end
 
-    # Returns the Network ID of the Trade.
-    # @return [Symbol] The Network ID
-    def network_id
-      Coinbase.to_sym(@model.network_id)
+    # Returns the Network of the Trade.
+    # @return [Coinbase::Network] The Network the Trade is on
+    def network
+      @network ||= Coinbase::Network.from_id(@model.network_id)
     end
 
     # Returns the Wallet ID of the Trade.
@@ -198,7 +199,7 @@ module Coinbase
     # Returns a String representation of the Trade.
     # @return [String] a String representation of the Trade
     def to_s
-      "Coinbase::Trade{transfer_id: '#{id}', network_id: '#{network_id}', " \
+      "Coinbase::Trade{transfer_id: '#{id}', network_id: '#{network.id}', " \
         "address_id: '#{address_id}', from_asset_id: '#{from_asset_id}', " \
         "to_asset_id: '#{to_asset_id}', from_amount: '#{from_amount}', " \
         "to_amount: '#{to_amount}' status: '#{status}'}"

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -62,12 +62,12 @@ module Coinbase
       # @param timeout_seconds [Integer] The maximum amount of time to wait for the ServerSigner to
       # create a seed for the Wallet, in seconds
       # @return [Coinbase::Wallet] the new Wallet
-      def create(network_id: 'base-sepolia', interval_seconds: 0.2, timeout_seconds: 20)
+      def create(network: Coinbase.default_network, interval_seconds: 0.2, timeout_seconds: 20)
         model = Coinbase.call_api do
           wallets_api.create_wallet(
             create_wallet_request: {
               wallet: {
-                network_id: Coinbase.normalize_network(network_id),
+                network_id: Coinbase.normalize_network(network),
                 use_server_signer: Coinbase.use_server_signer?
               }
             }

--- a/spec/factories/network.rb
+++ b/spec/factories/network.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
       is_testnet { true }
       native_asset { build(:asset_model, :eth, :base_sepolia) }
       chain_id { 84_532 }
+      address_path_prefix { "m/44'/60'/0'/0" }
     end
 
     trait :base_mainnet do
@@ -21,6 +22,7 @@ FactoryBot.define do
       is_testnet { false }
       native_asset { build(:asset_model, :eth, :base_mainnet) }
       chain_id { 8_453 }
+      address_path_prefix { "m/44'/60'/0'/0" }
     end
 
     trait :ethereum_mainnet do
@@ -30,6 +32,7 @@ FactoryBot.define do
       is_testnet { false }
       native_asset { build(:asset_model, :eth, :ethereum_mainnet) }
       chain_id { 1 }
+      address_path_prefix { "m/44'/60'/0'/0" }
     end
 
     trait :ethereum_holesky do
@@ -39,6 +42,7 @@ FactoryBot.define do
       is_testnet { true }
       native_asset { build(:asset_model, :eth, :ethereum_holesky) }
       chain_id { 17_000 }
+      address_path_prefix { "m/44'/60'/0'/0" }
     end
   end
 

--- a/spec/factories/network.rb
+++ b/spec/factories/network.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :network_model, class: Coinbase::Client::Network do
+    # Default traits
+    base_sepolia
+
+    trait :base_sepolia do
+      id { 'base_sepolia' }
+      display_name { 'Base Sepolia' }
+      protocol_family { 'evm' }
+      is_testnet { true }
+      native_asset { build(:asset_model, :eth, :base_sepolia) }
+      chain_id { 84_532 }
+    end
+
+    trait :base_mainnet do
+      id { 'base-mainnet' }
+      display_name { 'Base' }
+      protocol_family { 'evm' }
+      is_testnet { false }
+      native_asset { build(:asset_model, :eth, :base_mainnet) }
+      chain_id { 8_453 }
+    end
+
+    trait :ethereum_mainnet do
+      id { 'ethereum-mainnet' }
+      display_name { 'Ethereum' }
+      protocol_family { 'evm' }
+      is_testnet { false }
+      native_asset { build(:asset_model, :eth, :ethereum_mainnet) }
+      chain_id { 1 }
+    end
+
+    trait :ethereum_holesky do
+      id { 'ethereum-holesky' }
+      display_name { 'Ethereum Holesky' }
+      protocol_family { 'evm' }
+      is_testnet { true }
+      native_asset { build(:asset_model, :eth, :ethereum_holesky) }
+      chain_id { 17_000 }
+    end
+  end
+
+  factory :network, class: Coinbase::Network do
+    transient do
+      network_id { nil }
+      model { nil }
+    end
+
+    initialize_with do
+      Coinbase::Network.new(network_id).tap do |network|
+        network.instance_variable_set(:@model, model)
+      end
+    end
+
+    NETWORK_TRAITS.each do |trait|
+      trait trait do
+        network_id { Coinbase.to_sym(trait) }
+        model { build(:network_model, trait) }
+      end
+    end
+  end
+end

--- a/spec/factories/staking_balance.rb
+++ b/spec/factories/staking_balance.rb
@@ -2,18 +2,43 @@
 
 FactoryBot.define do
   factory :staking_balance_model, class: Coinbase::Client::StakingBalance do
+    transient do
+      network_trait { nil }
+    end
+
+    base_sepolia
+
     date { Time.now }
     address { '0xdeadbeef' }
-    bonded_stake { build(:balance_model) }
-    unbonded_balance { build(:balance_model) }
+    bonded_stake { build(:balance_model, network_trait) }
+    unbonded_balance { build(:balance_model, network_trait) }
     participant_type { 'validator' }
+
+    NETWORK_TRAITS.each do |network|
+      trait network do
+        network_trait { network }
+      end
+    end
   end
 
   factory :staking_balance, class: Coinbase::StakingBalance do
     transient do
+      network_trait { nil }
       model { build(:staking_balance_model) }
     end
 
     initialize_with { new(model) }
+
+    NETWORK_TRAITS.each do |network|
+      trait network do
+        network_trait { network }
+      end
+    end
+
+    before(:build) do |_, transients|
+      model do
+        build(:staking_balance_model, transients)
+      end
+    end
   end
 end

--- a/spec/factories/wallet.rb
+++ b/spec/factories/wallet.rb
@@ -35,10 +35,22 @@ FactoryBot.define do
     transient do
       seed { '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' }
       id { SecureRandom.uuid }
+      network_trait { nil }
     end
 
     initialize_with { Coinbase::Wallet.new(model, seed: seed) }
 
     model { build(:wallet_model, id: id) }
+
+    # Register traits to enable passing through to wallet model factory.
+    %i[without_default_address server_signer_pending server_signer_active].each do |trait_name|
+      trait(trait_name { model.traits[trait_name] = true })
+    end
+
+    before(:build) do |_wallet, transients|
+      transfer.model do
+        build(:wallet_model, transients, id: id)
+      end
+    end
   end
 end

--- a/spec/support/shared_examples/address_balances.rb
+++ b/spec/support/shared_examples/address_balances.rb
@@ -11,9 +11,9 @@ shared_examples 'an address that supports balance queries' do |_operation|
     let(:response) do
       Coinbase::Client::AddressBalanceList.new(
         data: [
-          build(:balance_model, amount: '1000000000000000000'),
-          build(:balance_model, :usdc, amount: '5000000000'),
-          build(:balance_model, :weth, amount: '3000000000000000000')
+          build(:balance_model, network_id, amount: '1000000000000000000'),
+          build(:balance_model, network_id, :usdc, amount: '5000000000'),
+          build(:balance_model, network_id, :weth, amount: '3000000000000000000')
         ]
       )
     end
@@ -43,7 +43,7 @@ shared_examples 'an address that supports balance queries' do |_operation|
   end
 
   describe '#balance' do
-    let(:response) { build(:balance_model, amount: '1000000000000000000') }
+    let(:response) { build(:balance_model, network_id, amount: '1000000000000000000') }
 
     before do
       allow(external_addresses_api)
@@ -83,8 +83,8 @@ shared_examples 'an address that supports balance queries' do |_operation|
       let(:asset_id) { :other }
       let(:primary_denomination) { 'other' }
       let(:decimals) { 7 }
-      let(:other_asset) { build(:asset_model, asset_id: 'other', decimals: decimals) }
-      let(:response) { build(:balance_model, asset: other_asset, amount: BigDecimal(10**18).to_s) }
+      let(:other_asset) { build(:asset_model, network_id, asset_id: 'other', decimals: decimals) }
+      let(:response) { build(:balance_model, network_id, asset: other_asset, amount: BigDecimal(10**18).to_s) }
 
       it 'returns the correct balance' do
         expect(address.balance(:other)).to eq BigDecimal('100_000_000_000')
@@ -104,7 +104,7 @@ shared_examples 'an address that supports balance queries' do |_operation|
 
   describe '#historical_balances' do
     let(:eth_asset) { build(:asset_model) }
-    let(:historical_balance) { build(:historical_balance_model, amount: '1000000000000000000') }
+    let(:historical_balance) { build(:historical_balance_model, network_id, amount: '1000000000000000000') }
     let(:response) do
       Coinbase::Client::AddressBalanceList.new(
         data: [

--- a/spec/support/shared_examples/address_staking.rb
+++ b/spec/support/shared_examples/address_staking.rb
@@ -10,9 +10,9 @@ shared_context 'with mocked staking_balances' do
       Coinbase::Client::StakingContext,
       context: instance_double(
         Coinbase::Client::StakingContextContext,
-        stakeable_balance: build(:balance_model, whole_amount: stake_balance),
-        unstakeable_balance: build(:balance_model, whole_amount: unstake_balance),
-        claimable_balance: build(:balance_model, whole_amount: claim_stake_balance)
+        stakeable_balance: build(:balance_model, network_id, whole_amount: stake_balance),
+        unstakeable_balance: build(:balance_model, network_id, whole_amount: unstake_balance),
+        claimable_balance: build(:balance_model, network_id, whole_amount: claim_stake_balance)
       )
     )
   end
@@ -55,7 +55,7 @@ shared_examples 'an address that supports staking' do
       subject
       expect(Coinbase::StakingOperation).to have_received(:build).with(
         amount,
-        network_id,
+        network,
         asset_id,
         address_id,
         operation,
@@ -160,7 +160,7 @@ shared_examples 'an address that supports staking' do
       subject.staking_rewards(asset_id, start_time: start_time, end_time: end_time)
 
       expect(Coinbase::StakingReward).to have_received(:list).with(
-        network_id,
+        network,
         asset_id,
         [address_id],
         start_time: start_time,
@@ -180,7 +180,7 @@ shared_examples 'an address that supports staking' do
       subject.historical_staking_balances(asset_id, start_time: start_time, end_time: start_time)
 
       expect(Coinbase::StakingBalance).to have_received(:list).with(
-        network_id,
+        network,
         asset_id,
         address_id,
         start_time: start_time,

--- a/spec/unit/coinbase/address/external_address_spec.rb
+++ b/spec/unit/coinbase/address/external_address_spec.rb
@@ -3,9 +3,14 @@
 describe Coinbase::ExternalAddress do
   subject(:address) { described_class.new(network_id, address_id) }
 
+  let(:network) { build(:network, :ethereum_mainnet) }
   let(:network_id) { :ethereum_mainnet }
   let(:normalized_network_id) { 'ethereum-mainnet' }
   let(:address_id) { '0x1234' }
+
+  before do
+    allow(Coinbase::Network).to receive(:from_id).with(network_id).and_return(network)
+  end
 
   describe '#initialize' do
     it 'initializes a new Address' do
@@ -13,9 +18,9 @@ describe Coinbase::ExternalAddress do
     end
   end
 
-  describe '#network_id' do
-    it 'returns the network ID' do
-      expect(address.network_id).to eq(network_id)
+  describe '#network' do
+    it 'returns the network' do
+      expect(address.network).to eq(network)
     end
   end
 

--- a/spec/unit/coinbase/address/wallet_address_spec.rb
+++ b/spec/unit/coinbase/address/wallet_address_spec.rb
@@ -8,6 +8,7 @@ describe Coinbase::WalletAddress do
   let(:key) { build(:key) }
   let(:network_id) { :base_sepolia }
   let(:normalized_network_id) { 'base-sepolia' }
+  let(:network) { build(:network, network_id) }
   let(:address_id) { key.address.to_s }
   let(:model) { build(:address_model, network_id) }
   let(:wallet_id) { model.wallet_id }
@@ -15,6 +16,11 @@ describe Coinbase::WalletAddress do
 
   before do
     allow(Coinbase::Client::ExternalAddressesApi).to receive(:new).and_return(addresses_api)
+
+    allow(Coinbase::Network)
+      .to receive(:from_id)
+      .with(satisfy { |id| id == network_id || id == normalized_network_id })
+      .and_return(network)
   end
 
   describe '#initialize' do
@@ -23,9 +29,9 @@ describe Coinbase::WalletAddress do
     end
   end
 
-  describe '#network_id' do
-    it 'returns the network ID' do
-      expect(address.network_id).to eq(network_id)
+  describe '#network' do
+    it 'returns the network' do
+      expect(address.network).to eq(network)
     end
   end
 
@@ -67,7 +73,7 @@ describe Coinbase::WalletAddress do
   describe '#export' do
     let(:private_key) { key.private_hex }
 
-    it 'export private key from address' do
+    it 'exports the private key from address' do
       expect(address.export).to eq(private_key)
     end
 
@@ -115,7 +121,7 @@ describe Coinbase::WalletAddress do
       allow(addresses_api)
         .to receive(:get_external_address_balance)
         .with(normalized_network_id, address_id, 'eth')
-        .and_return(build(:balance_model, whole_amount: balance))
+        .and_return(build(:balance_model, network_id, whole_amount: balance))
     end
 
     context 'when the transfer is successful' do
@@ -157,7 +163,7 @@ describe Coinbase::WalletAddress do
             amount: amount,
             asset_id: asset_id,
             destination: to_address_id,
-            network_id: network_id,
+            network: network,
             wallet_id: wallet_id,
             gasless: false
           )
@@ -217,7 +223,7 @@ describe Coinbase::WalletAddress do
       allow(addresses_api)
         .to receive(:get_external_address_balance)
         .with(normalized_network_id, address_id, normalized_from_asset_id)
-        .and_return(build(:balance_model, :eth, whole_amount: balance))
+        .and_return(build(:balance_model, network_id, :eth, whole_amount: balance))
 
       allow(Coinbase).to receive(:use_server_signer?).and_return(use_server_signer)
     end
@@ -247,7 +253,7 @@ describe Coinbase::WalletAddress do
             amount: amount,
             from_asset_id: from_asset_id,
             to_asset_id: to_asset_id,
-            network_id: network_id,
+            network: network,
             wallet_id: wallet_id
           )
         end
@@ -274,7 +280,7 @@ describe Coinbase::WalletAddress do
             amount: amount,
             from_asset_id: from_asset_id,
             to_asset_id: to_asset_id,
-            network_id: network_id,
+            network: network,
             wallet_id: wallet_id
           )
         end
@@ -346,7 +352,7 @@ describe Coinbase::WalletAddress do
     it 'creates a staking operation' do
       expect(Coinbase::StakingOperation).to have_received(:create).with(
         amount,
-        network_id,
+        network,
         asset_id,
         address_id,
         wallet_id,

--- a/spec/unit/coinbase/address_spec.rb
+++ b/spec/unit/coinbase/address_spec.rb
@@ -3,9 +3,14 @@
 describe Coinbase::Address do
   subject(:address) { described_class.new(network_id, address_id) }
 
+  let(:network) { build(:network, :ethereum_mainnet) }
   let(:network_id) { :ethereum_mainnet }
   let(:normalized_network_id) { 'ethereum-mainnet' }
   let(:address_id) { '0x1234' }
+
+  before do
+    allow(Coinbase::Network).to receive(:from_id).with(network_id).and_return(network)
+  end
 
   describe '#id' do
     subject { address.id }
@@ -13,10 +18,10 @@ describe Coinbase::Address do
     it { is_expected.to eq(address_id) }
   end
 
-  describe '#network_id' do
-    subject { address.network_id }
+  describe '#network' do
+    subject { address.network }
 
-    it { is_expected.to eq(network_id) }
+    it { is_expected.to eq(network) }
   end
 
   describe '#to_s' do

--- a/spec/unit/coinbase/balance_map_spec.rb
+++ b/spec/unit/coinbase/balance_map_spec.rb
@@ -1,21 +1,30 @@
 # frozen_string_literal: true
 
 describe Coinbase::BalanceMap do
-  let(:eth_asset) { build(:asset_model) }
+  let(:network_id) { :base_sepolia }
+  let(:network) { build(:network, network_id) }
+  let(:eth_asset) { build(:asset_model, network_id) }
 
   describe '.from_balances' do
     subject(:balance_map) { described_class.from_balances(balances) }
 
-    let(:eth_balance) { build(:balance_model, amount: BigDecimal('123.0')) }
+    let(:eth_balance) { build(:balance_model, network_id, amount: BigDecimal('123.0')) }
     let(:eth_atomic_amount) { Coinbase::Asset.from_model(eth_balance.asset).from_atomic_amount(eth_balance.amount) }
 
-    let(:usdc_balance) { build(:balance_model, :usdc, amount: BigDecimal('456.0')) }
+    let(:usdc_balance) { build(:balance_model, network_id, :usdc, amount: BigDecimal('456.0')) }
     let(:usdc_atomic_amount) { Coinbase::Asset.from_model(usdc_balance.asset).from_atomic_amount(usdc_balance.amount) }
 
-    let(:weth_balance) { build(:balance_model, :weth, amount: BigDecimal('789.0')) }
+    let(:weth_balance) { build(:balance_model, network_id, :weth, amount: BigDecimal('789.0')) }
     let(:weth_atomic_amount) { Coinbase::Asset.from_model(weth_balance.asset).from_atomic_amount(weth_balance.amount) }
 
     let(:balances) { [eth_balance, usdc_balance, weth_balance] }
+
+    before do
+      allow(Coinbase::Network)
+        .to receive(:from_id)
+        .with(network_id)
+        .and_return(network)
+    end
 
     it 'returns a new BalanceMap object with the correct balances' do
       expect(balance_map).to eq(
@@ -53,7 +62,7 @@ describe Coinbase::BalanceMap do
     subject(:balance_map) { described_class.new }
 
     let(:amount) { BigDecimal('123.0') }
-    let(:balance) { build(:balance, whole_amount: amount) }
+    let(:balance) { build(:balance, network_id, whole_amount: amount) }
 
     let(:expected_result) { { eth: '123' }.to_s }
 

--- a/spec/unit/coinbase/destination_spec.rb
+++ b/spec/unit/coinbase/destination_spec.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 
 describe Coinbase::Destination do
-  subject(:destination) { described_class.new(model, network_id: network_id) }
+  subject(:destination) { described_class.new(model, network: network) }
 
   let(:network_id) { :base_sepolia }
+  let(:network) { build(:network, network_id) }
   let(:address_id) { Eth::Key.new.address.to_s }
+
+  before do
+    allow(Coinbase::Network).to receive(:from_id).with(network).and_return(network)
+  end
 
   describe '#initialize' do
     context 'when initialized with a Coinbase::Destination' do
       let(:model) do
-        instance_double(described_class, address_id: address_id, network_id: network_id)
+        instance_double(described_class, address_id: address_id, network: network)
       end
 
       before do
@@ -20,104 +25,146 @@ describe Coinbase::Destination do
         expect(destination.address_id).to eq(address_id)
       end
 
-      it 'sets the network_id' do
-        expect(destination.network_id).to eq(network_id)
+      it 'sets the network' do
+        expect(destination.network).to eq(network)
       end
 
-      context 'when network_id does not match' do
+      context 'when the networks do not match' do
+        let(:destination_network) { build(:network, :ethereum_mainnet) }
         let(:model) do
-          instance_double(described_class, address_id: address_id, network_id: :ethereum_mainnet)
+          instance_double(described_class, address_id: address_id, network: destination_network)
         end
 
         it 'raises an ArgumentError' do
           expect do
-            described_class.new(model, network_id: network_id)
+            described_class.new(model, network: network)
           end.to raise_error(ArgumentError, 'destination network must match destination')
         end
       end
     end
 
     context 'when initialized with a Coinbase::Wallet' do
-      let(:default_address) { instance_double(Coinbase::Address, id: address_id, network_id: network_id) }
-      let(:model) { instance_double(Coinbase::Wallet, default_address: default_address, network_id: network_id) }
+      let(:default_address_network_id) { network_id }
+      let(:default_address_network) { network }
+      let(:default_address_model) { build(:address_model, default_address_network_id) }
+      let(:model) do
+        instance_double(
+          Coinbase::Wallet,
+          default_address: Coinbase::WalletAddress.new(default_address_model, nil),
+          network: network
+        )
+      end
 
       before do
+        # The wallet model's network method fetches the network constant from the network ID.
+        allow(Coinbase::Network)
+          .to receive(:from_id)
+          .with(Coinbase.normalize_network(default_address_network_id))
+          .and_return(default_address_network)
+
         allow(Coinbase::Wallet).to receive(:===).with(model).and_return(true)
       end
 
       it 'sets the address_id' do
-        expect(destination.address_id).to eq(address_id)
+        expect(destination.address_id).to eq(default_address_model.address_id)
       end
 
-      it 'sets the network_id' do
-        expect(destination.network_id).to eq(network_id)
+      it 'sets the network' do
+        expect(destination.network).to eq(default_address_network)
       end
 
-      context 'when network_id does not match' do
+      context 'when network does not match' do
+        let(:default_address_network_id) { :ethereum_mainnet }
+        let(:default_address_network) { build(:network, default_address_network_id) }
+        let(:default_address_model) { build(:address_model, default_address_network_id) }
         let(:model) do
-          instance_double(Coinbase::Wallet, default_address: default_address, network_id: :ethereum_mainnet)
+          instance_double(
+            Coinbase::Wallet,
+            default_address: Coinbase::WalletAddress.new(default_address_model, nil),
+            network: default_address_network
+          )
         end
 
         it 'raises an ArgumentError' do
           expect do
-            described_class.new(model, network_id: network_id)
+            described_class.new(model, network: network)
           end.to raise_error(ArgumentError, 'destination network must match wallet')
         end
       end
 
       context 'when wallet does not have a default address' do
-        let(:model) { instance_double(Coinbase::Wallet, default_address: nil, network_id: network_id) }
+        let(:model) do
+          instance_double(Coinbase::Wallet, network: network, default_address: nil)
+        end
 
         it 'raises an ArgumentError' do
           expect do
-            described_class.new(model, network_id: network_id)
+            described_class.new(model, network: network)
           end.to raise_error(ArgumentError, 'destination wallet must have default address')
         end
       end
     end
 
     context 'when model is a Coinbase::WalletAddress' do
-      let(:address_network) { network_id }
-      let(:address_model) { build(:address_model, address_network) }
+      let(:address_network_id) { network_id }
+      let(:address_network) { network }
+      let(:address_model) { build(:address_model, address_network_id) }
       let(:model) { Coinbase::WalletAddress.new(address_model, nil) }
+
+      before do
+        allow(Coinbase::Network)
+          .to receive(:from_id)
+          .with(Coinbase.normalize_network(address_network_id))
+          .and_return(address_network)
+      end
 
       it 'sets the address_id' do
         expect(destination.address_id).to eq(address_model.address_id)
       end
 
-      it 'sets the network_id' do
-        expect(destination.network_id).to eq(address_network)
+      it 'sets the network' do
+        expect(destination.network).to eq(network)
       end
 
-      context 'when network_id does not match' do
-        let(:address_network) { :ethereum_mainnet }
+      context 'when networks do not match' do
+        let(:address_network_id) { :ethereum_mainnet }
+        let(:address_network) { build(:network, address_network_id) }
 
         it 'raises an ArgumentError' do
           expect do
-            described_class.new(model, network_id: network_id)
+            described_class.new(model, network: network)
           end.to raise_error(ArgumentError, 'destination network must match address')
         end
       end
     end
 
     context 'when initialized with a Coinbase::ExternalAddress' do
-      let(:address_network) { network_id }
-      let(:model) { Coinbase::ExternalAddress.new(address_network, address_id) }
+      let(:address_network_id) { network_id }
+      let(:address_network) { network }
+      let(:model) { Coinbase::ExternalAddress.new(address_network_id, address_id) }
+
+      before do
+        allow(Coinbase::Network)
+          .to receive(:from_id)
+          .with(address_network_id)
+          .and_return(address_network)
+      end
 
       it 'sets the address_id' do
         expect(destination.address_id).to eq(address_id)
       end
 
-      it 'sets the network_id' do
-        expect(destination.network_id).to eq(network_id)
+      it 'sets the network' do
+        expect(destination.network).to eq(address_network)
       end
 
-      context 'when network_id does not match' do
-        let(:address_network) { :ethereum_mainnet }
+      context 'when network does not match' do
+        let(:address_network_id) { :ethereum_mainnet }
+        let(:address_network) { build(:network, address_network_id) }
 
         it 'raises an ArgumentError' do
           expect do
-            described_class.new(model, network_id: network_id)
+            described_class.new(model, network: network)
           end.to raise_error(ArgumentError, 'destination network must match address')
         end
       end
@@ -130,15 +177,15 @@ describe Coinbase::Destination do
         expect(destination.address_id).to eq(address_id)
       end
 
-      it 'sets the network_id to the provided network_id' do
-        expect(destination.network_id).to eq(network_id)
+      it 'sets the network to the provided network' do
+        expect(destination.network).to eq(network)
       end
     end
 
     context 'when model is an unsupported type' do
       it 'raises an ArgumentError' do
         expect do
-          described_class.new(123)
+          described_class.new(123, network: network)
         end.to raise_error(ArgumentError, 'unsupported destination type: Integer')
       end
     end

--- a/spec/unit/coinbase/historical_balance_spec.rb
+++ b/spec/unit/coinbase/historical_balance_spec.rb
@@ -2,9 +2,10 @@
 
 describe Coinbase::HistoricalBalance do
   let(:amount) { BigDecimal('1000000000000000000') }
-  let(:eth_asset) { build(:asset_model) }
+  let(:network_id) { :ethereum_mainnet }
+  let(:eth_asset) { build(:asset_model, network_id) }
   let(:asset) { Coinbase::Asset.from_model(eth_asset) }
-  let(:historical_balance_obj) { build(:historical_balance_model, amount: '1000000000000000000') }
+  let(:historical_balance_obj) { build(:historical_balance_model, network_id, amount: '1000000000000000000') }
 
   describe '.from_model' do
     subject(:historical_balance) { described_class.from_model(historical_balance_obj) }

--- a/spec/unit/coinbase/network_spec.rb
+++ b/spec/unit/coinbase/network_spec.rb
@@ -1,28 +1,78 @@
 # frozen_string_literal: true
 
 describe Coinbase::Network do
-  let(:eth) { Coinbase::Asset.new(network_id: :base_sepolia, asset_id: :eth, decimals: 18) }
-  let(:usdc) { Coinbase::Asset.new(network_id: :base_sepolia, asset_id: :usdc, decimals: 6) }
-  let(:network) do
-    described_class.new(
-      network_id: :ethereum,
-      display_name: 'Ethereum',
-      protocol_family: 'evm',
-      is_testnet: false,
-      native_asset_id: :eth,
-      chain_id: 1
-    )
+  subject(:network) { described_class.new(network_id) }
+
+  let(:networks_api) { instance_double(Coinbase::Client::NetworksApi) }
+  let(:network_id) { :ethereum_mainnet }
+  let(:normalized_network_id) { 'ethereum-mainnet' }
+  let(:network_model) { build(:network_model, :ethereum_mainnet) }
+
+  let(:eth) { build(:asset, network_id) }
+  let(:usdc) { build(:asset, network_id, :usdc) }
+
+  before do
+    allow(Coinbase::Client::NetworksApi).to receive(:new).and_return(networks_api)
+  end
+
+  describe 'network constants' do
+    Coinbase::Client::NetworkIdentifier.all_vars.each do |network_id|
+      let(:network_const) { Coinbase.normalize_network(network_id).upcase }
+
+      it "defines network constant for `#{network_id}`" do
+        expect(described_class).to be_const_defined(:BASE_SEPOLIA)
+      end
+    end
+
+    it 'defines the `ALL` constant' do
+      expect(described_class).to be_const_defined(:ALL)
+    end
   end
 
   describe '#initialize' do
+    before { allow(networks_api).to receive(:get_network) }
+
     it 'initializes a network' do
-      expect(network.chain_id).to eq(1)
+      expect(network).to be_a(described_class)
+    end
+
+    it 'sets the network ID' do
+      expect(network.id).to eq(network_id)
+    end
+
+    it 'does not fetch the network model' do
+      network
+
+      expect(networks_api).not_to have_received(:get_network)
+    end
+  end
+
+  {
+    chain_id: :chain_id,
+    display_name: :display_name,
+    testnet?: :is_testnet,
+    protocol_family: :protocol_family
+  }.each do |method, model_field|
+    describe "##{method}" do
+      before do
+        allow(networks_api).to receive(:get_network).and_return(network_model)
+      end
+
+      it 'returns the value from the network model field' do
+        expect(network.send(method)).to eq(network_model.send(model_field))
+      end
+
+      it 'fetches the network model' do
+        network.send(method)
+
+        expect(networks_api).to have_received(:get_network).with(normalized_network_id)
+      end
     end
   end
 
   describe '#get_asset' do
     before do
-      allow(Coinbase::Asset).to receive(:fetch).with(:ethereum, :usdc).and_return(usdc)
+      allow(Coinbase::Asset).to receive(:fetch).with(:ethereum_mainnet, :usdc).and_return(usdc)
     end
 
     it 'gets an asset by ID' do
@@ -32,11 +82,17 @@ describe Coinbase::Network do
 
   describe '#native_asset' do
     before do
-      allow(Coinbase::Asset).to receive(:fetch).with(:ethereum, :eth).and_return(eth)
+      allow(networks_api).to receive(:get_network).and_return(network_model)
     end
 
     it 'returns the native asset of the network' do
-      expect(network.native_asset).to eq(eth)
+      expect(network.native_asset.asset_id).to eq(eth.asset_id)
+    end
+
+    it 'fetches the network model' do
+      network.native_asset
+
+      expect(networks_api).to have_received(:get_network).with(normalized_network_id)
     end
   end
 end

--- a/spec/unit/coinbase/transaction_spec.rb
+++ b/spec/unit/coinbase/transaction_spec.rb
@@ -154,7 +154,7 @@ describe Coinbase::Transaction do
       end
 
       it 'returns the correct chain ID' do
-        expect(transaction.raw.chain_id).to eq(Coinbase::BASE_SEPOLIA.chain_id)
+        expect(transaction.raw.chain_id).to eq(84_532)
       end
 
       it 'returns the correct sanitized sender address' do
@@ -204,7 +204,7 @@ describe Coinbase::Transaction do
       end
 
       it 'returns the correct chain ID' do
-        expect(transaction.raw.chain_id).to eq(Coinbase::BASE_SEPOLIA.chain_id)
+        expect(transaction.raw.chain_id).to eq(84_532)
       end
 
       it 'returns the correct sanitized sender address' do

--- a/spec/unit/coinbase/transaction_spec.rb
+++ b/spec/unit/coinbase/transaction_spec.rb
@@ -15,7 +15,7 @@ describe Coinbase::Transaction do
     context 'when initialized with a model of a different type' do
       it 'raises an error' do
         expect do
-          described_class.new(build(:balance_model))
+          described_class.new(build(:balance_model, :base_sepolia))
         end.to raise_error(RuntimeError)
       end
     end

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -4,29 +4,35 @@ describe Coinbase::Wallet do
   subject(:wallet) { described_class.new(model) }
 
   let(:wallet_id) { SecureRandom.uuid }
-  let(:network) { :base_sepolia }
-  let(:network_id) { Coinbase.normalize_network(network) }
+  let(:network_id) { :base_sepolia }
+  let(:normalized_network_id) { Coinbase.normalize_network(network_id) }
   let(:seed) { '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f' }
-  let(:model) { build(:wallet_model, network, :without_default_address, id: wallet_id) }
-  let(:model_with_default_address) { build(:wallet_model, network, id: wallet_id, seed: seed) }
+  let(:model) { build(:wallet_model, network_id, :without_default_address, id: wallet_id) }
+  let(:model_with_default_address) { build(:wallet_model, network_id, id: wallet_id, seed: seed) }
   let(:model_with_seed_pending) do
-    build(:wallet_model, network, :server_signer_pending, id: wallet_id, seed: seed)
+    build(:wallet_model, network_id, :server_signer_pending, id: wallet_id, seed: seed)
   end
   let(:model_with_seed_active) do
-    build(:wallet_model, network, :server_signer_active, id: wallet_id, seed: seed)
+    build(:wallet_model, network_id, :server_signer_active, id: wallet_id, seed: seed)
   end
   let(:first_address_model) do
-    build(:address_model, network, :with_seed, seed: seed, wallet_id: wallet_id, index: 0)
+    build(:address_model, network_id, :with_seed, seed: seed, wallet_id: wallet_id, index: 0)
   end
   let(:second_address_model) do
-    build(:address_model, network, :with_seed, seed: seed, wallet_id: wallet_id, index: 1)
+    build(:address_model, network_id, :with_seed, seed: seed, wallet_id: wallet_id, index: 1)
   end
   let(:wallets_api) { instance_double(Coinbase::Client::WalletsApi) }
   let(:addresses_api) { instance_double(Coinbase::Client::AddressesApi) }
   let(:transfers_api) { instance_double(Coinbase::Client::TransfersApi) }
   let(:use_server_signer) { false }
+  let(:default_network) { build(:network, :base_sepolia) }
   let(:configuration) do
-    instance_double(Coinbase::Configuration, use_server_signer: use_server_signer, api_client: nil)
+    instance_double(
+      Coinbase::Configuration,
+      use_server_signer: use_server_signer,
+      api_client: nil,
+      default_network: default_network
+    )
   end
 
   before do
@@ -44,7 +50,7 @@ describe Coinbase::Wallet do
     let(:resource_list_klass) { Coinbase::Client::WalletList }
     let(:item_klass) { described_class }
     let(:item_initialize_args) { { seed: '' } }
-    let(:create_model) { ->(id) { build(:wallet_model, network, :without_default_address, id: id) } }
+    let(:create_model) { ->(id) { build(:wallet_model, network_id, :without_default_address, id: id) } }
 
     it_behaves_like 'it is a paginated enumerator', :wallets
   end
@@ -79,7 +85,7 @@ describe Coinbase::Wallet do
     subject(:imported_wallet) { described_class.import(exported_data) }
 
     let(:wallet_id) { SecureRandom.uuid }
-    let(:wallet_model) { build(:wallet_model, network, id: wallet_id) }
+    let(:wallet_model) { build(:wallet_model, network_id, id: wallet_id) }
     let(:exported_data) { Coinbase::Wallet::Data.new(wallet_id: wallet_id, seed: seed) }
 
     before do
@@ -126,10 +132,10 @@ describe Coinbase::Wallet do
 
     let(:wallet_id) { SecureRandom.uuid }
     let(:create_wallet_request) do
-      { wallet: { network_id: network_id, use_server_signer: use_server_signer } }
+      { wallet: { network_id: normalized_network_id, use_server_signer: use_server_signer } }
     end
     let(:request) { { create_wallet_request: create_wallet_request } }
-    let(:wallet_model) { build(:wallet_model, network, id: wallet_id) }
+    let(:wallet_model) { build(:wallet_model, network_id, id: wallet_id) }
 
     before do
       allow(wallets_api).to receive(:create_wallet).with(request).and_return(wallet_model)
@@ -178,13 +184,14 @@ describe Coinbase::Wallet do
       end
     end
 
-    context 'when setting the network ID explicitly' do
+    context 'when setting the network explicitly' do
       subject(:created_wallet) do
-        described_class.create(network_id: network)
+        described_class.create(network: network)
       end
 
-      let(:network) { :base_mainnet }
+      let(:network_id) { :ethereum_mainnet }
       let(:use_server_signer) { false }
+      let(:network) { build(:network, network_id) }
 
       before do
         allow(addresses_api)
@@ -211,10 +218,14 @@ describe Coinbase::Wallet do
       end
 
       it 'sets the specified network ID' do
-        expect(created_wallet.network_id).to eq(:base_mainnet)
+        expect(created_wallet.network_id).to eq(network_id)
       end
 
       context 'when using a network symbol' do
+        subject(:created_wallet) do
+          described_class.create(network: network_id)
+        end
+
         let(:network_id) { :base_mainnet }
         let(:create_wallet_request) do
           { wallet: { network_id: 'base-mainnet', use_server_signer: use_server_signer } }
@@ -225,7 +236,7 @@ describe Coinbase::Wallet do
         end
 
         it 'sets the specified network ID' do
-          expect(created_wallet.network_id).to eq(:base_mainnet)
+          expect(created_wallet.network_id).to eq(network_id)
         end
       end
     end
@@ -779,8 +790,8 @@ describe Coinbase::Wallet do
     let(:response) do
       Coinbase::Client::AddressBalanceList.new(
         data: [
-          build(:balance_model, network, amount: '1000000000000000000'),
-          build(:balance_model, network, :usdc, amount: '5000000')
+          build(:balance_model, network_id, amount: '1000000000000000000'),
+          build(:balance_model, network_id, :usdc, amount: '5000000')
         ]
       )
     end
@@ -797,7 +808,7 @@ describe Coinbase::Wallet do
   describe '#balance' do
     let(:eth_asset) { build(:asset_model) }
     let(:amount) { 5_000_000_000_000_000_000 }
-    let(:response) { build(:balance_model, network, amount: amount) }
+    let(:response) { build(:balance_model, network_id, amount: amount) }
 
     before do
       allow(wallets_api).to receive(:get_wallet_balance).with(wallet_id, 'eth').and_return(response)
@@ -900,7 +911,7 @@ describe Coinbase::Wallet do
     let(:asset_id) { :eth }
     let(:other_wallet_id) { SecureRandom.uuid }
     let(:other_wallet_model) do
-      build(:wallet_model, network, id: other_wallet_id, default_address: second_address_model)
+      build(:wallet_model, network_id, id: other_wallet_id, default_address: second_address_model)
     end
     let(:other_wallet) { described_class.new(other_wallet_model, seed: '') }
     let(:destination) { other_wallet }
@@ -1223,7 +1234,7 @@ describe Coinbase::Wallet do
     it 'loads the encrypted seed from file with multiple seeds' do
       seed_wallet.save_seed!(file_path, encrypt: true)
 
-      other_model = Coinbase::Client::Wallet.new(id: SecureRandom.uuid, network_id: network_id)
+      other_model = Coinbase::Client::Wallet.new(id: SecureRandom.uuid, network_id: normalized_network_id)
       other_wallet = described_class.new(other_model)
       other_wallet.save_seed!(file_path, encrypt: true)
 
@@ -1270,7 +1281,7 @@ describe Coinbase::Wallet do
 
   describe '#inspect' do
     it 'includes wallet details' do
-      expect(wallet.inspect).to include(wallet_id, Coinbase.to_sym(network_id).to_s)
+      expect(wallet.inspect).to include(wallet_id, network_id.to_s)
     end
 
     it 'returns the same value as to_s' do


### PR DESCRIPTION
### What changed? Why?
This dynamically constructs network constants based on the network
enum from our generated CDP service OpenAPI spec.

This will construct the `Coinbase::Network::ALL` constant that
enumerates the network objects.

For each network this will also construct network constants like:
`Coinbase::Network::BASE_SEPOLIA`

This will enable us to use these constants in place of network IDs,
for example:

```
Coinbase::Wallet.create(network: Coinbase::Network::BASE_MAINNET)
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->