### PR TITLE
Psdk 483 payable contract invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+
 - Add support for Arbitrum-Mainnet
+- Add optional arguments to allow setting amount for payable contract method invocations
 
 ## [0.3.0] - 2024-09-05
 

--- a/lib/coinbase/address/wallet_address.rb
+++ b/lib/coinbase/address/wallet_address.rb
@@ -101,9 +101,14 @@ module Coinbase
     # @param method [String] The method to invoke on the contract.
     # @param args [Hash] The arguments to pass to the contract method.
     #   The keys should be the argument names, and the values should be the argument values.
+    # @param amount [Integer, Float, BigDecimal] (Optional) The amount of the native Asset
+    #   to send to a payable contract method.
+    # @param asset_id [Symbol] (Optional) The ID of the Asset to send to a payable contract method.
+    #   The Asset must be a denomination of the native Asset. For Ethereum, :eth, :gwei, and :wei are supported.
     # @return [Coinbase::ContractInvocation] The contract invocation object.
-    def invoke_contract(contract_address:, abi:, method:, args:)
+    def invoke_contract(contract_address:, abi:, method:, args:, amount: nil, asset_id: nil)
       ensure_can_sign!
+      ensure_sufficient_balance!(amount, asset_id) if amount && asset_id
 
       invocation = ContractInvocation.create(
         address_id: id,
@@ -111,7 +116,10 @@ module Coinbase
         contract_address: contract_address,
         abi: abi,
         method: method,
-        args: args
+        args: args,
+        amount: amount,
+        asset_id: asset_id,
+        network: network
       )
 
       # If a server signer is managing keys, it will sign and broadcast the underlying transaction out of band.

--- a/spec/factories/contract_invocation.rb
+++ b/spec/factories/contract_invocation.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     transient do
       key { build(:key) }
       status { 'pending' }
+      amount { '0' }
     end
 
     address_id { key.address.to_s }
@@ -54,6 +55,7 @@ FactoryBot.define do
       network { nil }
       status { nil }
       key { build(:key) }
+      amount { '0' }
     end
 
     model { build(:contract_invocation_model, key: key) }

--- a/spec/unit/coinbase/contract_invocation_spec.rb
+++ b/spec/unit/coinbase/contract_invocation_spec.rb
@@ -37,6 +37,7 @@ describe Coinbase::ContractInvocation do
       contract_address: contract_address,
       abi: abi.to_json,
       method: method,
+      amount: '0',
       args: args.to_json,
       transaction: transaction_model
     )
@@ -61,6 +62,9 @@ describe Coinbase::ContractInvocation do
         contract_address: contract_address,
         abi: abi,
         method: method,
+        amount: nil,
+        asset_id: nil,
+        network: network,
         args: args
       )
     end
@@ -70,7 +74,8 @@ describe Coinbase::ContractInvocation do
         contract_address: contract_address,
         abi: abi.to_json,
         method: method,
-        args: args.to_json
+        args: args.to_json,
+        amount: nil
       }
     end
 
@@ -176,6 +181,12 @@ describe Coinbase::ContractInvocation do
 
     it 'sets the from_address_id' do
       expect(contract_invocation.transaction.from_address_id).to eq(address_id)
+    end
+  end
+
+  describe '#amount' do
+    it 'returns the Amount' do
+      expect(contract_invocation.amount).to eq(BigDecimal(0))
     end
   end
 


### PR DESCRIPTION
### What changed? Why?
- Support optionally setting `amount` for payable smart contract method invocations
- Bump openapi generated files to use latest generator version `7.8.0`

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->