### PR TITLE
Expose to_address_id method on Transaction class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add to_address_id method to Transaction class
+- Remove "pending" status from staking operation status
+
 ## [0.0.16] - 2024-08-14
 
 - Add support for gasless transfers. Initially only supporting USDC sends on Base mainnet.

--- a/lib/coinbase/client/models/staking_operation.rb
+++ b/lib/coinbase/client/models/staking_operation.rb
@@ -187,7 +187,7 @@ module Coinbase::Client
       return false if @network_id.nil?
       return false if @address_id.nil?
       return false if @status.nil?
-      status_validator = EnumAttributeValidator.new('String', ["initialized", "pending", "complete", "failed", "unspecified", "unknown_default_open_api"])
+      status_validator = EnumAttributeValidator.new('String', ["initialized", "complete", "failed", "unspecified", "unknown_default_open_api"])
       return false unless status_validator.valid?(@status)
       return false if @transactions.nil?
       true
@@ -196,7 +196,7 @@ module Coinbase::Client
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] status Object to be assigned
     def status=(status)
-      validator = EnumAttributeValidator.new('String', ["initialized", "pending", "complete", "failed", "unspecified", "unknown_default_open_api"])
+      validator = EnumAttributeValidator.new('String', ["initialized", "complete", "failed", "unspecified", "unknown_default_open_api"])
       unless validator.valid?(status)
         fail ArgumentError, "invalid value for \"status\", must be one of #{validator.allowable_values}."
       end

--- a/lib/coinbase/client/models/transaction.rb
+++ b/lib/coinbase/client/models/transaction.rb
@@ -16,11 +16,14 @@ require 'time'
 module Coinbase::Client
   # An onchain transaction.
   class Transaction
-    # The ID of the blockchain network
+    # The ID of the blockchain network.
     attr_accessor :network_id
 
-    # The onchain address of the sender
+    # The onchain address of the sender.
     attr_accessor :from_address_id
+
+    # The onchain address of the recipient.
+    attr_accessor :to_address_id
 
     # The unsigned payload of the transaction. This is the payload that needs to be signed by the sender.
     attr_accessor :unsigned_payload
@@ -28,13 +31,13 @@ module Coinbase::Client
     # The signed payload of the transaction. This is the payload that has been signed by the sender.
     attr_accessor :signed_payload
 
-    # The hash of the transaction
+    # The hash of the transaction.
     attr_accessor :transaction_hash
 
     # The link to view the transaction on a block explorer. This is optional and may not be present for all transactions.
     attr_accessor :transaction_link
 
-    # The status of the transaction
+    # The status of the transaction.
     attr_accessor :status
 
     class EnumAttributeValidator
@@ -64,6 +67,7 @@ module Coinbase::Client
       {
         :'network_id' => :'network_id',
         :'from_address_id' => :'from_address_id',
+        :'to_address_id' => :'to_address_id',
         :'unsigned_payload' => :'unsigned_payload',
         :'signed_payload' => :'signed_payload',
         :'transaction_hash' => :'transaction_hash',
@@ -82,6 +86,7 @@ module Coinbase::Client
       {
         :'network_id' => :'String',
         :'from_address_id' => :'String',
+        :'to_address_id' => :'String',
         :'unsigned_payload' => :'String',
         :'signed_payload' => :'String',
         :'transaction_hash' => :'String',
@@ -121,6 +126,10 @@ module Coinbase::Client
         self.from_address_id = attributes[:'from_address_id']
       else
         self.from_address_id = nil
+      end
+
+      if attributes.key?(:'to_address_id')
+        self.to_address_id = attributes[:'to_address_id']
       end
 
       if attributes.key?(:'unsigned_payload')
@@ -202,6 +211,7 @@ module Coinbase::Client
       self.class == o.class &&
           network_id == o.network_id &&
           from_address_id == o.from_address_id &&
+          to_address_id == o.to_address_id &&
           unsigned_payload == o.unsigned_payload &&
           signed_payload == o.signed_payload &&
           transaction_hash == o.transaction_hash &&
@@ -218,7 +228,7 @@ module Coinbase::Client
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [network_id, from_address_id, unsigned_payload, signed_payload, transaction_hash, transaction_link, status].hash
+      [network_id, from_address_id, to_address_id, unsigned_payload, signed_payload, transaction_hash, transaction_link, status].hash
     end
 
     # Builds the object from hash

--- a/lib/coinbase/transaction.rb
+++ b/lib/coinbase/transaction.rb
@@ -68,6 +68,12 @@ module Coinbase
       @model.from_address_id
     end
 
+    # Returns the to address for the Transaction.
+    # @return [String] The to address
+    def to_address_id
+      @model.to_address_id
+    end
+
     # Returns whether the Transaction is in a terminal state.
     # @return [Boolean] Whether the Transaction is in a terminal state
     def terminal_state?

--- a/spec/factories/keys.rb
+++ b/spec/factories/keys.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :key, class: Eth::Key do
-    initialize_with { new(priv: priv) }
+    initialize_with { Eth::Key.new(priv: priv) }
 
     transient do
       seed { nil }

--- a/spec/factories/wallet.rb
+++ b/spec/factories/wallet.rb
@@ -37,7 +37,7 @@ FactoryBot.define do
       id { SecureRandom.uuid }
     end
 
-    initialize_with { new(model, seed: seed) }
+    initialize_with { Coinbase::Wallet.new(model, seed: seed) }
 
     model { build(:wallet_model, id: id) }
   end

--- a/spec/unit/coinbase/transaction_spec.rb
+++ b/spec/unit/coinbase/transaction_spec.rb
@@ -95,6 +95,12 @@ describe Coinbase::Transaction do
     end
   end
 
+  describe '#to_address_id' do
+    it 'returns the to address' do
+      expect(transaction.to_address_id).to eq(transaction_model.to_address_id)
+    end
+  end
+
   describe '#terminal_state?' do
     let(:transaction_model) { build(:transaction_model, status: status) }
 


### PR DESCRIPTION
### What changed? Why?

This PR helps expose the `to_address_id` method on the Transaction class.


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->