### PR TITLE
(hotfix) fix conversion price

### DIFF
--- a/lib/coinbase/staking_reward.rb
+++ b/lib/coinbase/staking_reward.rb
@@ -62,7 +62,7 @@ module Coinbase
     # Returns the USD conversion price of the StakingReward.
     # @return [BigDecimal] The USD conversion price
     def usd_conversion_price
-      BigDecimal(@model.usd_value.conversion_price.to_i) / BigDecimal(100)
+      BigDecimal(@model.usd_value.conversion_price.to_i)
     end
 
     # Returns the USD conversion time of the StakingReward.

--- a/spec/unit/coinbase/staking_reward_spec.rb
+++ b/spec/unit/coinbase/staking_reward_spec.rb
@@ -140,7 +140,7 @@ describe Coinbase::StakingReward do
     let(:staking_reward) { described_class.new(staking_reward_model, asset, format) }
 
     it 'returns the usd conversion price' do
-      expect(staking_reward.usd_conversion_price).to eq(BigDecimal('1.50'))
+      expect(staking_reward.usd_conversion_price).to eq(BigDecimal('150'))
     end
   end
 


### PR DESCRIPTION
### What changed? Why?

- Correcting the conversion price function to not divide by `100`

**Testing notes**

- tested locally via `make repl`

**Results show correct conversion price for ETH**

```
USD value: 0.361e1, Conversion price: 0.2971e4, Conversion time: 2024-05-02 00:09:00 UTC
USD value: 0.203e1, Conversion price: 0.2984e4, Conversion time: 2024-05-03 00:09:00 UTC
USD value: 0.226e1, Conversion price: 0.3103e4, Conversion time: 2024-05-04 00:09:00 UTC
USD value: 0.213e1, Conversion price: 0.3116e4, Conversion time: 2024-05-05 00:09:00 UTC
```



#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->