### PR TITLE
Support contract invocations without ABI or amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `deploy_token` support for deploying ERC20 tokens from MPC / dev-managed wallets.
+- Allow for calling `invoke_contract` without an ABI for known contract types (ERC20, ERC721, and
+  ERC1155).
+- Fix handling when invoking a contract that is not-payable.
 
 ## [0.5.0] - 2024-09-11
 

--- a/lib/coinbase/address/wallet_address.rb
+++ b/lib/coinbase/address/wallet_address.rb
@@ -106,7 +106,7 @@ module Coinbase
     # @param asset_id [Symbol] (Optional) The ID of the Asset to send to a payable contract method.
     #   The Asset must be a denomination of the native Asset. For Ethereum, :eth, :gwei, and :wei are supported.
     # @return [Coinbase::ContractInvocation] The contract invocation object.
-    def invoke_contract(contract_address:, abi:, method:, args:, amount: nil, asset_id: nil)
+    def invoke_contract(contract_address:, method:, args:, abi: nil, amount: nil, asset_id: nil)
       ensure_can_sign!
       ensure_sufficient_balance!(amount, asset_id) if amount && asset_id
 

--- a/spec/factories/smart_contract.rb
+++ b/spec/factories/smart_contract.rb
@@ -78,9 +78,12 @@ FactoryBot.define do
       status { nil }
       key { build(:key) }
       type { :token }
+      contract_address { '0x5FbDB2315678afecb367f032d93F642f64180aa3' }
     end
 
-    model { build(:smart_contract_model, type, key: key) }
+    model do
+      build(:smart_contract_model, type, key: key, contract_address: contract_address)
+    end
 
     trait :token do
       type { :token }
@@ -107,7 +110,10 @@ FactoryBot.define do
         build(
           :smart_contract_model,
           transients,
-          **{ key: transients.key }.compact
+          **{
+            key: transients.key,
+            contract_address: contract_address
+          }.compact
         )
       end
     end

--- a/spec/unit/coinbase/address/wallet_address_spec.rb
+++ b/spec/unit/coinbase/address/wallet_address_spec.rb
@@ -173,6 +173,30 @@ describe Coinbase::WalletAddress do
           expect(created_invocation).not_to have_received(:broadcast!)
         end
       end
+
+      context 'when ABI is not specified' do
+        subject(:contract_invocation) do
+          address.invoke_contract(
+            contract_address: contract_invocation_model.contract_address,
+            method: contract_invocation_model.method,
+            args: args
+          )
+        end
+
+        it 'creates a contract invocation without an ABI' do # rubocop:disable RSpec/ExampleLength
+          expect(Coinbase::ContractInvocation).to have_received(:create).with(
+            address_id: address_id,
+            wallet_id: wallet_id,
+            contract_address: contract_invocation_model.contract_address,
+            method: contract_invocation_model.method,
+            abi: nil,
+            amount: nil,
+            asset_id: nil,
+            network: network,
+            args: args
+          )
+        end
+      end
     end
 
     context 'when invoking a payable contract method' do


### PR DESCRIPTION
### What changed? Why?

This adds fixes for invoking contracts without an ABI, which is now supported for ERC20, ERC721, and ERC1155 standard contracts.

This also fixes handling for contract invocations that omitted a payable amount, as we were receiving a backend error when passing through the `null` value, v.s. omitting the key.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->