### PR TITLE
Refactor code to use uniform styling for class methods

### DIFF
--- a/lib/coinbase/balance.rb
+++ b/lib/coinbase/balance.rb
@@ -3,29 +3,31 @@
 module Coinbase
   # A representation of an Balance.
   class Balance
-    # Converts a Coinbase::Client::Balance model to a Coinbase::Balance
-    # @param balance_model [Coinbase::Client::Balance] The balance fetched from the API.
-    # @return [Balance] The converted Balance object.
-    def self.from_model(balance_model)
-      asset = Coinbase::Asset.from_model(balance_model.asset)
+    class << self
+      # Converts a Coinbase::Client::Balance model to a Coinbase::Balance
+      # @param balance_model [Coinbase::Client::Balance] The balance fetched from the API.
+      # @return [Balance] The converted Balance object.
+      def from_model(balance_model)
+        asset = Coinbase::Asset.from_model(balance_model.asset)
 
-      new(amount: asset.from_atomic_amount(balance_model.amount), asset: asset)
-    end
+        new(amount: asset.from_atomic_amount(balance_model.amount), asset: asset)
+      end
 
-    # Converts a Coinbase::Client::Balance model and asset ID to a Coinbase::Balance
-    # This can be used to specify a non-primary denomination that we want the balance
-    # to be converted to.
-    # @param balance_model [Coinbase::Client::Balance] The balance fetched from the API.
-    # @param asset_id [Symbol] The Asset ID of the denomination we want returned.
-    # @return [Balance] The converted Balance object.
-    def self.from_model_and_asset_id(balance_model, asset_id)
-      asset = Coinbase::Asset.from_model(balance_model.asset, asset_id: asset_id)
+      # Converts a Coinbase::Client::Balance model and asset ID to a Coinbase::Balance
+      # This can be used to specify a non-primary denomination that we want the balance
+      # to be converted to.
+      # @param balance_model [Coinbase::Client::Balance] The balance fetched from the API.
+      # @param asset_id [Symbol] The Asset ID of the denomination we want returned.
+      # @return [Balance] The converted Balance object.
+      def from_model_and_asset_id(balance_model, asset_id)
+        asset = Coinbase::Asset.from_model(balance_model.asset, asset_id: asset_id)
 
-      new(
-        amount: asset.from_atomic_amount(balance_model.amount),
-        asset: asset,
-        asset_id: asset_id
-      )
+        new(
+          amount: asset.from_atomic_amount(balance_model.amount),
+          asset: asset,
+          asset_id: asset_id
+        )
+      end
     end
 
     # Returns a new Balance object. Do not use this method. Instead, use Balance.from_model or

--- a/lib/coinbase/balance_map.rb
+++ b/lib/coinbase/balance_map.rb
@@ -5,15 +5,17 @@ require 'bigdecimal'
 module Coinbase
   # A convenience class for printing out Asset balances in a human-readable format.
   class BalanceMap < Hash
-    # Converts a list of Coinbase::Client::Balance models to a Coinbase::BalanceMap.
-    # @param balances [Array<Coinbase::Client::Balance>] The list of balances fetched from the API.
-    # @return [BalanceMap] The converted BalanceMap object.
-    def self.from_balances(balances)
-      BalanceMap.new.tap do |balance_map|
-        balances.each do |balance_model|
-          balance = Coinbase::Balance.from_model(balance_model)
+    class << self
+      # Converts a list of Coinbase::Client::Balance models to a Coinbase::BalanceMap.
+      # @param balances [Array<Coinbase::Client::Balance>] The list of balances fetched from the API.
+      # @return [BalanceMap] The converted BalanceMap object.
+      def from_balances(balances)
+        BalanceMap.new.tap do |balance_map|
+          balances.each do |balance_model|
+            balance = Coinbase::Balance.from_model(balance_model)
 
-          balance_map.add(balance)
+            balance_map.add(balance)
+          end
         end
       end
     end

--- a/lib/coinbase/client/api_client.rb
+++ b/lib/coinbase/client/api_client.rb
@@ -30,6 +30,12 @@ module Coinbase::Client
     # @return [Hash]
     attr_accessor :default_headers
 
+    class << self
+      def default
+        @@default ||= ApiClient.new
+      end
+    end
+
     # Initializes the ApiClient
     # @option config [Configuration] Configuration for initializing the object, default to Configuration.default
     def initialize(config = Configuration.default)
@@ -39,10 +45,6 @@ module Coinbase::Client
         'Content-Type' => 'application/json',
         'User-Agent' => @user_agent
       }
-    end
-
-    def self.default
-      @@default ||= ApiClient.new
     end
 
     # Call an API with given options.

--- a/lib/coinbase/client/configuration.rb
+++ b/lib/coinbase/client/configuration.rb
@@ -155,6 +155,13 @@ module Coinbase::Client
 
     attr_accessor :force_ending_format
 
+    class << self
+      # The default Configuration object.
+      def default
+        @@default ||= Configuration.new
+      end
+    end
+
     def initialize
       @scheme = 'https'
       @host = 'api.cdp.coinbase.com'
@@ -184,11 +191,6 @@ module Coinbase::Client
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
 
       yield(self) if block_given?
-    end
-
-    # The default Configuration object.
-    def self.default
-      @@default ||= Configuration.new
     end
 
     def configure

--- a/lib/coinbase/historical_balance.rb
+++ b/lib/coinbase/historical_balance.rb
@@ -3,18 +3,21 @@
 module Coinbase
   # A representation of an HistoricalBalance.
   class HistoricalBalance
-    # Converts a Coinbase::Client::HistoricalBalance model to a Coinbase::HistoricalBalance
-    # @param historical_balance_model [Coinbase::Client::HistoricalBalance] The historical balance fetched from the API.
-    # @return [HistoricalBalance] The converted HistoricalBalance object.
-    def self.from_model(historical_balance_model)
-      asset = Coinbase::Asset.from_model(historical_balance_model.asset)
+    class << self
+      # Converts a Coinbase::Client::HistoricalBalance model to a Coinbase::HistoricalBalance
+      # @param historical_balance_model [Coinbase::Client::HistoricalBalance] The historical
+      # balance fetched from the API.
+      # @return [HistoricalBalance] The converted HistoricalBalance object.
+      def from_model(historical_balance_model)
+        asset = Coinbase::Asset.from_model(historical_balance_model.asset)
 
-      new(
-        amount: asset.from_atomic_amount(historical_balance_model.amount),
-        block_height: BigDecimal(historical_balance_model.block_height),
-        block_hash: historical_balance_model.block_hash,
-        asset: asset
-      )
+        new(
+          amount: asset.from_atomic_amount(historical_balance_model.amount),
+          block_height: BigDecimal(historical_balance_model.block_height),
+          block_hash: historical_balance_model.block_hash,
+          asset: asset
+        )
+      end
     end
 
     # Returns a new HistoricalBalance object. Do not use this method. Instead, use Balance.from_model or

--- a/lib/coinbase/middleware.rb
+++ b/lib/coinbase/middleware.rb
@@ -11,26 +11,28 @@ module Coinbase
     Faraday::Request.register_middleware authenticator: -> { Coinbase::Authenticator }
     Faraday::Request.register_middleware correlation: -> { Coinbase::Correlation }
 
-    # Returns the default middleware configuration for the Coinbase SDK.
-    def self.config
-      Coinbase::Client::Configuration.default.tap do |config|
-        uri = URI(Coinbase.configuration.api_url)
+    class << self
+      # Returns the default middleware configuration for the Coinbase SDK.
+      def config
+        Coinbase::Client::Configuration.default.tap do |config|
+          uri = URI(Coinbase.configuration.api_url)
 
-        config.debugging = Coinbase.configuration.debug_api
-        config.host = uri.host + (uri.port ? ":#{uri.port}" : '')
-        config.scheme = uri.scheme if uri.scheme
-        config.request(:authenticator)
-        config.request(:correlation)
-        retry_options = {
-          max: Coinbase.configuration.max_network_tries,
-          interval: 0.05,
-          interval_randomness: 0.5,
-          backoff_factor: 2,
-          methods: %i[get],
-          retry_statuses: [500, 502, 503, 504]
-        }
-        config.configure_faraday_connection do |conn|
-          conn.request :retry, retry_options
+          config.debugging = Coinbase.configuration.debug_api
+          config.host = uri.host + (uri.port ? ":#{uri.port}" : '')
+          config.scheme = uri.scheme if uri.scheme
+          config.request(:authenticator)
+          config.request(:correlation)
+          retry_options = {
+            max: Coinbase.configuration.max_network_tries,
+            interval: 0.05,
+            interval_randomness: 0.5,
+            backoff_factor: 2,
+            methods: %i[get],
+            retry_statuses: [500, 502, 503, 504]
+          }
+          config.configure_faraday_connection do |conn|
+            conn.request :retry, retry_options
+          end
         end
       end
     end

--- a/lib/coinbase/pagination.rb
+++ b/lib/coinbase/pagination.rb
@@ -3,22 +3,24 @@
 module Coinbase
   # A module of helper methods for paginating through resources.
   module Pagination
-    def self.enumerate(fetcher, &build_resource)
-      Enumerator.new do |yielder|
-        page = nil
+    class << self
+      def enumerate(fetcher, &build_resource)
+        Enumerator.new do |yielder|
+          page = nil
 
-        loop do
-          response = Coinbase.call_api { fetcher.call(page) }
+          loop do
+            response = Coinbase.call_api { fetcher.call(page) }
 
-          break if response.data.empty?
+            break if response.data.empty?
 
-          response.data.each do |model|
-            yielder << build_resource.call(model)
+            response.data.each do |model|
+              yielder << build_resource.call(model)
+            end
+
+            break unless response.has_more
+
+            page = response.next_page
           end
-
-          break unless response.has_more
-
-          page = response.next_page
         end
       end
     end

--- a/lib/coinbase/staking_balance.rb
+++ b/lib/coinbase/staking_balance.rb
@@ -5,20 +5,35 @@ require 'date'
 module Coinbase
   # A representation of a staking balance on a network for a given asset.
   class StakingBalance
-    # Returns a list of StakingBalance for the provided network, asset, and addresses.
-    # @param network [Coinbase::Network, Symbol] The Network or Network ID
-    # @param asset_id [Symbol] The asset ID
-    # @param address_id [String] The address ID
-    # @param start_time [Time] The start time. Defaults to one month ago.
-    # @param end_time [Time] The end time. Defaults to the current time.
-    # @return [Enumerable<Coinbase::StakingBalance>] The staking balances
-    def self.list(network, asset_id, address_id, start_time: DateTime.now.prev_month(1), end_time: DateTime.now)
-      network = Coinbase::Network.from_id(network)
+    class << self
+      # Returns a list of StakingBalance for the provided network, asset, and addresses.
+      # @param network_id [Symbol] The network ID
+      # @param asset_id [Symbol] The asset ID
+      # @param address_id [String] The address ID
+      # @param start_time [Time] The start time. Defaults to one month ago.
+      # @param end_time [Time] The end time. Defaults to the current time.
+      # @return [Enumerable<Coinbase::StakingBalance>] The staking balances
+      def list(network_id, asset_id, address_id, start_time: DateTime.now.prev_month(1), end_time: DateTime.now)
+        Coinbase::Pagination.enumerate(
+          ->(page) { list_page(network_id, asset_id, address_id, start_time, end_time, page) }
+        ) do |staking_balance|
+          new(staking_balance)
+        end
+      end
 
-      Coinbase::Pagination.enumerate(
-        ->(page) { list_page(network, asset_id, address_id, start_time, end_time, page) }
-      ) do |staking_balance|
-        new(staking_balance)
+      def stake_api
+        Coinbase::Client::StakeApi.new(Coinbase.configuration.api_client)
+      end
+
+      def list_page(network_id, asset_id, address_id, start_time, end_time, page)
+        stake_api.fetch_historical_staking_balances(
+          Coinbase.normalize_network(network_id),
+          asset_id,
+          address_id,
+          start_time.iso8601,
+          end_time.iso8601,
+          { next_page: page }
+        )
       end
     end
 
@@ -69,24 +84,5 @@ module Coinbase
     def inspect
       to_s
     end
-
-    def self.stake_api
-      Coinbase::Client::StakeApi.new(Coinbase.configuration.api_client)
-    end
-
-    private_class_method :stake_api
-
-    def self.list_page(network, asset_id, address_id, start_time, end_time, page)
-      stake_api.fetch_historical_staking_balances(
-        network.normalized_id,
-        asset_id,
-        address_id,
-        start_time.iso8601,
-        end_time.iso8601,
-        { next_page: page }
-      )
-    end
-
-    private_class_method :list_page
   end
 end

--- a/lib/coinbase/staking_reward.rb
+++ b/lib/coinbase/staking_reward.rb
@@ -5,23 +5,42 @@ require 'date'
 module Coinbase
   # A representation of a staking reward earned on a network for a given asset.
   class StakingReward
-    # Returns a list of StakingRewards for the provided network, asset, and addresses.
-    # @param network_id [Symbol] The network ID
-    # @param asset_id [Symbol] The asset ID
-    # @param address_ids [Array<String>] The address IDs
-    # @param start_time [Time] The start time. Defaults to one month ago.
-    # @param end_time [Time] The end time. Defaults to the current time.
-    # @param format [Symbol] The format to return the rewards in. (:usd, :native) Defaults to :usd.
-    # @return [Enumerable<Coinbase::StakingReward>] The staking rewards
-    def self.list(network_id, asset_id, address_ids, start_time: DateTime.now.prev_month(1), end_time: DateTime.now,
-                  format: :usd)
-      asset = Coinbase.call_api do
-        Asset.fetch(network_id, asset_id)
+    class << self
+      # Returns a list of StakingRewards for the provided network, asset, and addresses.
+      # @param network_id [Symbol] The network ID
+      # @param asset_id [Symbol] The asset ID
+      # @param address_ids [Array<String>] The address IDs
+      # @param start_time [Time] The start time. Defaults to one month ago.
+      # @param end_time [Time] The end time. Defaults to the current time.
+      # @param format [Symbol] The format to return the rewards in. (:usd, :native) Defaults to :usd.
+      # @return [Enumerable<Coinbase::StakingReward>] The staking rewards
+      def list(network_id, asset_id, address_ids, start_time: DateTime.now.prev_month(1), end_time: DateTime.now,
+               format: :usd)
+        asset = Coinbase.call_api do
+          Asset.fetch(network_id, asset_id)
+        end
+        Coinbase::Pagination.enumerate(
+          ->(page) { list_page(network_id, asset_id, address_ids, start_time, end_time, page, format) }
+        ) do |staking_reward|
+          new(staking_reward, asset, format)
+        end
       end
-      Coinbase::Pagination.enumerate(
-        ->(page) { list_page(network_id, asset_id, address_ids, start_time, end_time, page, format) }
-      ) do |staking_reward|
-        new(staking_reward, asset, format)
+
+      def stake_api
+        Coinbase::Client::StakeApi.new(Coinbase.configuration.api_client)
+      end
+
+      def list_page(network_id, asset_id, address_ids, start_time, end_time, page, format)
+        req = {
+          network_id: Coinbase.normalize_network(network_id),
+          asset_id: asset_id,
+          address_ids: address_ids,
+          start_time: start_time.iso8601,
+          end_time: end_time.iso8601,
+          format: format,
+          next_page: page
+        }
+        stake_api.fetch_staking_rewards(req)
       end
     end
 
@@ -81,23 +100,6 @@ module Coinbase
     # @return [String] a string representation of the StakingReward
     def inspect
       to_s
-    end
-
-    def self.stake_api
-      Coinbase::Client::StakeApi.new(Coinbase.configuration.api_client)
-    end
-
-    def self.list_page(network_id, asset_id, address_ids, start_time, end_time, page, format)
-      req = {
-        network_id: Coinbase.normalize_network(network_id),
-        asset_id: asset_id,
-        address_ids: address_ids,
-        start_time: start_time.iso8601,
-        end_time: end_time.iso8601,
-        format: format,
-        next_page: page
-      }
-      stake_api.fetch_staking_rewards(req)
     end
   end
 end

--- a/lib/coinbase/wallet/data.rb
+++ b/lib/coinbase/wallet/data.rb
@@ -6,6 +6,15 @@ module Coinbase
     class Data
       attr_reader :wallet_id, :seed
 
+      class << self
+        # Creates a Data object from the given Hash.
+        # @param data [Hash] The Hash to create the Data object from
+        # @return [Data] The new Data object
+        def from_hash(data)
+          Data.new(wallet_id: data['wallet_id'], seed: data['seed'])
+        end
+      end
+
       # Returns a new Data object.
       # @param wallet_id [String] The ID of the Wallet
       # @param seed [String] The seed of the Wallet
@@ -18,13 +27,6 @@ module Coinbase
       # @return [Hash] The Hash representation of the Data object
       def to_hash
         { wallet_id: wallet_id, seed: seed }
-      end
-
-      # Creates a Data object from the given Hash.
-      # @param data [Hash] The Hash to create the Data object from
-      # @return [Data] The new Data object
-      def self.from_hash(data)
-        Data.new(wallet_id: data['wallet_id'], seed: data['seed'])
       end
     end
   end


### PR DESCRIPTION
### What changed? Why?
Styling change: Use a uniform way of defining class methods across the codebase.
It is scattered across the codebase using `self.method_name` or `class << self`.

All test cases are passing.
No linting issues found.

 

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->