### PR TITLE
Add wallet model support for Dedicated ETH Staking

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -6,24 +6,20 @@ those capabilities for the Ruby SDK:
 ## Developer Wallets
 
 | Concept       | Base-Sepolia | Base-Mainnet | Ethereum-Holesky | Ethereum-Mainnet |
-| ------------- | :----------: | :----------: | :--------------: | :--------------: |
-| Addresses     |      ✅      |      ✅      |        ✅        |        ✅        |
-| Send          |      ✅      |      ✅      |        ✅        |        ❌        |
-| Trade         |      ❌      |      ✅      |        ❌        |        ❌        |
-| Faucet        |      ✅      |      ❌      |        ✅        |        ❌        |
-| Server-Signer |      ✅      |      ✅      |        ❌        |        ❌        |
-| Stake [^1]    |      ❌      |      ❌      |        ✅        |        ✅        |
-
-[^1]: Currently only available for Shared ETH Staking.
+|---------------|:------------:|:------------:|:----------------:|:----------------:|
+| Addresses     |      ✅       |      ✅       |        ✅         |        ✅         |
+| Send          |      ✅       |      ✅       |        ✅         |        ❌         |
+| Trade         |      ❌       |      ✅       |        ❌         |        ❌         |
+| Faucet        |      ✅       |      ❌       |        ✅         |        ❌         |
+| Server-Signer |      ✅       |      ✅       |        ❌         |        ❌         |
+| Stake         |      ❌       |      ❌       |        ✅         |        ✅         |
 
 ## End-User Wallets
 
 | Concept            | Base-Sepolia | Base-Mainnet | Ethereum-Holesky | Ethereum-Mainnet |
-| ------------------ | :----------: | :----------: | :--------------: | :--------------: |
-| External Addresses |      ✅      |      ✅      |        ✅        |        ✅        |
-| Stake [^2]         |      ❌      |      ❌      |        ✅        |        ✅        |
-
-[^2]: Dedicated ETH Staking is currently only available on Testnet (Ethereum-Holesky).
+|--------------------|:------------:|:------------:|:----------------:|:----------------:|
+| External Addresses |      ✅       |      ✅       |        ✅         |        ✅         |
+| Stake              |      ❌       |      ❌       |        ✅         |        ✅         |
 
 ## Testnet vs. Mainnet
 
@@ -32,4 +28,4 @@ The Coinbase SDK supports both testnets and mainnets.
 - Testnets are for building and testing applications. Funds are not real, and you can get test currencies from a faucet.
 - Mainnet is where the funds, contracts and applications are real.
 
-Wallets, assets, etc, cannot be moved from testnet to mainnet (or vice versa).
+Wallets, assets, etc. cannot be moved from testnet to mainnet (or vice versa).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ historical_balances function for wallet: listing historical balances for default
 - Expose all networks as constants, e.g. `Coinbase::Network::ETHEREUM_MAINNET`
 - Add support for managing Webhooks.
 - Add support for listing smart contract events.
+- Add support for Dedicated ETH Staking for wallet addresses
 
 ### Breaking Changes
 - All method signatures that took a `network_id` now take a `network` that can be either a network constant (e.g. `Coinbase::Network::BASE_MAINNET`) or a network ID (e.g.  `:base_mainnet`)

--- a/lib/coinbase/address/wallet_address.rb
+++ b/lib/coinbase/address/wallet_address.rb
@@ -100,11 +100,16 @@ module Coinbase
     # @param asset_id [Symbol] The ID of the Asset to stake. For Ether, :eth, :gwei, and :wei are supported.
     # @param mode [Symbol] The staking mode. Defaults to :default.
     # @param options [Hash] Additional options for the stake operation
+    # @param interval_seconds [Integer] The number of seconds to wait between polling for updates. Defaults to 5.
+    # @param timeout_seconds [Integer] The number of seconds to wait before timing out. Defaults to 600.
     # @return [Coinbase::StakingOperation] The staking operation
-    def stake(amount, asset_id, mode: :default, options: {})
+    # @raise [Timeout::Error] if the Staking Operation takes longer than the given timeout.
+    def stake(amount, asset_id, mode: :default, options: {}, interval_seconds: 5, timeout_seconds: 600)
       validate_can_perform_staking_action!(amount, asset_id, 'stakeable_balance', mode, options)
 
-      complete_staking_operation(amount, asset_id, 'stake', mode: mode, options: options)
+      op = StakingOperation.create(amount, network, asset_id, id, wallet_id, 'stake', mode, options)
+
+      op.complete(@key, interval_seconds: interval_seconds, timeout_seconds: timeout_seconds)
     end
 
     # Unstakes the given amount of the given Asset
@@ -112,11 +117,16 @@ module Coinbase
     # @param asset_id [Symbol] The ID of the Asset to stake. For Ether, :eth, :gwei, and :wei are supported.
     # @param mode [Symbol] The staking mode. Defaults to :default.
     # @param options [Hash] Additional options for the stake operation
+    # @param interval_seconds [Integer] The number of seconds to wait between polling for updates. Defaults to 5.
+    # @param timeout_seconds [Integer] The number of seconds to wait before timing out. Defaults to 600.
     # @return [Coinbase::StakingOperation] The staking operation
-    def unstake(amount, asset_id, mode: :default, options: {})
+    # @raise [Timeout::Error] if the Staking Operation takes longer than the given timeout.
+    def unstake(amount, asset_id, mode: :default, options: {}, interval_seconds: 5, timeout_seconds: 600)
       validate_can_perform_staking_action!(amount, asset_id, 'unstakeable_balance', mode, options)
 
-      complete_staking_operation(amount, asset_id, 'unstake', mode: mode, options: options)
+      op = StakingOperation.create(amount, network, asset_id, id, wallet_id, 'unstake', mode, options)
+
+      op.complete(@key, interval_seconds: interval_seconds, timeout_seconds: timeout_seconds)
     end
 
     # Claims the given amount of the given Asset
@@ -124,11 +134,16 @@ module Coinbase
     # @param asset_id [Symbol] The ID of the Asset to stake. For Ether, :eth, :gwei, and :wei are supported.
     # @param mode [Symbol] The staking mode. Defaults to :default.
     # @param options [Hash] Additional options for the stake operation
+    # @param interval_seconds [Integer] The number of seconds to wait between polling for updates. Defaults to 5.
+    # @param timeout_seconds [Integer] The number of seconds to wait before timing out. Defaults to 600.
     # @return [Coinbase::StakingOperation] The staking operation
-    def claim_stake(amount, asset_id, mode: :default, options: {})
+    # @raise [Timeout::Error] if the Staking Operation takes longer than the given timeout.
+    def claim_stake(amount, asset_id, mode: :default, options: {}, interval_seconds: 5, timeout_seconds: 600)
       validate_can_perform_staking_action!(amount, asset_id, 'claimable_balance', mode, options)
 
-      complete_staking_operation(amount, asset_id, 'claim_stake', mode: mode, options: options)
+      op = StakingOperation.create(amount, network, asset_id, id, wallet_id, 'claim_stake', mode, options)
+
+      op.complete(@key, interval_seconds: interval_seconds, timeout_seconds: timeout_seconds)
     end
 
     # Returns whether the Address has a private key backing it to sign transactions.
@@ -182,36 +197,6 @@ module Coinbase
       return unless current_balance < amount
 
       raise InsufficientFundsError.new(amount, current_balance)
-    end
-
-    def complete_staking_operation(amount, asset_id, action, mode: :default, options: {}, interval_seconds: 5,
-                                   timeout_seconds: 600)
-      op = StakingOperation.create(amount, network, asset_id, id, wallet_id, action, mode, options)
-      start_time = Time.now
-
-      while Time.now - start_time < timeout_seconds
-        op.transactions.each_with_index do |transaction, i|
-          next if transaction.signed?
-
-          transaction.sign(@key)
-          @model = Coinbase.call_api do
-            stake_api.broadcast_staking_operation(
-              wallet_id,
-              id,
-              op.id,
-              { signed_payload: transaction.raw.hex, transaction_index: i }
-            )
-          end
-        end
-
-        op.reload
-
-        return op if op.terminal_state?
-
-        sleep interval_seconds
-      end
-
-      raise
     end
   end
 end

--- a/lib/coinbase/staking_operation.rb
+++ b/lib/coinbase/staking_operation.rb
@@ -105,9 +105,9 @@ module Coinbase
     end
 
     # Returns the Network ID of the Staking Operation.
-    # @return [String] The Network ID
+    # @return [Symbol] The Network ID
     def network_id
-      @model.network_id
+      Coinbase.to_sym(@model.network_id)
     end
 
     # Returns the Address ID of the Staking Operation.

--- a/lib/coinbase/staking_operation.rb
+++ b/lib/coinbase/staking_operation.rb
@@ -122,14 +122,20 @@ module Coinbase
       @model.status
     end
 
+    # Returns whether the Staking Operation is in a terminal state.
+    # @return [Boolean] Whether the Staking Operation is in a terminal state
     def terminal_state?
       failed_state? || complete_state?
     end
 
+    # Returns whether the Staking Operation is in a failed state.
+    # @return [Boolean] Whether the Staking Operation is in a failed state
     def failed_state?
       status == 'failed'
     end
 
+    # Returns whether the Staking Operation is in a complete state.
+    # @return [Boolean] Whether the Staking Operation is in a complete state
     def complete_state?
       status == 'complete'
     end

--- a/lib/coinbase/staking_operation.rb
+++ b/lib/coinbase/staking_operation.rb
@@ -89,7 +89,9 @@ module Coinbase
     # Returns a new StakingOperation object.
     # @param model [Coinbase::Client::StakingOperation] The underlying StakingOperation object
     def initialize(model)
-      from_model(model)
+      @model = model
+      @transactions ||= []
+      update_transactions(model.transactions)
     end
 
     # Returns the Staking Operation ID.
@@ -102,12 +104,6 @@ module Coinbase
     # @return [Coinbase::Network] The Network
     def network
       @network ||= Coinbase::Network.from_id(@model.network_id)
-    end
-
-    # Returns the Network ID of the Staking Operation.
-    # @return [Symbol] The Network ID
-    def network_id
-      Coinbase.to_sym(@model.network_id)
     end
 
     # Returns the Address ID of the Staking Operation.
@@ -125,25 +121,31 @@ module Coinbase
     # Returns whether the Staking Operation is in a terminal state.
     # @return [Boolean] Whether the Staking Operation is in a terminal state
     def terminal_state?
-      failed_state? || complete_state?
+      failed? || completed?
     end
 
     # Returns whether the Staking Operation is in a failed state.
     # @return [Boolean] Whether the Staking Operation is in a failed state
-    def failed_state?
+    def failed?
       status == 'failed'
     end
 
     # Returns whether the Staking Operation is in a complete state.
     # @return [Boolean] Whether the Staking Operation is in a complete state
-    def complete_state?
+    def completed?
       status == 'complete'
     end
 
     # Returns a String representation of the Staking Operation.
     # @return [String] a String representation of the Staking Operation
     def to_s
-      "StakingOperation { id: #{id}, status: #{status}, network_id: #{network_id}, address_id: #{address_id} }"
+      Coinbase.pretty_print_object(
+        self.class,
+        id: id,
+        status: status,
+        network_id: network.id,
+        address_id: address_id
+      )
     end
 
     # Returns the Wallet ID of the Staking Operation.
@@ -152,12 +154,12 @@ module Coinbase
       @model.wallet_id
     end
 
-    # Waits until the Staking Operation is completed or failed by polling its status at the given interval. Raises a
-    # Timeout::Error if the Staking Operation takes longer than the given timeout.
+    # Waits until the Staking Operation is completed or failed by polling its status at the given interval.
     # @param interval_seconds [Integer] The interval at which to poll, in seconds
     # @param timeout_seconds [Integer] The maximum amount of time
     #   to wait for the StakingOperation to complete, in seconds
     # @return [StakingOperation] The completed StakingOperation object
+    # @raise [Timeout::Error] if the Staking Operation takes longer than the given timeout.
     def wait!(interval_seconds = 5, timeout_seconds = 3600)
       start_time = Time.now
 
@@ -170,6 +172,44 @@ module Coinbase
         raise Timeout::Error, 'Staking Operation timed out' if Time.now - start_time > timeout_seconds
 
         self.sleep interval_seconds
+      end
+
+      self
+    end
+
+    # Complete helps the Staking Operation reach complete state, by polling its status at the given interval, signing
+    # and broadcasting any available transaction.
+    # @param key [Eth::Key] The key to sign the Staking Operation transactions with
+    # @param interval_seconds [Integer] The interval at which to poll, in seconds
+    # @param timeout_seconds [Integer] The maximum amount of time
+    #   to wait for the StakingOperation to complete, in seconds
+    # @return [StakingOperation] The completed StakingOperation object
+    # @raise [Timeout::Error] if the Staking Operation takes longer than the given timeout.
+    def complete(key, interval_seconds: 5, timeout_seconds: 600)
+      start_time = Time.now
+
+      loop do
+        @transactions.each_with_index do |transaction, i|
+          next if transaction.signed?
+
+          transaction.sign(key)
+          @model = Coinbase.call_api do
+            stake_api.broadcast_staking_operation(
+              wallet_id,
+              address_id,
+              id,
+              { signed_payload: transaction.raw.hex, transaction_index: i }
+            )
+          end
+        end
+
+        return self if terminal_state?
+
+        reload
+
+        raise Timeout::Error, 'Staking Operation timed out' if Time.now - start_time > timeout_seconds
+
+        sleep interval_seconds
       end
 
       self
@@ -214,7 +254,9 @@ module Coinbase
         end
       end
 
-      from_model(@model)
+      update_transactions(@model.transactions)
+
+      self
     end
 
     # Fetches the presigned_voluntary exit messages for the staking operation
@@ -261,28 +303,22 @@ module Coinbase
       @wallet_stake_api ||= Coinbase::Client::WalletStakeApi.new(Coinbase.configuration.api_client)
     end
 
-    def from_model(model)
-      @model = model
-      @status = model.status
-      @transactions ||= []
-
+    def update_transactions(transactions)
       # Only overwrite the transactions if the response is populated.
-      if model.transactions && !model.transactions.empty?
-        # Create a set of existing unsigned payloads to avoid duplicates.
-        existing_unsigned_payloads = Set.new
-        @transactions.each do |transaction|
-          existing_unsigned_payloads.add(transaction.unsigned_payload)
-        end
+      return unless transactions && !transactions.empty?
 
-        # Add transactions that are not already in the transactions array.
-        model.transactions.each do |transaction_model|
-          unless existing_unsigned_payloads.include?(transaction_model.unsigned_payload)
-            @transactions << Transaction.new(transaction_model)
-          end
-        end
+      # Create a set of existing unsigned payloads to avoid duplicates.
+      existing_unsigned_payloads = Set.new
+      @transactions.each do |transaction|
+        existing_unsigned_payloads.add(transaction.unsigned_payload)
       end
 
-      self
+      # Add transactions that are not already in the transactions array.
+      transactions.each do |transaction_model|
+        unless existing_unsigned_payloads.include?(transaction_model.unsigned_payload)
+          @transactions << Transaction.new(transaction_model)
+        end
+      end
     end
   end
 end

--- a/spec/unit/coinbase/address/wallet_address_spec.rb
+++ b/spec/unit/coinbase/address/wallet_address_spec.rb
@@ -339,14 +339,13 @@ describe Coinbase::WalletAddress do
     let(:asset_id) { :eth }
     let(:staking_operation) { instance_double(Coinbase::StakingOperation, id: 'test-id') }
     let(:transaction) { instance_double(Coinbase::Transaction) }
-    let(:stake_api) { instance_double(Coinbase::Client::StakeApi) }
     let(:raw_tx) { instance_double(Eth::Tx::Eip1559) }
     let(:hex_encoded_transaction) { '0xdeadbeef' }
 
     before do
       allow(Coinbase::Client::StakeApi).to receive(:new).and_return(stake_api)
-      allow(stake_api).to receive(:broadcast_staking_operation)
       allow(Coinbase::StakingOperation).to receive(:create).and_return(staking_operation)
+      allow(staking_operation).to receive(:complete)
       allow(staking_operation).to receive_messages(
         transactions: [transaction],
         broadcast!: nil,
@@ -377,14 +376,8 @@ describe Coinbase::WalletAddress do
       )
     end
 
-    it 'signs the transaction' do
-      expect(transaction).to have_received(:sign).with(key)
-    end
-
-    it 'broadcasts the transaction' do
-      expect(stake_api).to have_received(:broadcast_staking_operation).with(wallet_id, address_id, 'test-id',
-                                                                            { signed_payload: '0xdeadbeef',
-                                                                              transaction_index: 0 })
+    it 'completes the operation' do
+      expect(staking_operation).to have_received(:complete)
     end
   end
 

--- a/spec/unit/coinbase/staking_operation_spec.rb
+++ b/spec/unit/coinbase/staking_operation_spec.rb
@@ -353,8 +353,8 @@ describe Coinbase::StakingOperation do
     end
   end
 
-  describe '#failed_state?' do
-    subject { staking_operation.failed_state? }
+  describe '#failed?' do
+    subject { staking_operation.failed? }
 
     context 'when status is failed' do
       before do
@@ -373,8 +373,8 @@ describe Coinbase::StakingOperation do
     end
   end
 
-  describe '#complete_state?' do
-    subject { staking_operation.complete_state? }
+  describe '#completed?' do
+    subject { staking_operation.completed? }
 
     context 'when status is complete' do
       before do
@@ -395,8 +395,8 @@ describe Coinbase::StakingOperation do
 
   describe '#to_s' do
     it 'returns the correct string representation of the staking operation' do
-      expected_string = 'StakingOperation { id: some_id, status: initialized, network_id: ethereum_holesky, ' \
-                        'address_id: address_id }'
+      expected_string = "Coinbase::StakingOperation{id: 'some_id', status: 'initialized', " \
+                        "network_id: 'ethereum_holesky', address_id: 'address_id'}"
       expect(staking_operation.to_s).to eq(expected_string)
     end
   end

--- a/spec/unit/coinbase/staking_operation_spec.rb
+++ b/spec/unit/coinbase/staking_operation_spec.rb
@@ -395,7 +395,7 @@ describe Coinbase::StakingOperation do
 
   describe '#to_s' do
     it 'returns the correct string representation of the staking operation' do
-      expected_string = 'StakingOperation { id: some_id, status: initialized, network_id: ethereum-holesky, ' \
+      expected_string = 'StakingOperation { id: some_id, status: initialized, network_id: ethereum_holesky, ' \
                         'address_id: address_id }'
       expect(staking_operation.to_s).to eq(expected_string)
     end


### PR DESCRIPTION
### What changed? Why?

This PR helps introduce dedicated eth staking for wallet mode.

### Testing

#### External Address

##### Shared ETH Stake
```
=> Coinbase::ExternalAddress{id: '0x87Bf57c3d7B211a100ee4d00dee08435130A62fA', network_id: 'ethereum_holesky'}
[3] pry(main)> stakeable_balance = address.stakeable_balance(:eth)
=> 0.142741462753428918384e3
[4] pry(main)> stake_operation = address.build_stake_operation(0.005, :eth)
=> #<Coinbase::StakingOperation:0x0000000106032760
 @model=
  #<Coinbase::Client::StakingOperation:0x0000000106032b48
   @address_id="0x87Bf57c3d7B211a100ee4d00dee08435130A62fA",
   @id="051abaec-399a-4a4c-b226-34c39f0ca8c2",
   @network_id="ethereum-holesky",
   @status="complete",
   @transactions=
    [#<Coinbase::Client::Transaction:0x0000000106032f58
      @from_address_id="0x87Bf57c3d7B211a100ee4d00dee08435130A62fA",
      @network_id="ethereum-holesky",
      @status="pending",
      @to_address_id="0xA55416de5DE61A0AC1aa8970a280E04388B1dE4b",
      @unsigned_payload=
       "7b2274797065223a22307832222c22636861696e4964223a22307834323638222c226e6f6e6365223a223078313064222c22746f223a22307861353534313664653564653631613061633161613839373061323830653034333838623164653462222c22676173223a2230783439336530222c226761735072696365223a6e756c6c2c226d61785072696f72697479466565506572476173223a223078323534306265343030222c226d6178466565506572476173223a223078323534306265343163222c2276616c7565223a2230783131633337393337653038303030222c22696e707574223a2230783361346236366631222c226163636573734c697374223a5b5d2c2276223a22307830222c2272223a22307830222c2273223a22307830222c2279506172697479223a22307830222c2268617368223a22307834646664613337653734333333643038633437636361303061626137636537666161663330643863373863376562623464373665616639396564386433353339227d">]>,
 @status="complete",
 ```

##### Dedicated ETH Stake

```
[13] pry(main)> staking_operation = address.build_stake_operation(32, :eth, mode: :native)
=> #<Coinbase::StakingOperation:0x000000015897e560
 @model=#<Coinbase::Client::StakingOperation:0x000000015897e948 @address_id="0x87Bf57c3d7B211a100ee4d00dee08435130A62fA", @id="15e68e18-4aa6-4a40-be2c-454c30ebca45", @network_id="ethereum-holesky", @status="initialized", @transactions=[]>,
 @status="initialized",
 @transactions=[]>
[14] pry(main)> staking_operation.wait!
=> #<Coinbase::StakingOperation:0x000000015897e560
 @model=
  #<Coinbase::Client::StakingOperation:0x000000015a3063c0
   @address_id="0x87Bf57c3d7B211a100ee4d00dee08435130A62fA",
   @id="15e68e18-4aa6-4a40-be2c-454c30ebca45",
   @network_id="ethereum_holesky",
   @status="complete",
   @transactions=
    [#<Coinbase::Client::Transaction:0x000000015a3067d0
      @from_address_id="0x87Bf57c3d7B211a100ee4d00dee08435130A62fA",
      @network_id="ethereum-holesky",
      @status="pending",
      @to_address_id="0x4242424242424242424242424242424242424242",
      @unsigned_payload=
       "7b2274797065223a22307832222c22636861696e4964223a22307834323638222c226e6f6e6365223a223078313063222c22746f223a22307834323432343234323432343234323432343234323432343234323432343234323432343234323432222c22676173223a22307866653637222c226761735072696365223a6e756c6c2c226d61785072696f72697479466565506572476173223a2230783163653838333430222c226d6178466565506572476173223a2230783163653838333530222c2276616c7565223a2230783162633136643637346563383030303030222c22696e707574223a223078323238393531313830303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303830303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303065303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303031323064643038373364336666656333343034353562653464366233303432653961613231653361623264306263656164323539343066633336333233343163313463303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303033303839633938613236616466373666666331613262366165356661366332396535666563663062316431303465626464366434386531323839663035326635393732613838333138323265623832656261643362643965336439386439343335343030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303032303031303030303030303030303030303030303030303030303837626635376333643762323131613130306565346430306465653038343335313330613632666130303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303630386162666362333066343732666433336634373262313565343234323433363934623939333261393239636563393335346164373563656635646531313831353631616465313637373130666164616131303563326535663163373731396635313239323733613766393137376430373461343233323764656239316331346166653738633230323339393237356565316131663663363464666631613034613133313935643264643138356436643565346537356233643335623034383636222c226163636573734c697374223a5b5d2c2276223a22307830222c2272223a22307830222c2273223a22307830222c2279506172697479223a22307830222c2268617368223a22307865666238643236336630343033373864656262633664663039333335356438383937313763666139653963386532336435356235356564366339353865313235227d">]>,
 @network=Coinbase::Network{id: 'ethereum_holesky'},
 ....
```

##### Unstake

```
[21] pry(main)> staking_operation = address.build_unstake_operation(32, :eth, mode: :native)
[22] pry(main)> staking_operation.wait!
[23] pry(main)> staking_operation.signed_voluntary_exit_messages
=> ["{\"message\":{\"epoch\":\"73972\",\"validator_index\":\"1795481\"},\"signature\":\"0xa1f85d55d3b261b1062197ea265269a7cc40b8b8d61488c93f879f0f12d8c1a0444e9902c8aa768498b4704eae55c86e0cd07d9611a618c411f9750ec8815ea31b39baaae26b40dd7b938a795ab844a7414b715d3db2029eedd5f66a46ffe20d\"}"]
```

#### Wallet Address Model

##### Stake

```
[2] pry(main)> wallet = Coinbase::Wallet.fetch("8586db95-6467-4786-8ebb-c403f05e2018")
=> Coinbase::Wallet{id: '8586db95-6467-4786-8ebb-c403f05e2018', network_id: 'ethereum_holesky', default_address: '0x946B29aDb5Bd7F9B3f87a19499EFF8FFd95A5044'}
[3] pry(main)> wallet.load_seed("my_seed_2.json")
=> "Successfully loaded seed for wallet 8586db95-6467-4786-8ebb-c403f05e2018 from my_seed_2.json."
[4] pry(main)> wallet.balances
=> {:eth=>0.3040929998432744e-2}
[7] pry(main)> wallet.balance(:eth).to_f
=> 32.103040929998436
[9] pry(main)> wallet.stakeable_balance(:eth).to_f
=> 32.103040929998436
[10] pry(main)> staking_operation = wallet.stake(32, :eth, mode: :native)
=> #<Coinbase::StakingOperation:0x000000011b04c858
 @model=
  #<Coinbase::Client::StakingOperation:0x000000014db3c038
   @address_id="0x946B29aDb5Bd7F9B3f87a19499EFF8FFd95A5044",
   @id="5dee8cd0-6a7f-47db-85fa-37129a6c1cdc",
   @network_id="ethereum-holesky",
   @status="complete",
   @transactions=
    [#<Coinbase::Client::Transaction:0x000000014db3c538
      @from_address_id="0x946B29aDb5Bd7F9B3f87a19499EFF8FFd95A5044",
      @network_id="ethereum-holesky",
      @signed_payload=
       "02f9021b82426801841dcd6500841dcd651282fe769442424242424242424242424242424242424242428901bc16d674ec800000b901a422895118000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000120221273702f454378ad5a1882ed452628f79a7cec9d23e88b963407bb02408f3f0000000000000000000000000000000000000000000000000000000000000030a5724c2e030af161b2793e9a65d042fdb8055d5c2b92e5510a487acc404b07280734e624369eb976fea3ca1052de27ec000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020010000000000000000000000946b29adb5bd7f9b3f87a19499eff8ffd95a504400000000000000000000000000000000000000000000000000000000000000608fb2966daadb9a02e5cc85ebaa1c7cbdb43223707017076620d960212a005899b84a88848bfcdbf509b483c6c10f3d7f0f228dab26031212de27bca868083cb6bd3f59d28f5a7622a36a731507f50c22a626063adfe46ba13c54defca21607a6c001a0c7307f87de53c39d7c5929e4a14f0737d6d66dc58f0a7d8cc7a92d66d1bd0ebaa0597aa3d9580f6f3c647cccfab412da07fcbea2d30d60eb0c48481cbae27e642d",
      @status="complete",
      @to_address_id="0x4242424242424242424242424242424242424242",
      @transaction_hash="0x34f2f3eabfda3b6e030f28f18bdb5c5d17090b2fe0b794bc234697d4c69bed5f",
      @transaction_link="https://holesky.etherscan.io/tx/0x34f2f3eabfda3b6e030f28f18bdb5c5d17090b2fe0b794bc234697d4c69bed5f",
      @unsigned_payload=
```

##### Unstake

```
[32] pry(main)> wallet.unstakeable_balance(:eth, mode: :native)
=> 0.32001906127e2
[33] pry(main)> staking_operation = wallet.unstake(32, :eth, mode: :native)
[34] pry(main)> staking_operation.signed_voluntary_exit_messages
=> ["{\"message\":{\"epoch\":\"73973\",\"validator_index\":\"1795481\"},\"signature\":\"0x984a68dc6611b5b0ff50f0232fa54c5edb1d059e6a689a632b70da2d39e45c92e146fcb98acef94650ed6e3bcb262524154d7ee32f90fb23d7a49f742c1bea6ee1c2890ada7150ec194789338212719cfbe42a1ea782d9f1f7e002bc3d69188e\"}"]
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->