### PR TITLE
revert wallet level historical balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2024-08-22
 
-- Add support for listing historical balances for a wallet, defaulting to the
-historical_balances function for wallet: listing historical balances for default address of the wallet.
 - Expose all networks as constants, e.g. `Coinbase::Network::ETHEREUM_MAINNET`
 - Add support for managing Webhooks.
 - Add support for listing smart contract events.

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -225,17 +225,8 @@ module Coinbase
     # @param options [Hash] Additional options for the staking operation
     # @return [BigDecimal] The claimable balance
 
-    # @!method historical_balances
-    # Enumerates the historical balances for a given asset belonging to the default address of the wallet.
-    # The result is an enumerator that lazily fetches from the server, and can be iterated over,
-    # converted to an array, etc...
-    # @param asset_id [Symbol, String] The ID of the Asset to retrieve historical balances for.
-    #   This can be an asset alias (e.g. `:usdc`) or a contract address
-    #   (e.g. `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`).
-    # @return [Enumerable<Coinbase::HistoricalBalance>] Enumerator that returns historical_balance
-
     def_delegators :default_address, :transfer, :trade, :faucet, :stake, :unstake, :claim_stake, :staking_balances,
-                   :stakeable_balance, :unstakeable_balance, :claimable_balance, :historical_balances
+                   :stakeable_balance, :unstakeable_balance, :claimable_balance
 
     # Returns the addresses belonging to the Wallet.
     # @return [Array<Coinbase::WalletAddress>] The addresses belonging to the Wallet

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -892,6 +892,7 @@ describe Coinbase::Wallet do
         end
       end
     end
+  end
 
   describe '#transfer' do
     subject(:wallet) do

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -893,23 +893,6 @@ describe Coinbase::Wallet do
       end
     end
 
-    describe '#historical_balances' do
-      subject(:historical_balances) { wallet.historical_balances(:eth) }
-
-      before do
-        allow(wallet.default_address).to receive(:historical_balances)
-      end
-
-      it 'calls historical_balances' do
-        historical_balances
-
-        expect(wallet.default_address)
-          .to have_received(:historical_balances)
-          .with(:eth)
-      end
-    end
-  end
-
   describe '#transfer' do
     subject(:wallet) do
       described_class.new(model_with_default_address, seed: '')


### PR DESCRIPTION
- add webhook api to ruby sdk
- [HistoricalBalances] add wallet level function (#148)
- Expose to_address_id method on Transaction class
- network id symbol
- test cases
- [chore] Fix MPC wallet address initailization (#154)
- fix conversion price
- Refactor Wallet class to use delegators (#136)
- Pass address index when registering address (#150)
- Remove the user concept (#153)
- Add dynamic network constants (#138)
- Inject correlation context headers (#158)
- contract event ruby
- update
- Bump client and update changelog for v0.1.0 release (#161)
- revert wallet level historical balances

### What changed? Why?


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->