### PR TITLE
[chore] Bump gemspec to v0.0.16

### DIFF
--- a/coinbase.gemspec
+++ b/coinbase.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'coinbase-sdk'
-  spec.version = '0.0.14'
+  spec.version = '0.0.16'
   spec.authors = ['Yuga Cohler']
   spec.files = Dir['lib/**/*.rb']
   spec.summary = 'Coinbase Ruby SDK'

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -20,7 +20,7 @@ describe Coinbase do
     end
   end
 
-  describe 'v0.0.9 SDK' do
+  describe 'v0.0.16 SDK' do
     it 'behaves as expected' do # rubocop:disable RSpec/NoExpectationExample
       user = fetch_user_test
       new_address = create_new_address_test(user)


### PR DESCRIPTION
### What changed? Why?
This bumps the gemspec to v0.0.16 to prepare for release

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->