### PR TITLE
Added support for deploy_nft to deploy an ERC721 contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Gemfile.lock
 .yardoc
 lib/**/.DS_Store
 .idea
+.vscode/
 .DS_Store
 seeds.json
 coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add `deploy_nft` support for deploying ERC721 contracts from MPC / dev-managed wallets.
+
 ## [0.6.0] - 2024-09-18
 
 ### Added

--- a/lib/coinbase/address/wallet_address.rb
+++ b/lib/coinbase/address/wallet_address.rb
@@ -155,6 +155,30 @@ module Coinbase
       smart_contract
     end
 
+    # Deploys a new ERC721 NFT contract with the given name, symbol, and base URI.
+    # @param name [String] The name of the NFT contract.
+    # @param symbol [String] The symbol of the NFT contract.
+    # @param base_uri [String] The base URI for the NFT contract.
+    # @return [Coinbase::SmartContract] The deployed NFT contract.
+    # @raise [AddressCannotSignError] if the Address does not have a private key backing it.
+    def deploy_nft(name:, symbol:, base_uri:)
+      ensure_can_sign!
+
+      smart_contract = SmartContract.create_nft_contract(
+        address_id: id,
+        wallet_id: wallet_id,
+        name: name,
+        symbol: symbol,
+        base_uri: base_uri
+      )
+
+      return smart_contract if Coinbase.use_server_signer?
+
+      smart_contract.sign(@key)
+      smart_contract.deploy!
+      smart_contract
+    end
+
     # Signs the given unsigned payload.
     # @param unsigned_payload [String] The hex-encoded hashed unsigned payload for the Address to sign.
     # @return [Coinbase::PayloadSignature] The payload signature

--- a/lib/coinbase/client/models/nft_contract_options.rb
+++ b/lib/coinbase/client/models/nft_contract_options.rb
@@ -22,11 +22,15 @@ module Coinbase::Client
     # The symbol of the NFT
     attr_accessor :symbol
 
+    # The base URI for the NFT metadata
+    attr_accessor :base_uri
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
         :'name' => :'name',
-        :'symbol' => :'symbol'
+        :'symbol' => :'symbol',
+        :'base_uri' => :'base_uri'
       }
     end
 
@@ -39,7 +43,8 @@ module Coinbase::Client
     def self.openapi_types
       {
         :'name' => :'String',
-        :'symbol' => :'String'
+        :'symbol' => :'String',
+        :'base_uri' => :'String'
       }
     end
 
@@ -75,6 +80,12 @@ module Coinbase::Client
       else
         self.symbol = nil
       end
+
+      if attributes.key?(:'base_uri')
+        self.base_uri = attributes[:'base_uri']
+      else
+        self.base_uri = nil
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -90,6 +101,10 @@ module Coinbase::Client
         invalid_properties.push('invalid value for "symbol", symbol cannot be nil.')
       end
 
+      if @base_uri.nil?
+        invalid_properties.push('invalid value for "base_uri", base_uri cannot be nil.')
+      end
+
       invalid_properties
     end
 
@@ -99,6 +114,7 @@ module Coinbase::Client
       warn '[DEPRECATED] the `valid?` method is obsolete'
       return false if @name.nil?
       return false if @symbol.nil?
+      return false if @base_uri.nil?
       true
     end
 
@@ -108,7 +124,8 @@ module Coinbase::Client
       return true if self.equal?(o)
       self.class == o.class &&
           name == o.name &&
-          symbol == o.symbol
+          symbol == o.symbol &&
+          base_uri == o.base_uri
     end
 
     # @see the `==` method
@@ -120,7 +137,7 @@ module Coinbase::Client
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [name, symbol].hash
+      [name, symbol, base_uri].hash
     end
 
     # Builds the object from hash

--- a/lib/coinbase/client/models/smart_contract_type.rb
+++ b/lib/coinbase/client/models/smart_contract_type.rb
@@ -17,10 +17,11 @@ module Coinbase::Client
   class SmartContractType
     ERC20 = "erc20".freeze
     ERC721 = "erc721".freeze
+    ERC1155 = "erc1155".freeze
     UNKNOWN_DEFAULT_OPEN_API = "unknown_default_open_api".freeze
 
     def self.all_vars
-      @all_vars ||= [ERC20, ERC721, UNKNOWN_DEFAULT_OPEN_API].freeze
+      @all_vars ||= [ERC20, ERC721, ERC1155, UNKNOWN_DEFAULT_OPEN_API].freeze
     end
 
     # Builds the enum from string

--- a/lib/coinbase/smart_contract.rb
+++ b/lib/coinbase/smart_contract.rb
@@ -72,6 +72,14 @@ module Coinbase
       new(contract)
     end
 
+    # Creates a new ERC721 token contract, that can subsequently be deployed to
+    # the blockchain.
+    # @param address_id [String] The address ID of deployer
+    # @param wallet_id [String] The wallet ID of the deployer
+    # @param name [String] The name of the token
+    # @param symbol [String] The symbol of the token
+    # @param base_uri [String] The base URI for the token metadata
+    # @return [SmartContract] The new ERC721 Token SmartContract object
     def self.create_nft_contract(
       address_id:,
       wallet_id:,

--- a/lib/coinbase/smart_contract.rb
+++ b/lib/coinbase/smart_contract.rb
@@ -72,6 +72,27 @@ module Coinbase
       new(contract)
     end
 
+    def self.create_nft_contract(
+      address_id:,
+      wallet_id:,
+      name:,
+      symbol:,
+      base_uri:
+    )
+      contract = Coinbase.call_api do
+        smart_contracts_api.create_smart_contract(
+          wallet_id,
+          address_id,
+          {
+            type: Coinbase::Client::SmartContractType::ERC721,
+            options: Coinbase::Client::NftContractOptions.new(name: name, symbol: symbol, base_uri: base_uri).to_body
+          }
+        )
+      end
+
+      new(contract)
+    end
+
     def self.contract_events_api
       Coinbase::Client::ContractEventsApi.new(Coinbase.configuration.api_client)
     end

--- a/lib/coinbase/smart_contract.rb
+++ b/lib/coinbase/smart_contract.rb
@@ -85,7 +85,11 @@ module Coinbase
           address_id,
           {
             type: Coinbase::Client::SmartContractType::ERC721,
-            options: Coinbase::Client::NftContractOptions.new(name: name, symbol: symbol, base_uri: base_uri).to_body
+            options: Coinbase::Client::NFTContractOptions.new(
+              name: name,
+              symbol: symbol,
+              base_uri: base_uri
+            ).to_body
           }
         )
       end

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -244,9 +244,17 @@ module Coinbase
     # @return [Coinbase::SmartContract] The deployed token contract.
     # @raise [AddressCannotSignError] if the Address does not have a private key backing it.
 
+    # @!method deploy_nft
+    # Deploys a new ERC721 NFT contract with the given name, symbol, and base URI.
+    # @param name [String] The name of the NFT contract.
+    # @param symbol [String] The symbol of the NFT contract.
+    # @param base_uri [String] The base URI for the NFT contract.
+    # @return [Coinbase::SmartContract] The deployed NFT contract.
+    # @raise [AddressCannotSignError] if the Address does not have a private key backing it.
+
     def_delegators :default_address, :transfer, :trade, :faucet, :stake, :unstake, :claim_stake, :staking_balances,
                    :stakeable_balance, :unstakeable_balance, :claimable_balance, :sign_payload, :invoke_contract,
-                   :deploy_token
+                   :deploy_token, :deploy_nft
 
     # Returns the addresses belonging to the Wallet.
     # @return [Array<Coinbase::WalletAddress>] The addresses belonging to the Wallet

--- a/spec/factories/smart_contract.rb
+++ b/spec/factories/smart_contract.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
       name { 'Test Token' }
       symbol { 'TT' }
       total_supply { 1_000 }
+      base_uri { 'https://test.com' }
     end
 
     deployer_address { key.address.to_s }
@@ -48,7 +49,8 @@ FactoryBot.define do
       options do
         Coinbase::Client::NFTContractOptions.new(
           name: name,
-          symbol: symbol
+          symbol: symbol,
+          base_uri: base_uri
         )
       end
     end

--- a/spec/unit/coinbase/address/wallet_address_spec.rb
+++ b/spec/unit/coinbase/address/wallet_address_spec.rb
@@ -714,7 +714,7 @@ describe Coinbase::WalletAddress do
       end
     end
   end
-  
+
   describe '#deploy_nft' do
     subject(:deploy_nft) do
       address.deploy_nft(
@@ -797,5 +797,4 @@ describe Coinbase::WalletAddress do
       end
     end
   end
-
 end

--- a/spec/unit/coinbase/address/wallet_address_spec.rb
+++ b/spec/unit/coinbase/address/wallet_address_spec.rb
@@ -631,4 +631,171 @@ describe Coinbase::WalletAddress do
       expect(address.trades).to eq(trade_enumerator)
     end
   end
+
+  describe '#deploy_token' do
+    subject(:deploy_token) do
+      address.deploy_token(
+        name: token_name,
+        symbol: token_symbol,
+        total_supply: token_total_supply
+      )
+    end
+
+    let(:token_name) { 'My Token' }
+    let(:token_symbol) { 'MTK' }
+    let(:token_total_supply) { 1_000_000 }
+    let(:created_smart_contract) { build(:smart_contract, network_id, key: key) }
+    let(:use_server_signer) { false }
+
+    before do
+      allow(Coinbase).to receive(:use_server_signer?).and_return(use_server_signer)
+    end
+
+    context 'when the token contract deployment is successful' do
+      before do
+        allow(Coinbase::SmartContract).to receive(:create_token_contract).and_return(created_smart_contract)
+
+        allow(created_smart_contract).to receive(:sign)
+        allow(created_smart_contract).to receive(:deploy!)
+
+        deploy_token
+      end
+
+      it 'creates a token contract' do
+        expect(Coinbase::SmartContract).to have_received(:create_token_contract).with(
+          address_id: address_id,
+          wallet_id: wallet_id,
+          name: token_name,
+          symbol: token_symbol,
+          total_supply: token_total_supply
+        )
+      end
+
+      it 'returns the created smart contract' do
+        expect(deploy_token).to eq(created_smart_contract)
+      end
+
+      context 'when not using server signer' do
+        let(:use_server_signer) { false }
+
+        it 'signs the contract with the key' do
+          expect(created_smart_contract).to have_received(:sign).with(key)
+        end
+
+        it 'deploys the contract' do
+          expect(created_smart_contract).to have_received(:deploy!)
+        end
+      end
+
+      context 'when using server signer' do
+        let(:use_server_signer) { true }
+
+        it 'does not sign the contract with the key' do
+          expect(created_smart_contract).not_to have_received(:sign)
+        end
+
+        it 'does not deploy the contract' do
+          expect(created_smart_contract).not_to have_received(:deploy!)
+        end
+      end
+    end
+
+    context 'when the address cannot sign' do
+      let(:unhydrated_address) { described_class.new(model, nil) }
+
+      it 'raises an AddressCannotSignError' do
+        expect do
+          unhydrated_address.deploy_token(
+            name: token_name,
+            symbol: token_symbol,
+            total_supply: token_total_supply
+          )
+        end.to raise_error(Coinbase::AddressCannotSignError)
+      end
+    end
+  end
+  
+  describe '#deploy_nft' do
+    subject(:deploy_nft) do
+      address.deploy_nft(
+        name: nft_name,
+        symbol: nft_symbol,
+        base_uri: nft_base_uri
+      )
+    end
+
+    let(:nft_name) { 'My NFT Collection' }
+    let(:nft_symbol) { 'MNFT' }
+    let(:nft_base_uri) { 'https://example.com/nft/' }
+    let(:created_smart_contract) { build(:smart_contract, network_id, key: key) }
+    let(:use_server_signer) { false }
+
+    before do
+      allow(Coinbase).to receive(:use_server_signer?).and_return(use_server_signer)
+    end
+
+    context 'when the NFT contract deployment is successful' do
+      before do
+        allow(Coinbase::SmartContract).to receive(:create_nft_contract).and_return(created_smart_contract)
+
+        allow(created_smart_contract).to receive(:sign)
+        allow(created_smart_contract).to receive(:deploy!)
+
+        deploy_nft
+      end
+
+      it 'creates an NFT contract' do
+        expect(Coinbase::SmartContract).to have_received(:create_nft_contract).with(
+          address_id: address_id,
+          wallet_id: wallet_id,
+          name: nft_name,
+          symbol: nft_symbol,
+          base_uri: nft_base_uri
+        )
+      end
+
+      it 'returns the created smart contract' do
+        expect(deploy_nft).to eq(created_smart_contract)
+      end
+
+      context 'when not using server signer' do
+        let(:use_server_signer) { false }
+
+        it 'signs the contract with the key' do
+          expect(created_smart_contract).to have_received(:sign).with(key)
+        end
+
+        it 'deploys the contract' do
+          expect(created_smart_contract).to have_received(:deploy!)
+        end
+      end
+
+      context 'when using server signer' do
+        let(:use_server_signer) { true }
+
+        it 'does not sign the contract with the key' do
+          expect(created_smart_contract).not_to have_received(:sign)
+        end
+
+        it 'does not deploy the contract' do
+          expect(created_smart_contract).not_to have_received(:deploy!)
+        end
+      end
+    end
+
+    context 'when the address cannot sign' do
+      let(:unhydrated_address) { described_class.new(model, nil) }
+
+      it 'raises an AddressCannotSignError' do
+        expect do
+          unhydrated_address.deploy_nft(
+            name: nft_name,
+            symbol: nft_symbol,
+            base_uri: nft_base_uri
+          )
+        end.to raise_error(Coinbase::AddressCannotSignError)
+      end
+    end
+  end
+
 end

--- a/spec/unit/coinbase/smart_contract_spec.rb
+++ b/spec/unit/coinbase/smart_contract_spec.rb
@@ -72,6 +72,77 @@ describe Coinbase::SmartContract do
     end
   end
 
+  describe '.create_nft_contract' do
+    subject(:smart_contract) do
+      described_class.create_nft_contract(
+        address_id: address_id,
+        wallet_id: wallet_id,
+        name: nft_name,
+        symbol: nft_symbol,
+        base_uri: base_uri
+      )
+    end
+
+    let(:nft_name) { 'Test NFT' }
+    let(:nft_symbol) { 'TNFT' }
+    let(:base_uri) { 'https://example.com/nft/' }
+
+    let(:create_smart_contract_request) do
+      {
+        type: Coinbase::Client::SmartContractType::ERC721,
+        options: Coinbase::Client::NFTContractOptions.new(
+          name: nft_name,
+          symbol: nft_symbol,
+          base_uri: base_uri
+        ).to_body
+      }
+    end
+
+    let(:nft_contract_model) do
+      build(:smart_contract_model, network_id,
+            type: Coinbase::Client::SmartContractType::ERC721,
+            options: Coinbase::Client::NFTContractOptions.new(
+              name: nft_name,
+              symbol: nft_symbol,
+              base_uri: base_uri
+            ))
+    end
+
+    before do
+      allow(Coinbase::Client::SmartContractsApi).to receive(:new).and_return(smart_contracts_api)
+      allow(smart_contracts_api)
+        .to receive(:create_smart_contract)
+        .with(wallet_id, address_id, create_smart_contract_request)
+        .and_return(nft_contract_model)
+    end
+
+    it 'creates a new SmartContract' do
+      expect(smart_contract).to be_a(described_class)
+    end
+
+    it 'sets the smart_contract properties' do
+      expect(smart_contract.id).to eq(nft_contract_model.smart_contract_id)
+    end
+
+    it 'sets the correct contract type' do
+      expect(smart_contract.type).to eq(Coinbase::Client::SmartContractType::ERC721)
+    end
+
+    context 'when checking NFT options' do
+      it 'sets the correct name' do
+        expect(smart_contract.options.name).to eq(nft_name)
+      end
+
+      it 'sets the correct symbol' do
+        expect(smart_contract.options.symbol).to eq(nft_symbol)
+      end
+
+      it 'sets the correct base URI' do
+        expect(smart_contract.options.base_uri).to eq(base_uri)
+      end
+    end
+  end
+
   describe '.list_events' do
     subject(:enumerator) do
       described_class.list_events(

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -934,6 +934,44 @@ describe Coinbase::Wallet do
     end
   end
 
+  describe '#deploy_nft' do
+    subject(:nft_contract) { wallet.deploy_nft(parameters) }
+
+    let(:wallet) do
+      described_class.new(model_with_default_address, seed: '')
+    end
+
+    let(:created_nft_contract) { build(:smart_contract, :nft) }
+    let(:smart_contract_model) { build(:smart_contract_model, :nft) }
+    let(:parameters) do
+      {
+        name: 'NFT Collection',
+        symbol: 'NFTC',
+        base_uri: 'https://example.com/nft/'
+      }
+    end
+
+    before do
+      allow(addresses_api)
+        .to receive(:list_addresses)
+        .with(wallet_id, { limit: 20 })
+        .and_return(Coinbase::Client::AddressList.new(data: [first_address_model], total_count: 1))
+
+      allow(wallet.default_address).to receive(:deploy_nft)
+        .and_return(created_nft_contract)
+
+      nft_contract
+    end
+
+    it 'returns the deployed NFT contract' do
+      expect(nft_contract).to eq(created_nft_contract)
+    end
+
+    it 'calls deploy_nft on the default address' do
+      expect(wallet.default_address).to have_received(:deploy_nft).with(parameters)
+    end
+  end
+
   describe '#invoke_contract' do
     subject(:contract_invocation) { wallet.invoke_contract(parameters) }
 


### PR DESCRIPTION
### What changed? Why?
- Added support for deploy_nft to deploy an ERC721 contract

### Testing
- Unit tests pass
- Did an e2e test and was able to deploy the contract successfully followed by invoke_contract to mint a few NFTs!

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->