### PR TITLE
Bug fix for non-checksummed address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2025-01-24
+
+### Fixed
+- Fixed a bug where non-checksummed asset IDs were throwing an error.
+
 ## [0.14.0] - 2025-01-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.0] - 2025-01-24
+## Unreleased
 
 ### Fixed
 - Fixed a bug where non-checksummed asset IDs were throwing an error.

--- a/lib/coinbase/asset.rb
+++ b/lib/coinbase/asset.rb
@@ -23,14 +23,19 @@ module Coinbase
 
         # Handle the non-primary denomination case at the asset level.
         # TODO: Push this logic down to the backend.
-        if asset_id && Coinbase.to_sym(asset_id) != Coinbase.to_sym(asset_model.asset_id)
-          case asset_id
-          when :gwei
-            decimals = GWEI_DECIMALS
-          when :wei
-            decimals = 0
-          else
-            raise ArgumentError, "Unsupported asset ID: #{asset_id}"
+        if asset_id && asset_model.asset_id 
+          normalized_asset_id = asset_id.downcase
+          normalized_asset_model_id = asset_model.asset_id.downcase
+
+          if Coinbase.to_sym(normalized_asset_id) != Coinbase.to_sym(normalized_asset_model_id)
+            case normalized_asset_id
+            when :gwei
+              decimals = GWEI_DECIMALS
+            when :wei
+              decimals = 0
+            else
+              raise ArgumentError, "Unsupported asset ID: #{asset_id}"
+            end
           end
         end
 

--- a/lib/coinbase/asset.rb
+++ b/lib/coinbase/asset.rb
@@ -23,7 +23,7 @@ module Coinbase
 
         # Handle the non-primary denomination case at the asset level.
         # TODO: Push this logic down to the backend.
-        if asset_id && asset_model.asset_id 
+        if asset_id && asset_model.asset_id
           normalized_asset_id = asset_id.downcase
           normalized_asset_model_id = asset_model.asset_id.downcase
 

--- a/spec/unit/coinbase/asset_spec.rb
+++ b/spec/unit/coinbase/asset_spec.rb
@@ -94,11 +94,11 @@ describe Coinbase::Asset do
 
     context 'when the asset_id is non-checksummed' do
       subject(:asset) { described_class.from_model(asset_model, asset_id: lowercase_address) }
-      
+
       let(:checksummed_address) { '0x8309fbdF021eDF768DC13195741940ba544dEa98' }
       let(:lowercase_address) { checksummed_address.downcase }
       let(:asset_model) { build(:asset_model, asset_id: checksummed_address) }
-      
+
       it 'handles case-insensitive address matching' do
         expect(asset.asset_id).to eq(lowercase_address)
       end
@@ -107,7 +107,7 @@ describe Coinbase::Asset do
     context 'when the asset_id is checksummed' do
       let(:contract_address) { '0x8309fbdF021eDF768DC13195741940ba544dEa98' }
       let(:asset_model) { build(:asset_model, network_id, :usdc, contract_address: contract_address) }
-    
+
       it 'sets the address_id as the checksummed address' do
         expect(asset.address_id).to eq(contract_address)
       end

--- a/spec/unit/coinbase/asset_spec.rb
+++ b/spec/unit/coinbase/asset_spec.rb
@@ -91,6 +91,27 @@ describe Coinbase::Asset do
         expect(asset.address_id).to eq(contract_address)
       end
     end
+
+    context 'when the asset_id is non-checksummed' do
+      subject(:asset) { described_class.from_model(asset_model, asset_id: lowercase_address) }
+      
+      let(:checksummed_address) { '0x8309fbdF021eDF768DC13195741940ba544dEa98' }
+      let(:lowercase_address) { checksummed_address.downcase }
+      let(:asset_model) { build(:asset_model, asset_id: checksummed_address) }
+      
+      it 'handles case-insensitive address matching' do
+        expect(asset.asset_id).to eq(lowercase_address)
+      end
+    end
+
+    context 'when the asset_id is checksummed' do
+      let(:contract_address) { '0x8309fbdF021eDF768DC13195741940ba544dEa98' }
+      let(:asset_model) { build(:asset_model, network_id, :usdc, contract_address: contract_address) }
+    
+      it 'sets the address_id as the checksummed address' do
+        expect(asset.address_id).to eq(contract_address)
+      end
+    end
   end
 
   describe '.primary_denomination' do


### PR DESCRIPTION
### What changed? Why?
There was a bug in the from_model function in asset.py. On the backend side, any asset id is checksummed before retrieving its details, and when it returns a response to the SDK, its asset id is also checksummed. When a user enters a non-checksummed address, they will get an error since those two asset ids are not equivalent.

This change will allow users to use non-checksummed addresses without getting erroneous errors in their workflow.

Before:
```
>>> wallet.balance('0x8309fbdf021edf768dc13195741940ba544dea98')

ArgumentError: Unsupported asset ID: 0x8309fbdf021edf768dc13195741940ba544dea98
```

After:
```
>>> wallet.balance('0x8309fbdf021edf768dc13195741940ba544dea98')

0.0
```

#### Qualified Impact
This change should not be a breaking change for the SDK. The same logic of the check for asset ids exists, but with the normalization of cases, it prevents the bug of non-checksummed addresses and checksummed addresses being considered as unequal.