### PR TITLE
[chore] Fix MPC wallet address initailization

### DIFF
--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -516,6 +516,7 @@ describe Coinbase::Wallet do
         .to receive(:list_addresses)
         .with(wallet_id, { limit: 20 })
         .and_return(Coinbase::Client::AddressList.new(data: existing_addresses, total_count: existing_addresses.length))
+        .once
 
       allow(addresses_api)
         .to receive(:create_address)
@@ -527,7 +528,7 @@ describe Coinbase::Wallet do
 
             public_key == expected_public_key && attestation.is_a?(String)
           end
-        ).and_return(created_address_model)
+        ).and_return(created_address_model).once
     end
 
     context 'when the wallet does not have a default address initially' do
@@ -585,6 +586,7 @@ describe Coinbase::Wallet do
           .to receive(:create_address)
           .with(wallet_id).and_return(created_address_model)
 
+        # Reload the wallet with the new address
         allow(wallets_api)
           .to receive(:get_wallet)
           .with(wallet_id)


### PR DESCRIPTION

### What changed? Why?
Previously when creating MPC wallet's we were accidentally appending 2 identical wallet addresses to the cached addresses.

This makes it so that when we're initially creating the wallet, we just do a full model reload instead of using the local cache.


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->