### PR TITLE
USDC faucet for base sepolia

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,7 +39,7 @@ RSpec/ExampleLength:
   Max: 10
 
 RSpec/MultipleMemoizedHelpers:
-  Max: 25
+  Max: 35
 
 RSpec/NestedGroups:
   Max: 4

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -74,13 +74,16 @@ module Coinbase
 
     # Requests funds for the address from the faucet and returns the faucet transaction.
     # This is only supported on testnet networks.
+    # @param asset_id [Symbol] The ID of the Asset to transfer to the wallet.
     # @return [Coinbase::FaucetTransaction] The successful faucet transaction
     # @raise [Coinbase::FaucetLimitReachedError] If the faucet limit has been reached for the address or user.
     # @raise [Coinbase::Client::ApiError] If an unexpected error occurs while requesting faucet funds.
-    def faucet
+    def faucet(asset_id: '')
+      opts = asset_id.empty? ? {} : { asset_id: asset_id }
+
       Coinbase.call_api do
         Coinbase::FaucetTransaction.new(
-          addresses_api.request_external_faucet_funds(network.normalized_id, id)
+          addresses_api.request_external_faucet_funds(network.normalized_id, id, opts)
         )
       end
     end

--- a/lib/coinbase/address.rb
+++ b/lib/coinbase/address.rb
@@ -78,8 +78,8 @@ module Coinbase
     # @return [Coinbase::FaucetTransaction] The successful faucet transaction
     # @raise [Coinbase::FaucetLimitReachedError] If the faucet limit has been reached for the address or user.
     # @raise [Coinbase::Client::ApiError] If an unexpected error occurs while requesting faucet funds.
-    def faucet(asset_id: '')
-      opts = asset_id.empty? ? {} : { asset_id: asset_id }
+    def faucet(asset_id: nil)
+      opts = { asset_id: asset_id }.compact
 
       Coinbase.call_api do
         Coinbase::FaucetTransaction.new(

--- a/lib/coinbase/client/api/addresses_api.rb
+++ b/lib/coinbase/client/api/addresses_api.rb
@@ -53,7 +53,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
       # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
@@ -127,7 +127,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -202,7 +202,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -278,7 +278,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -351,7 +351,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -387,6 +387,7 @@ module Coinbase::Client
     # @param wallet_id [String] The ID of the wallet the address belongs to.
     # @param address_id [String] The onchain address of the address that is being fetched.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :asset_id The ID of the asset to transfer from the faucet.
     # @return [FaucetTransaction]
     def request_faucet_funds(wallet_id, address_id, opts = {})
       data, _status_code, _headers = request_faucet_funds_with_http_info(wallet_id, address_id, opts)
@@ -398,6 +399,7 @@ module Coinbase::Client
     # @param wallet_id [String] The ID of the wallet the address belongs to.
     # @param address_id [String] The onchain address of the address that is being fetched.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :asset_id The ID of the asset to transfer from the faucet.
     # @return [Array<(FaucetTransaction, Integer, Hash)>] FaucetTransaction data, response status code and response headers
     def request_faucet_funds_with_http_info(wallet_id, address_id, opts = {})
       if @api_client.config.debugging
@@ -416,11 +418,12 @@ module Coinbase::Client
 
       # query parameters
       query_params = opts[:query_params] || {}
+      query_params[:'asset_id'] = opts[:'asset_id'] if !opts[:'asset_id'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/lib/coinbase/client/api/addresses_api.rb
+++ b/lib/coinbase/client/api/addresses_api.rb
@@ -53,8 +53,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
-      # HTTP header 'Content-Type'
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])      # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
           header_params['Content-Type'] = content_type
@@ -202,7 +201,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -278,7 +277,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -351,7 +350,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -423,7 +422,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/lib/coinbase/client/api/addresses_api.rb
+++ b/lib/coinbase/client/api/addresses_api.rb
@@ -53,7 +53,8 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])      # HTTP header 'Content-Type'
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      # HTTP header 'Content-Type'
       content_type = @api_client.select_header_content_type(['application/json'])
       if !content_type.nil?
           header_params['Content-Type'] = content_type
@@ -126,7 +127,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
 
       # form parameters
       form_params = opts[:form_params] || {}

--- a/lib/coinbase/client/api/external_addresses_api.rb
+++ b/lib/coinbase/client/api/external_addresses_api.rb
@@ -224,7 +224,7 @@ module Coinbase::Client
       # header parameters
       header_params = opts[:header_params] || {}
       # HTTP header 'Accept' (if needed)
-      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      header_params['Accept'] = @api_client.select_header_accept(['application/json']) unless header_params['Accept']
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -260,6 +260,7 @@ module Coinbase::Client
     # @param network_id [String] The ID of the wallet the address belongs to.
     # @param address_id [String] The onchain address of the address that is being fetched.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :asset_id The ID of the asset to transfer from the faucet.
     # @return [FaucetTransaction]
     def request_external_faucet_funds(network_id, address_id, opts = {})
       data, _status_code, _headers = request_external_faucet_funds_with_http_info(network_id, address_id, opts)
@@ -271,6 +272,7 @@ module Coinbase::Client
     # @param network_id [String] The ID of the wallet the address belongs to.
     # @param address_id [String] The onchain address of the address that is being fetched.
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :asset_id The ID of the asset to transfer from the faucet.
     # @return [Array<(FaucetTransaction, Integer, Hash)>] FaucetTransaction data, response status code and response headers
     def request_external_faucet_funds_with_http_info(network_id, address_id, opts = {})
       if @api_client.config.debugging
@@ -289,6 +291,7 @@ module Coinbase::Client
 
       # query parameters
       query_params = opts[:query_params] || {}
+      query_params[:'asset_id'] = opts[:'asset_id'] if !opts[:'asset_id'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -363,9 +363,9 @@ module Coinbase
       Data.new(wallet_id: id, seed: @master.seed_hex)
     end
 
-    def faucet
+    def faucet(asset: '')
       Coinbase.call_api do
-        Coinbase::FaucetTransaction.new(addresses_api.request_faucet_funds(id, default_address.id))
+        Coinbase::FaucetTransaction.new(addresses_api.request_faucet_funds(id, default_address.id, {asset_id: asset}))
       end
     end
 

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -364,10 +364,6 @@ module Coinbase
       Data.new(wallet_id: id, seed: @master.seed_hex)
     end
 
-    def faucet(asset_id: nil)
-      default_address.faucet(asset_id: asset_id)
-    end
-
     # Returns whether the Wallet has a seed with which to derive keys and sign transactions.
     # @return [Boolean] Whether the Wallet has a seed with which to derive keys and sign transactions.
     def can_sign?

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -365,11 +365,7 @@ module Coinbase
     end
 
     def faucet(asset_id: '')
-      opts = asset_id.empty? ? {} : { asset_id: asset_id }
-
-      Coinbase.call_api do
-        Coinbase::FaucetTransaction.new(addresses_api.request_faucet_funds(id, default_address.id, opts))
-      end
+      default_address.faucet(asset_id: asset_id)
     end
 
     # Returns whether the Wallet has a seed with which to derive keys and sign transactions.

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -364,7 +364,7 @@ module Coinbase
       Data.new(wallet_id: id, seed: @master.seed_hex)
     end
 
-    def faucet(asset_id: '')
+    def faucet(asset_id: nil)
       default_address.faucet(asset_id: asset_id)
     end
 

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -365,7 +365,7 @@ module Coinbase
     end
 
     def faucet(asset_id: '')
-      opts = asset_id.empty? ? {} : {asset_id: asset_id}
+      opts = asset_id.empty? ? {} : { asset_id: asset_id }
 
       Coinbase.call_api do
         Coinbase::FaucetTransaction.new(addresses_api.request_faucet_funds(id, default_address.id, opts))

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -162,6 +162,7 @@ module Coinbase
     # @return [Coinbase::Trade] The Trade object.
 
     # @!method faucet
+    # @param asset_id [Symbol] The ID of the Asset to transfer to the wallet.
     # Requests funds from the faucet for the Wallet's default address and returns the faucet transaction.
     # This is only supported on testnet networks.
     # @return [Coinbase::FaucetTransaction] The successful faucet transaction
@@ -363,9 +364,11 @@ module Coinbase
       Data.new(wallet_id: id, seed: @master.seed_hex)
     end
 
-    def faucet(asset: '')
+    def faucet(asset_id: '')
+      opts = asset_id.empty? ? {} : {asset_id: asset_id}
+
       Coinbase.call_api do
-        Coinbase::FaucetTransaction.new(addresses_api.request_faucet_funds(id, default_address.id, {asset_id: asset}))
+        Coinbase::FaucetTransaction.new(addresses_api.request_faucet_funds(id, default_address.id, opts))
       end
     end
 

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -92,20 +92,22 @@ def fetch_addresses_balances_test(wallet)
 end
 
 def transfer_test(imported_address, new_address)
-  # Transfer gwei from imported address to new address.
-  puts 'Transferring 1 Gwei from imported address to new address...'
-  t = imported_address.transfer(1, :gwei, new_address).wait!
+  # Transfer eth from imported address to new address.
+  puts 'Transferring 0.00008 Eth from imported address to new address...'
+  t = imported_address.transfer(0.00008, :eth, new_address).wait!
   expect(t.status).to eq('complete')
-  puts "Transferred 1 Gwei from #{imported_address} to #{new_address}"
+  puts "Transferred 0.00008 eth from #{imported_address} to #{new_address}"
 
   # Fund the new address with faucet.
   faucet_tx = new_address.faucet
   puts "Requested faucet funds: #{faucet_tx}"
 
+  send_amount = new_address.balance(:eth) - 1e-5 # Leave some eth for gas.
+
   # Transfer eth back from new address to imported address.
-  t = new_address.transfer(0.008, :eth, imported_address).wait!
+  t = new_address.transfer(send_amount, :eth, imported_address).wait!
   expect(t.status).to eq('complete')
-  puts "Transferred 0.008 eth from #{new_address} to #{imported_address}"
+  puts "Transferred #{send_amount} eth from #{new_address} to #{imported_address}"
 
   puts 'Fetching updated balances...'
   first_balance = imported_address.balances

--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -99,8 +99,12 @@ def transfer_test(imported_address, new_address)
   puts "Transferred 0.00008 eth from #{imported_address} to #{new_address}"
 
   # Fund the new address with faucet.
-  faucet_tx = new_address.faucet
-  puts "Requested faucet funds: #{faucet_tx}"
+  begin
+    faucet_tx = new_address.faucet
+    puts "Requested faucet funds: #{faucet_tx}"
+  rescue Coinbase::InternalError
+    puts 'Faucet has reached limit. Will continue with test'
+  end
 
   send_amount = new_address.balance(:eth) - 1e-5 # Leave some eth for gas.
 

--- a/spec/support/shared_examples/address_balances.rb
+++ b/spec/support/shared_examples/address_balances.rb
@@ -150,7 +150,7 @@ shared_examples 'an address that supports requesting faucet funds' do |_operatio
       before do
         allow(external_addresses_api)
           .to receive(:request_external_faucet_funds)
-          .with(normalized_network_id, address_id)
+          .with(normalized_network_id, address_id, {})
           .and_return(faucet_tx)
       end
 
@@ -159,7 +159,7 @@ shared_examples 'an address that supports requesting faucet funds' do |_operatio
 
         expect(external_addresses_api)
           .to have_received(:request_external_faucet_funds)
-          .with(normalized_network_id, address_id)
+          .with(normalized_network_id, address_id, {})
       end
 
       it 'returns the faucet transaction' do
@@ -175,7 +175,7 @@ shared_examples 'an address that supports requesting faucet funds' do |_operatio
       before do
         allow(external_addresses_api)
           .to receive(:request_external_faucet_funds)
-          .with(normalized_network_id, address_id)
+          .with(normalized_network_id, address_id, {})
           .and_raise(api_error)
       end
 

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -1037,20 +1037,19 @@ describe Coinbase::Wallet do
       end
     end
 
-
     context 'when using specific asset' do
       subject(:faucet_transaction) { wallet.faucet(asset_id: :usdc) }
 
       before do
         allow(addresses_api)
           .to receive(:list_addresses)
-                .with(wallet_id, { limit: 20 })
-                .and_return(Coinbase::Client::AddressList.new(data: [first_address_model], total_count: 1))
+          .with(wallet_id, { limit: 20 })
+          .and_return(Coinbase::Client::AddressList.new(data: [first_address_model], total_count: 1))
 
         allow(addresses_api)
           .to receive(:request_faucet_funds)
-                .with(wallet_id, first_address_model.address_id, {asset_id: :usdc})
-                .and_return(faucet_transaction_model)
+          .with(wallet_id, first_address_model.address_id, { asset_id: :usdc })
+          .and_return(faucet_transaction_model)
       end
 
       it 'returns the faucet transaction' do
@@ -1061,7 +1060,6 @@ describe Coinbase::Wallet do
         expect(faucet_transaction.transaction_hash).to eq(faucet_transaction_model.transaction_hash)
       end
     end
-
   end
 
   describe '#can_sign?' do

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -23,6 +23,7 @@ describe Coinbase::Wallet do
   end
   let(:wallets_api) { instance_double(Coinbase::Client::WalletsApi) }
   let(:addresses_api) { instance_double(Coinbase::Client::AddressesApi) }
+  let(:external_addresses_api) { instance_double(Coinbase::Client::ExternalAddressesApi) }
   let(:transfers_api) { instance_double(Coinbase::Client::TransfersApi) }
   let(:use_server_signer) { false }
   let(:default_network) { build(:network, :base_sepolia) }
@@ -39,6 +40,7 @@ describe Coinbase::Wallet do
   before do
     allow(Coinbase::Client::AddressesApi).to receive(:new).and_return(addresses_api)
     allow(Coinbase::Client::WalletsApi).to receive(:new).and_return(wallets_api)
+    allow(Coinbase::Client::ExternalAddressesApi).to receive(:new).and_return(external_addresses_api)
 
     allow(Coinbase).to receive(:configuration).and_return(configuration)
 
@@ -1022,9 +1024,9 @@ describe Coinbase::Wallet do
           .with(wallet_id, { limit: 20 })
           .and_return(Coinbase::Client::AddressList.new(data: [first_address_model], total_count: 1))
 
-        allow(addresses_api)
-          .to receive(:request_faucet_funds)
-          .with(wallet_id, first_address_model.address_id, {})
+        allow(external_addresses_api)
+          .to receive(:request_external_faucet_funds)
+          .with(normalized_network_id, first_address_model.address_id, {})
           .and_return(faucet_transaction_model)
       end
 
@@ -1046,9 +1048,9 @@ describe Coinbase::Wallet do
           .with(wallet_id, { limit: 20 })
           .and_return(Coinbase::Client::AddressList.new(data: [first_address_model], total_count: 1))
 
-        allow(addresses_api)
-          .to receive(:request_faucet_funds)
-          .with(wallet_id, first_address_model.address_id, { asset_id: :usdc })
+        allow(external_addresses_api)
+          .to receive(:request_external_faucet_funds)
+          .with(normalized_network_id, first_address_model.address_id, { asset_id: :usdc })
           .and_return(faucet_transaction_model)
       end
 

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -1024,7 +1024,7 @@ describe Coinbase::Wallet do
 
         allow(addresses_api)
           .to receive(:request_faucet_funds)
-          .with(wallet_id, first_address_model.address_id, {asset_id: ''})
+          .with(wallet_id, first_address_model.address_id, {})
           .and_return(faucet_transaction_model)
       end
 
@@ -1039,7 +1039,7 @@ describe Coinbase::Wallet do
 
 
     context 'when using specific asset' do
-      subject(:faucet_transaction) { wallet.faucet(asset: :usdc) }
+      subject(:faucet_transaction) { wallet.faucet(asset_id: :usdc) }
 
       before do
         allow(addresses_api)


### PR DESCRIPTION
### What changed? Why?

```
[2] pry(main)> wallet = Coinbase::Wallet.create
=> Coinbase::Wallet{id: '11f3f496-c4df-47ab-a2cd-56091828bb35', network_id: 'base_sepolia', default_address: '0x57bbdBBE6d240793BE9325E691EA1b7fED3311B5'}
[3] pry(main)> wallet.faucet
=> Coinbase::FaucetTransaction{transaction_hash: '0xdf98a7f4ae7aedfb2d68b502fddd8949edbb98a4f3860e850c34b161611f145c', transaction_link: 'https://sepolia.basescan.org/tx/0xdf98a7f4ae7aedfb2d68b502fddd8949edbb98a4f3860e850c34b161611f145c'}
[4] pry(main)> wallet.faucet(asset_id: :usdc)
=> Coinbase::FaucetTransaction{transaction_hash: '0x0e7b10e7aee5f00c3bbf2c230a397a901cbcf5b1e78d696505bac9694b556cd7', transaction_link: 'https://sepolia.basescan.org/tx/0x0e7b10e7aee5f00c3bbf2c230a397a901cbcf5b1e78d696505bac9694b556cd7'}
[5] pry(main)> wallet.faucet(asset_id: :eth)
=> Coinbase::FaucetTransaction{transaction_hash: '0x015390de3932976065faaf9207423f676fd51c5e09fe32b9c2e5cee8f9ad72a9', transaction_link: 'https://sepolia.basescan.org/tx/0x015390de3932976065faaf9207423f676fd51c5e09fe32b9c2e5cee8f9ad72a9'}

```
#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->