### PR TITLE
chore: bump version to v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.14.0] - 2025-01-14
 
 ### Added
 - Add `skip_batching` option to `Wallet.transfer` to allow for lower latency gasless transfers.

--- a/lib/coinbase/version.rb
+++ b/lib/coinbase/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coinbase
-  VERSION = '0.13.0'
+  VERSION = '0.14.0'
 end


### PR DESCRIPTION
### What changed? Why?
Bumping changelog and relevant files to v0.14.0!
