### PR TITLE
[bugfix] use the right staking api client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2024-08-22
+
+### Fixed
+
+- Incorrect stake client api being used for staking_operation.complete when calling `broadcast_staking_operation`
+
 ## [0.1.0] - 2024-08-22
 
 - Expose all networks as constants, e.g. `Coinbase::Network::ETHEREUM_MAINNET`

--- a/lib/coinbase/staking_operation.rb
+++ b/lib/coinbase/staking_operation.rb
@@ -194,7 +194,7 @@ module Coinbase
 
           transaction.sign(key)
           @model = Coinbase.call_api do
-            stake_api.broadcast_staking_operation(
+            wallet_stake_api.broadcast_staking_operation(
               wallet_id,
               address_id,
               id,
@@ -211,8 +211,6 @@ module Coinbase
 
         sleep interval_seconds
       end
-
-      self
     end
 
     # Fetch the StakingOperation with the provided network, address and staking operation ID.

--- a/lib/coinbase/version.rb
+++ b/lib/coinbase/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coinbase
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
### What changed? Why?

Looks like in the last rebase, I ended up incorrectly choosing the wrong stake api client while calling `broadcast_staking_operation`.

### Testing

1. Added unit tests for the newly added function which I missed the last time.
2. Tested SDK locally

```
[27] pry(main)> wallet = Coinbase::Wallet.create(network: :ethereum_holesky)
=> Coinbase::Wallet{id: 'f253b29f-3f6b-426f-93c2-80300f533301', network_id: 'ethereum_holesky', default_address: '0x9a423EA007a38AaF90D84c4eb0D4dc258B49f211'}
[28] pry(main)> wallet.faucet
=> Coinbase::FaucetTransaction{transaction_hash: '0xad1e4859c7da1442062580823ecb1956ab835a4dc91a9ed8aef465bada3f6412', transaction_link: 'https://holesky.etherscan.io/tx/0xad1e4859c7da1442062580823ecb1956ab835a4dc91a9ed8aef465bada3f6412'}
[32] pry(main)> wallet.balances
=> {:eth=>0.1e-1}
[33] pry(main)> staking_operation = wallet.stake(0.00001, :eth)
=> #<Coinbase::StakingOperation:0x000000014b1cb488
 @model=
  #<Coinbase::Client::StakingOperation:0x0000000107034960
   @address_id="0x9a423EA007a38AaF90D84c4eb0D4dc258B49f211",
   @id="f488c865-2152-4bef-95bb-84ef3e93128c",
   @network_id="ethereum-holesky",
   @status="complete",
   @transactions=
    [#<Coinbase::Client::Transaction:0x0000000107034e88
      @from_address_id="0x9a423EA007a38AaF90D84c4eb0D4dc258B49f211",
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->