### PR TITLE
chore: Merge latest master into v0.6.0

### DIFF
--- a/spec/e2e/end_to_end.rb
+++ b/spec/e2e/end_to_end.rb
@@ -31,23 +31,6 @@ describe Coinbase do
       list_address_transactions_test(imported_address)
     end
   end
-
-  # Use Server-Signer only half the runs to save test time.
-  describe 'use for serve signer', skip: rand >= 0.5 do
-    it 'behaves as expected' do # rubocop:disable RSpec/NoExpectationExample
-      described_class.configuration.use_server_signer = true
-      signer = Coinbase::ServerSigner.default
-      puts "Using ServerSigner with ID: #{signer.id}"
-
-      new_address = create_new_address_test
-      existing_wallet = fetch_existing_wallet
-      fetch_addresses_balances_test(existing_wallet)
-      existing_address = existing_wallet.addresses[0]
-      transfer_test(existing_address, new_address)
-      fetch_address_historical_balances_test(existing_address)
-      list_address_transactions_test(existing_address)
-    end
-  end
 end
 
 def create_new_address_test


### PR DESCRIPTION
### What changed? Why?
This merges the latest master into v0.6.0 to disable the E2E test, that was disabled in: https://github.com/coinbase/coinbase-sdk-ruby/pull/192


#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->