### PR TITLE
Allow invoking contracts using a smart contract object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `deploy_token` support for deploying ERC20 tokens from MPC / dev-managed wallets.
+- Allow for calling `invoke_contract` with a SmartContract object.
 
 ## [0.5.0] - 2024-09-11
 

--- a/lib/coinbase/contract_invocation.rb
+++ b/lib/coinbase/contract_invocation.rb
@@ -40,6 +40,11 @@ module Coinbase
           atomic_amount = asset.to_atomic_amount(amount).to_i_to_s
         end
 
+        # If the contract address is a SmartContract object, get the contract address from it.
+        if contract_address.is_a?(Coinbase::SmartContract)
+          contract_address = contract_address.contract_address
+        end
+
         model = Coinbase.call_api do
           contract_invocation_api.create_contract_invocation(
             wallet_id,

--- a/spec/factories/smart_contract.rb
+++ b/spec/factories/smart_contract.rb
@@ -78,9 +78,12 @@ FactoryBot.define do
       status { nil }
       key { build(:key) }
       type { :token }
+      contract_address { '0x5FbDB2315678afecb367f032d93F642f64180aa3' }
     end
 
-    model { build(:smart_contract_model, type, key: key) }
+    model do
+      build(:smart_contract_model, type, key: key, contract_address: contract_address)
+    end
 
     trait :token do
       type { :token }
@@ -107,7 +110,10 @@ FactoryBot.define do
         build(
           :smart_contract_model,
           transients,
-          **{ key: transients.key }.compact
+          **{
+            key: transients.key,
+            contract_address: contract_address
+          }.compact
         )
       end
     end

--- a/spec/unit/coinbase/contract_invocation_spec.rb
+++ b/spec/unit/coinbase/contract_invocation_spec.rb
@@ -24,7 +24,8 @@ describe Coinbase::ContractInvocation do
     ]
   end
   let(:method) { 'mint' }
-  let(:contract_address) { '0xa82aB8504fDeb2dADAa3B4F075E967BbE35065b9' }
+  let(:expected_contract_address) { '0xa82aB8504fDeb2dADAa3B4F075E967BbE35065b9' }
+  let(:contract_address) { expected_contract_address }
   let(:args) do
     { recipient: '0x475d41de7A81298Ba263184996800CBcaAD73C0b' }
   end
@@ -34,7 +35,7 @@ describe Coinbase::ContractInvocation do
       wallet_id: wallet_id,
       address_id: address_id,
       contract_invocation_id: contract_invocation_id,
-      contract_address: contract_address,
+      contract_address: expected_contract_address,
       abi: abi.to_json,
       method: method,
       amount: '0',
@@ -71,7 +72,7 @@ describe Coinbase::ContractInvocation do
 
     let(:create_contract_invocation_request) do
       {
-        contract_address: contract_address,
+        contract_address: expected_contract_address,
         abi: abi.to_json,
         method: method,
         args: args.to_json,
@@ -84,6 +85,8 @@ describe Coinbase::ContractInvocation do
         .to receive(:create_contract_invocation)
         .with(wallet_id, address_id, create_contract_invocation_request)
         .and_return(model)
+
+      contract_invocation
     end
 
     it 'creates a new ContractInvocation' do
@@ -92,6 +95,38 @@ describe Coinbase::ContractInvocation do
 
     it 'sets the contract_invocation properties' do
       expect(contract_invocation.id).to eq(contract_invocation_id)
+    end
+
+    it 'creates the contract invocation' do
+      expect(contract_invocations_api)
+        .to have_received(:create_contract_invocation)
+        .with(wallet_id, address_id, create_contract_invocation_request)
+    end
+
+    context 'when the contract address is a SmartContract' do
+      let(:contract_address) do
+        build(:smart_contract, network_id, :token, contract_address: expected_contract_address)
+      end
+
+      let(:create_contract_invocation_request) do
+        {
+          contract_address: expected_contract_address,
+          abi: abi.to_json,
+          method: method,
+          args: args.to_json,
+          amount: nil
+        }
+      end
+
+      it 'sets the contract address' do
+        expect(contract_invocation.contract_address).to eq(expected_contract_address)
+      end
+
+      it 'creates the contract invocation with the SmartContract contract address' do
+        expect(contract_invocations_api)
+          .to have_received(:create_contract_invocation)
+          .with(wallet_id, address_id, create_contract_invocation_request)
+      end
     end
   end
 


### PR DESCRIPTION
This adds support for calling `invoke_contract` with a smart contract object, instead of just a contract address.

For example:
```
smart_contract = address.deploy_token(name: "Test", symbol: "TST", total_supply: 1_000)

smart_contract.wait!

address.invoke_contract(
  method: "transferFrom",
  contract_address: smart_contract,
  args: {
    amount: "10",
    sender: address.id,
    recipient: "0x<recipient"
  }
)
```

### What changed? Why?


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->