### PR TITLE
[HistoricalBalances] add wallet level function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add historical_balances function for wallet: listing historical balances for default address of the wallet.
 
 ## [0.0.16] - 2024-08-14
 

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -367,6 +367,14 @@ module Coinbase
       default_address.claimable_balance(asset_id, mode: mode, options: options)
     end
 
+    # Enumerates the historical balances for a given asset belonging of default address.
+    # The result is an enumerator that lazily fetches from the server, and can be iterated over,
+    # converted to an array, etc...
+    # @return [Enumerable<Coinbase::HistoricalBalance>] Enumerator that returns historical_balance
+    def historical_balances(asset_id)
+      default_address.historical_balances(asset_id)
+    end
+
     # Exports the Wallet's data to a Data object.
     # @return [Coinbase::Wallet::Data] The Wallet data
     def export

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -367,7 +367,7 @@ module Coinbase
       default_address.claimable_balance(asset_id, mode: mode, options: options)
     end
 
-    # Enumerates the historical balances for a given asset belonging of default address.
+    # Enumerates the historical balances for a given asset belonging to the default address of the wallet.
     # The result is an enumerator that lazily fetches from the server, and can be iterated over,
     # converted to an array, etc...
     # @return [Enumerable<Coinbase::HistoricalBalance>] Enumerator that returns historical_balance

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -873,6 +873,22 @@ describe Coinbase::Wallet do
           .with(:eth, mode: :default, options: {})
       end
     end
+
+    describe '#historical_balances' do
+      subject(:historical_balances) { wallet.historical_balances(:eth) }
+
+      before do
+        allow(wallet.default_address).to receive(:historical_balances)
+      end
+
+      it 'calls historical_balances' do
+        historical_balances
+
+        expect(wallet.default_address)
+          .to have_received(:historical_balances)
+          .with(:eth)
+      end
+    end
   end
 
   describe '#transfer' do


### PR DESCRIPTION
### What changed? Why?
Add wallet level function for get historical balances: fetch historical balances for default address.



#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->