### PR TITLE
chore: bump version to v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.16.0] - 2025-01-28
 
 ### Fixed
 - Fixed a bug where non-checksummed asset IDs were throwing an error.

--- a/lib/coinbase/version.rb
+++ b/lib/coinbase/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coinbase
-  VERSION = '0.14.0'
+  VERSION = '0.16.0'
 end


### PR DESCRIPTION
What changed? Why?
The package versions and changelog were updated to reflect the upcoming release of SDK version v0.16.0.

Qualified Impact
The impact of this change will update the SDK to the latest version which includes one bug fix. In the case of any errors or failures, the best approach would be to rollback to v0.14.0 and re-release a new version after fixing any errors.