### PR TITLE
chore: Fix Smart Contract reads without ABI specified

### DIFF
--- a/lib/coinbase/smart_contract.rb
+++ b/lib/coinbase/smart_contract.rb
@@ -143,9 +143,9 @@ module Coinbase
     # @return [Object] The result of the contract call, converted to an appropriate Ruby type
     # @raise [Coinbase::ApiError] If there's an error in the API call
     def self.read(
-      network:,
       contract_address:,
       method:,
+      network: Coinbase.default_network,
       abi: nil,
       args: {}
     )
@@ -159,7 +159,7 @@ module Coinbase
             method: method,
             args: (args || {}).to_json,
             abi: abi&.to_json
-          }
+          }.compact
         )
       end
 


### PR DESCRIPTION
### What changed? Why?

This fixes Smart Contract reads with no ABI specified. We support using ABIs from our deployed smart contracts and well known asset standards, namely ERC20, ERC721, and ERC1155 token contracts.

### How to test this

Make a request to read a well known ERC20 asset without specifying an ABI:
```
asset = Coinbase::Asset.fetch('base-sepolia', 'usdc')

Coinbase::SmartContract.read(
  network: Coinbase::Network::BASE_SEPOLIA,
  contract_address: asset.address_id,
  method: 'balanceOf',
  args: { account: "alexstone.base.eth"},
)
```



#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->