### PR TITLE
chore(PSDK-640): add network_id to WalletData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 * Add support for fetching address reputation.
+* Add `network_id` to `WalletData` so that it is saved with the seed data and surfaced via the export function
 
 ## [0.12.0] - Skipped
 

--- a/lib/coinbase/wallet.rb
+++ b/lib/coinbase/wallet.rb
@@ -406,7 +406,7 @@ module Coinbase
 
       raise 'Cannot export Wallet without loaded seed' if @master.nil?
 
-      Data.new(wallet_id: id, seed: @master.seed_hex)
+      Data.new(wallet_id: id, seed: @master.seed_hex, network_id: network.id)
     end
 
     # Returns whether the Wallet has a seed with which to derive keys and sign transactions.
@@ -447,7 +447,8 @@ module Coinbase
         seed: seed_to_store,
         encrypted: encrypt,
         auth_tag: auth_tag,
-        iv: iv
+        iv: iv,
+        network_id: network.id
       }
 
       File.write(file_path, JSON.pretty_generate(existing_seeds_in_store))

--- a/lib/coinbase/wallet/data.rb
+++ b/lib/coinbase/wallet/data.rb
@@ -4,27 +4,29 @@ module Coinbase
   class Wallet
     # The data required to recreate a Wallet.
     class Data
-      attr_reader :wallet_id, :seed
+      attr_reader :wallet_id, :seed, :network_id
 
       # Returns a new Data object.
       # @param wallet_id [String] The ID of the Wallet
       # @param seed [String] The seed of the Wallet
-      def initialize(wallet_id:, seed:)
+      # @param network_id [String, nil] The network ID of the Wallet (optional)
+      def initialize(wallet_id:, seed:, network_id: nil)
         @wallet_id = wallet_id
         @seed = seed
+        @network_id = network_id
       end
 
       # Converts the Data object to a Hash.
       # @return [Hash] The Hash representation of the Data object
       def to_hash
-        { wallet_id: wallet_id, seed: seed }
+        { wallet_id: wallet_id, seed: seed, network_id: network_id }
       end
 
       # Creates a Data object from the given Hash.
       # @param data [Hash] The Hash to create the Data object from
       # @return [Data] The new Data object
       def self.from_hash(data)
-        Data.new(wallet_id: data['wallet_id'], seed: data['seed'])
+        Data.new(wallet_id: data['wallet_id'], seed: data['seed'], network_id: data['network_id'])
       end
     end
   end

--- a/spec/unit/coinbase/wallet_spec.rb
+++ b/spec/unit/coinbase/wallet_spec.rb
@@ -1350,7 +1350,13 @@ describe Coinbase::Wallet do
 
       it 'saves the wallet data to the seed file' do
         expect(saved_seed_data[wallet.id])
-          .to eq({ 'seed' => seed, 'encrypted' => false, 'iv' => '', 'auth_tag' => '' })
+          .to eq({
+                   'seed' => seed,
+                   'encrypted' => false,
+                   'iv' => '',
+                   'auth_tag' => '',
+                   'network_id' => network_id.to_s
+                 })
       end
     end
 
@@ -1387,7 +1393,13 @@ describe Coinbase::Wallet do
 
       it 'saves the wallet data to the new file' do
         expect(saved_seed_data[wallet.id])
-          .to eq({ 'seed' => seed, 'encrypted' => false, 'iv' => '', 'auth_tag' => '' })
+          .to eq({
+                   'seed' => seed,
+                   'encrypted' => false,
+                   'iv' => '',
+                   'auth_tag' => '',
+                   'network_id' => network_id.to_s
+                 })
       end
     end
 


### PR DESCRIPTION
### What changed? Why?
It should be clear which saved wallets belong to which networks when you `save_seed` / `export_data` for a given wallet.

#### Qualified Impact
The network id should always be present, and if it is not, it will simply not be included in the WalletData